### PR TITLE
Allow capitalized <Slot> and <Template> tags

### DIFF
--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -188,9 +188,11 @@ defmodule Surface.Compiler do
   end
 
   defp node_type({"#" <> _, _, _, _}), do: :macro_component
-  defp node_type({<<first, _::binary>>, _, _, _}) when first in ?A..?Z, do: :component
   defp node_type({"template", _, _, _}), do: :template
+  defp node_type({"Template", _, _, _}), do: :template
   defp node_type({"slot", _, _, _}), do: :slot
+  defp node_type({"Slot", _, _, _}), do: :slot
+  defp node_type({<<first, _::binary>>, _, _, _}) when first in ?A..?Z, do: :component
   defp node_type({name, _, _, _}) when name in @void_elements, do: :void_tag
   defp node_type({_, _, _, _}), do: :tag
   defp node_type({:interpolation, _, _}), do: :interpolation

--- a/test/slot_test.exs
+++ b/test/slot_test.exs
@@ -265,13 +265,14 @@ defmodule Surface.SlotTest do
   end
 
   test "render slot when tag is capitalized" do
-    html = render_surface do
-      ~H"""
-        <WithCapitalizedSlot>
-          Content
-        </WithCapitalizedSlot>
-      """
-    end
+    html =
+      render_surface do
+        ~H"""
+          <WithCapitalizedSlot>
+            Content
+          </WithCapitalizedSlot>
+        """
+      end
 
     assert html =~ """
            <div>

--- a/test/slot_test.exs
+++ b/test/slot_test.exs
@@ -206,6 +206,20 @@ defmodule Surface.SlotTest do
     end
   end
 
+  defmodule WithCapitalizedSlot do
+    use Surface.Component
+
+    slot default
+
+    def render(assigns) do
+      ~H"""
+      <div>
+        <Slot />
+      </div>
+      """
+    end
+  end
+
   test "render slot without slot props" do
     html =
       render_surface do
@@ -246,6 +260,22 @@ defmodule Surface.SlotTest do
              Content 3
              <div>Stateful</div>
              </div>
+           </div>
+           """
+  end
+
+  test "render slot when tag is capitalized" do
+    html = render_surface do
+      ~H"""
+        <WithCapitalizedSlot>
+          Content
+        </WithCapitalizedSlot>
+      """
+    end
+
+    assert html =~ """
+           <div>
+               Content
            </div>
            """
   end
@@ -315,6 +345,31 @@ defmodule Surface.SlotTest do
           <template slot="footer">
             My footer
           </template>
+        </OuterWithNamedSlot>
+        """
+      end
+
+    assert html =~ """
+           <div>
+               My header
+             My body
+               My footer
+           </div>
+           """
+  end
+
+  test "assign named slots without props and capitalized template tag" do
+    html =
+      render_surface do
+        ~H"""
+        <OuterWithNamedSlot>
+          <Template slot="header">
+            My header
+          </Template>
+          My body
+          <Template slot="footer">
+            My footer
+          </Template>
         </OuterWithNamedSlot>
         """
       end


### PR DESCRIPTION
As discussed in #259, this keeps everything hard coded and leaves available the downcased tags.