### PR TITLE
Warn if slot is required and has a default value

### DIFF
--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -862,7 +862,7 @@ defmodule Surface.Compiler do
       slot_name_tag = if short_syntax?, do: "", else: " name=\"#{slot.name}\""
 
       message = """
-      setting a fallback content on a required slot has no effect.
+      setting the fallback content on a required slot has no effect.
 
       Hint: Either keep the fallback content and remove the `required: true`:
 

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -862,14 +862,18 @@ defmodule Surface.Compiler do
       slot_name_tag = if short_syntax?, do: "", else: " name=\"#{slot.name}\""
 
       message = """
-      setting a default value on a required slot has no effect.
+      setting a fallback content on a required slot has no effect.
 
-      Hint: Either set the default value
+      Hint: Either keep the fallback content and remove the `required: true`:
+
         slot #{slot.name}
-        <slot#{slot_name_tag}>...</slot>
+        ...
+        <slot#{slot_name_tag}>Fallback content</slot>
 
-      or set the slot as required,
+      or keep the slot as required and remove the fallback content:
+
         slot #{slot.name}, required: true`
+        ...
         <slot#{slot_name_tag} />
 
       but not both.

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -284,20 +284,23 @@ defmodule Surface.Compiler do
   defp convert_node_to_ast(:slot, {_, attributes, children, node_meta}, compile_meta) do
     meta = Helpers.to_meta(node_meta, compile_meta)
 
-    defined_slot_names =
+    defined_slots =
       meta.caller.module
       |> Surface.API.get_slots()
-      |> Enum.map(& &1.name)
 
     # TODO: Validate attributes with custom messages
     name = attribute_value(attributes, "name", :default)
+    short_slot_syntax? = not has_attribute?(attributes, "name")
 
     index =
       attribute_value_as_ast(attributes, "index", %Surface.AST.Literal{value: 0}, compile_meta)
 
     with {:ok, directives, _attrs} <-
            collect_directives(@slot_directive_handlers, attributes, meta),
-         true <- name in defined_slot_names do
+         slot <- Enum.find(defined_slots, fn slot -> slot.name == name end),
+         slot when not is_nil(slot) <- slot do
+      maybe_warn_required_slot_with_default_value(slot, children, short_slot_syntax?, meta)
+
       {:ok,
        %AST.Slot{
          name: name,
@@ -309,13 +312,11 @@ defmodule Surface.Compiler do
        }}
     else
       _ ->
-        short_slot_syntax? = not has_attribute?(attributes, "name")
-
         raise_missing_slot_error!(
           meta.caller.module,
           name,
           meta,
-          defined_slot_names,
+          defined_slots,
           short_slot_syntax?
         )
     end
@@ -766,7 +767,7 @@ defmodule Surface.Compiler do
          module,
          slot_name,
          meta,
-         _defined_slot_names,
+         _defined_slots,
          true = _short_syntax?
        ) do
     message = """
@@ -782,11 +783,11 @@ defmodule Surface.Compiler do
          module,
          slot_name,
          meta,
-         defined_slot_names,
+         defined_slots,
          false = _short_syntax?
        ) do
+    defined_slot_names = Enum.map(defined_slots, & &1.name)
     similar_slot_message = similar_slot_message(slot_name, defined_slot_names)
-
     existing_slots_message = existing_slots_message(defined_slot_names)
 
     message = """
@@ -852,5 +853,29 @@ defmodule Surface.Compiler do
     slots = Enum.map(existing_slots, &to_string/1)
     available = Helpers.list_to_string("slot:", "slots:", slots)
     "\n\nAvailable #{available}"
+  end
+
+  defp maybe_warn_required_slot_with_default_value(_, [], _, _), do: nil
+
+  defp maybe_warn_required_slot_with_default_value(slot, _, short_syntax?, meta) do
+    if Keyword.get(slot.opts, :required, false) do
+      slot_name_tag = if short_syntax?, do: "", else: " name=\"#{slot.name}\""
+
+      message = """
+      setting a default value on a required slot has no effect.
+
+      Hint: Either set the default value
+        slot #{slot.name}
+        <slot#{slot_name_tag}>...</slot>
+
+      or set the slot as required,
+        slot #{slot.name}, required: true`
+        <slot#{slot_name_tag} />
+
+      but not both.
+      """
+
+      IOHelper.warn(message, meta.caller, fn _ -> meta.line end)
+    end
   end
 end

--- a/test/compiler_test.exs
+++ b/test/compiler_test.exs
@@ -905,6 +905,70 @@ defmodule Surface.CompilerSyncTest do
     assert extract_line(output) == 6
   end
 
+  test "warning on component with required slot that has a default value" do
+    id = :erlang.unique_integer([:positive]) |> to_string()
+
+    view_code = """
+    defmodule TestComponent_#{id} do
+      use Surface.Component
+
+      slot default, required: true
+      slot header, required: true
+      slot footer
+
+      def render(assigns) do
+        ~H"\""
+        <div>
+          <slot>Default Content</slot>
+          <slot name="header">Default Header</slot>
+          <slot name="footer">Default Footer</slot>
+        </div>
+        "\""
+      end
+    end
+    """
+
+    output =
+      capture_io(:standard_error, fn ->
+        {{:module, _, _, _}, _} =
+          Code.eval_string(view_code, [], %{__ENV__ | file: "code.exs", line: 1})
+      end)
+
+    assert output =~ """
+           setting a default value on a required slot has no effect.
+
+           Hint: Either set the default value
+             slot default
+             <slot>...</slot>
+
+           or set the slot as required,
+             slot default, required: true`
+             <slot />
+
+           but not both.
+
+             code.exs:11: Surface.CompilerSyncTest.TestComponent_#{id}.render/1
+
+           """
+
+    assert output =~ """
+           setting a default value on a required slot has no effect.
+
+           Hint: Either set the default value
+             slot header
+             <slot name="header">...</slot>
+
+           or set the slot as required,
+             slot header, required: true`
+             <slot name="header" />
+
+           but not both.
+
+             code.exs:12: Surface.CompilerSyncTest.TestComponent_#{id}.render/1
+
+           """
+  end
+
   defp compile_component(code) do
     id = :erlang.unique_integer([:positive]) |> to_string()
 

--- a/test/compiler_test.exs
+++ b/test/compiler_test.exs
@@ -935,14 +935,18 @@ defmodule Surface.CompilerSyncTest do
       end)
 
     assert output =~ """
-           setting a default value on a required slot has no effect.
+           setting a fallback content on a required slot has no effect.
 
-           Hint: Either set the default value
+           Hint: Either keep the fallback content and remove the `required: true`:
+
              slot default
-             <slot>...</slot>
+             ...
+             <slot>Fallback content</slot>
 
-           or set the slot as required,
+           or keep the slot as required and remove the fallback content:
+
              slot default, required: true`
+             ...
              <slot />
 
            but not both.
@@ -952,14 +956,18 @@ defmodule Surface.CompilerSyncTest do
            """
 
     assert output =~ """
-           setting a default value on a required slot has no effect.
+           setting a fallback content on a required slot has no effect.
 
-           Hint: Either set the default value
+           Hint: Either keep the fallback content and remove the `required: true`:
+
              slot header
-             <slot name="header">...</slot>
+             ...
+             <slot name="header">Fallback content</slot>
 
-           or set the slot as required,
+           or keep the slot as required and remove the fallback content:
+
              slot header, required: true`
+             ...
              <slot name="header" />
 
            but not both.

--- a/test/compiler_test.exs
+++ b/test/compiler_test.exs
@@ -935,7 +935,7 @@ defmodule Surface.CompilerSyncTest do
       end)
 
     assert output =~ """
-           setting a fallback content on a required slot has no effect.
+           setting the fallback content on a required slot has no effect.
 
            Hint: Either keep the fallback content and remove the `required: true`:
 
@@ -956,7 +956,7 @@ defmodule Surface.CompilerSyncTest do
            """
 
     assert output =~ """
-           setting a fallback content on a required slot has no effect.
+           setting the fallback content on a required slot has no effect.
 
            Hint: Either keep the fallback content and remove the `required: true`:
 


### PR DESCRIPTION
Fixes #295 

The compiler will generate a proper message if a slot is required and if it has a default value.

The warning messages reflect the usage of the short syntax `<slot>...</slot>` or the full syntax `<slot name="header">...</slot>`