### PR TITLE
Generate doc for slots and events

### DIFF
--- a/lib/surface.ex
+++ b/lib/surface.ex
@@ -73,7 +73,7 @@ defmodule Surface do
     * `Surface.LiveView` - A wrapper component around `Phoenix.LiveView`.
     * `Surface.MacroComponent` - A low-level component which is responsible for translating its own content at compile time.
 
-  ### Example
+  ## Example
 
       # A functional stateless component
 

--- a/lib/surface/api.ex
+++ b/lib/surface/api.ex
@@ -497,7 +497,7 @@ defmodule Surface.API do
 
     if docs != "" do
       """
-      ### Properties
+      ## Properties
 
       #{docs}
       """
@@ -516,7 +516,7 @@ defmodule Surface.API do
 
     if docs != "" do
       """
-      ### Slots
+      ## Slots
 
       #{docs}
       """
@@ -535,7 +535,7 @@ defmodule Surface.API do
 
     if docs != "" do
       """
-      ### Events
+      ## Events
 
       #{docs}
       """

--- a/test/api_test.exs
+++ b/test/api_test.exs
@@ -434,17 +434,17 @@ defmodule Surface.APITest do
 
   test "generate documentation when no @moduledoc is defined" do
     assert get_docs(Surface.PropertiesTest.Components.MyComponent) == """
-           ### Properties
+           ## Properties
 
            * **label** *:string, required: true* - The label.
            * **class** *:css_class* - The class.
 
-           ### Slots
+           ## Slots
 
            * **default** - The default slot.
            * **header, required: true** - The required header slot.
 
-           ### Events
+           ## Events
 
            * **click, required: true** - The click event.
            * **cancel** - The cancel event.
@@ -455,17 +455,17 @@ defmodule Surface.APITest do
     assert get_docs(Surface.PropertiesTest.Components.MyComponentWithModuledoc) == """
            My component with @moduledoc
 
-           ### Properties
+           ## Properties
 
            * **label** *:string, required: true* - The label.
            * **class** *:css_class* - The class.
 
-           ### Slots
+           ## Slots
 
            * **default** - The default slot.
            * **header, required: true** - The required header slot.
 
-           ### Events
+           ## Events
 
            * **click, required: true** - The click event.
            * **cancel** - The cancel event.

--- a/test/api_test.exs
+++ b/test/api_test.exs
@@ -438,6 +438,16 @@ defmodule Surface.APITest do
 
            * **label** *:string, required: true* - The label.
            * **class** *:css_class* - The class.
+
+           ### Slots
+
+           * **default** - The default slot.
+           * **header, required: true** - The required header slot.
+
+           ### Events
+
+           * **click, required: true** - The click event.
+           * **cancel** - The cancel event.
            """
   end
 
@@ -449,11 +459,28 @@ defmodule Surface.APITest do
 
            * **label** *:string, required: true* - The label.
            * **class** *:css_class* - The class.
+
+           ### Slots
+
+           * **default** - The default slot.
+           * **header, required: true** - The required header slot.
+
+           ### Events
+
+           * **click, required: true** - The click event.
+           * **cancel** - The cancel event.
            """
   end
 
   test "do not generate documentation when @moduledoc is false" do
     assert get_docs(Surface.PropertiesTest.Components.MyComponentWithModuledocFalse) == nil
+  end
+
+  test "do not generate documentation sections when there is no props, slots or event" do
+    assert get_docs(Surface.PropertiesTest.Components.MyComponentWithDocButPropSlotAndEvent) ==
+             """
+             My Component with doc but props, slots and events
+             """
   end
 
   defp eval(code, component_type \\ "LiveComponent") do

--- a/test/support/properties_test_components.ex
+++ b/test/support/properties_test_components.ex
@@ -8,9 +8,23 @@ defmodule Surface.PropertiesTest.Components do
     @doc "The class"
     prop class, :css_class
 
+    @doc "The click event"
+    prop click, :event, required: true
+
+    @doc "The cancel event"
+    prop cancel, :event
+
+    @doc "The default slot"
+    slot default
+
+    @doc "The required header slot"
+    slot header, required: true
+
     def render(assigns) do
       ~H"""
-      <div />
+      <div>
+        <slot name="default" />
+      </div>
       """
     end
   end
@@ -28,9 +42,23 @@ defmodule Surface.PropertiesTest.Components do
     @doc "The class"
     prop class, :css_class
 
+    @doc "The click event"
+    prop click, :event, required: true
+
+    @doc "The cancel event"
+    prop cancel, :event
+
+    @doc "The default slot"
+    slot default
+
+    @doc "The required header slot"
+    slot header, required: true
+
     def render(assigns) do
       ~H"""
-      <div />
+      <div>
+        <slot name="default" />
+      </div>
       """
     end
   end
@@ -45,6 +73,20 @@ defmodule Surface.PropertiesTest.Components do
 
     @doc "The class"
     prop class, :css_class
+
+    def render(assigns) do
+      ~H"""
+      <div />
+      """
+    end
+  end
+
+  defmodule MyComponentWithDocButPropSlotAndEvent do
+    use Surface.Component
+
+    @moduledoc """
+    My Component with doc but props, slots and events
+    """
 
     def render(assigns) do
       ~H"""


### PR DESCRIPTION
Fixes #293 

Here is an output example with the `Form` component:
![image](https://user-images.githubusercontent.com/553321/111882047-a7a9b380-89b3-11eb-865e-5e2e48b32ac5.png)
