### PR TITLE
Handle events in Submit component

### DIFF
--- a/lib/surface/components/form/submit.ex
+++ b/lib/surface/components/form/submit.ex
@@ -8,6 +8,7 @@ defmodule Surface.Components.Form.Submit do
   use Surface.Component
 
   import Phoenix.HTML.Form, only: [submit: 2]
+  import Surface.Components.Form.Utils
 
   @doc "The label to be used in the button"
   prop label, :string
@@ -38,9 +39,10 @@ defmodule Surface.Components.Form.Submit do
 
   def render(assigns) do
     children = ~H"<slot>{{ @label }}</slot>"
+    event_opts = events_to_opts(assigns)
 
     ~H"""
-    {{ submit prop_to_attr_opts(@class, :class) ++ @opts, do: children }}
+    {{ submit prop_to_attr_opts(@class, :class) ++ @opts ++ event_opts, do: children }}
     """
   end
 end

--- a/test/components/form/submit_test.exs
+++ b/test/components/form/submit_test.exs
@@ -67,4 +67,69 @@ defmodule Surface.Components.Form.SubmitTest do
            </button>
            """
   end
+
+  test "blur event with parent live view as target" do
+    html =
+      render_surface do
+        ~H"""
+        <Submit label="Submit" blur="my_blur" />
+        """
+      end
+
+    assert html =~ """
+           <button phx-blur="my_blur" type="submit">Submit</button>
+           """
+  end
+
+  test "focus event with parent live view as target" do
+    html =
+      render_surface do
+        ~H"""
+        <Submit label="Submit" focus="my_focus" />
+        """
+      end
+
+    assert html =~ """
+           <button phx-focus="my_focus" type="submit">Submit</button>
+           """
+  end
+
+  test "capture click event with parent live view as target" do
+    html =
+      render_surface do
+        ~H"""
+        <Submit label="Submit" capture_click="my_click" />
+        """
+      end
+
+    assert html =~ """
+           <button phx-capture-click="my_click" type="submit">Submit</button>
+           """
+  end
+
+  test "keydown event with parent live view as target" do
+    html =
+      render_surface do
+        ~H"""
+        <Submit label="Submit" keydown="my_keydown" />
+        """
+      end
+
+    assert html =~ """
+           <button phx-keydown="my_keydown" type="submit">Submit</button>
+           """
+  end
+
+  test "keyup event with parent live view as target" do
+    html =
+      render_surface do
+        ~H"""
+        <Submit label="Submit" keyup="my_keyup" />
+        """
+      end
+
+    assert html =~ """
+           <button phx-keyup="my_keyup" type="submit">Submit</button>
+           """
+  end
 end


### PR DESCRIPTION
The `Submit` component had all the usual event props defined, but they weren't being forwarded to the `submit/3` function.