### PR TITLE
Introduce the upload macro

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -6,7 +6,9 @@ locals_without_parens = [
   data: 3,
   data: 2,
   slot: 1,
-  slot: 2
+  slot: 2,
+  upload: 1,
+  upload: 2
 ]
 
 [

--- a/lib/surface.ex
+++ b/lib/surface.ex
@@ -160,6 +160,14 @@ defmodule Surface do
     |> LiveView.assign_new(:__context__, fn -> %{} end)
   end
 
+  def allow_upload(socket, []), do: socket
+
+  def allow_upload(socket, data) do
+    Enum.reduce(data, socket, fn {name, opts}, socket ->
+      Phoenix.LiveView.allow_upload(socket, name, opts)
+    end)
+  end
+
   @doc false
   def default_props(module) do
     Enum.map(module.__props__(), fn %{name: name, opts: opts} -> {name, opts[:default]} end)

--- a/lib/surface/compiler/helpers.ex
+++ b/lib/surface/compiler/helpers.ex
@@ -56,7 +56,10 @@ defmodule Surface.Compiler.Helpers do
          component_type
        )
        when component_type in [Surface.Component, Surface.LiveComponent] do
-    defined_assigns = Keyword.keys(Surface.API.get_assigns(caller.module))
+    defined_assigns =
+      Surface.API.get_assigns(caller.module)
+      |> Enum.map(fn {name, _} -> name end)
+
     builtin_assigns = builtin_assigns_by_type(component_type)
     undefined_assigns = Keyword.drop(used_assigns, builtin_assigns ++ defined_assigns)
 

--- a/lib/surface/component.ex
+++ b/lib/surface/component.ex
@@ -41,7 +41,7 @@ defmodule Surface.Component do
 
       use Surface.BaseComponent, type: unquote(__MODULE__)
 
-      use Surface.API, include: [:prop, :slot, :data]
+      use Surface.API, include: [:prop, :slot, :data, :upload]
       import Phoenix.HTML
 
       alias Surface.Constructs.{For, If}

--- a/lib/surface/live_component.ex
+++ b/lib/surface/live_component.ex
@@ -61,7 +61,7 @@ defmodule Surface.LiveComponent do
 
       @before_compile unquote(__MODULE__)
 
-      use Surface.API, include: [:prop, :slot, :data]
+      use Surface.API, include: [:prop, :slot, :data, :upload]
       import Phoenix.HTML
 
       alias Surface.Constructs.{For, If}
@@ -103,6 +103,11 @@ defmodule Surface.LiveComponent do
   defp quoted_mount(env) do
     defaults = env.module |> Surface.API.get_defaults() |> Macro.escape()
 
+    upload_data =
+      env.module
+      |> Surface.API.get_uploads()
+      |> Enum.map(fn %{name: name, opts_ast: opts} -> {name, opts} end)
+
     if Module.defines?(env.module, {:mount, 1}) do
       quote do
         defoverridable mount: 1
@@ -111,6 +116,7 @@ defmodule Surface.LiveComponent do
           super(
             socket
             |> Surface.init()
+            |> Surface.allow_upload(unquote(upload_data))
             |> assign(unquote(defaults))
           )
         end
@@ -121,6 +127,7 @@ defmodule Surface.LiveComponent do
           {:ok,
            socket
            |> Surface.init()
+           |> Surface.allow_upload(unquote(upload_data))
            |> assign(unquote(defaults))}
         end
       end

--- a/lib/surface/live_view.ex
+++ b/lib/surface/live_view.ex
@@ -34,7 +34,7 @@ defmodule Surface.LiveView do
     quote do
       use Surface.BaseComponent, type: unquote(__MODULE__)
 
-      use Surface.API, include: [:prop, :data]
+      use Surface.API, include: [:prop, :data, :upload]
       import Phoenix.HTML
 
       alias Surface.Constructs.{For, If}
@@ -76,6 +76,11 @@ defmodule Surface.LiveView do
   defp quoted_mount(env) do
     defaults = env.module |> Surface.API.get_defaults() |> Macro.escape()
 
+    upload_data =
+      env.module
+      |> Surface.API.get_uploads()
+      |> Enum.map(fn %{name: name, opts_ast: opts} -> {name, opts} end)
+
     if Module.defines?(env.module, {:mount, 3}) do
       quote do
         defoverridable mount: 3
@@ -84,6 +89,7 @@ defmodule Surface.LiveView do
           socket =
             socket
             |> Surface.init()
+            |> Surface.allow_upload(unquote(upload_data))
             |> assign(unquote(defaults))
 
           super(params, session, socket)
@@ -95,6 +101,7 @@ defmodule Surface.LiveView do
           {:ok,
            socket
            |> Surface.init()
+           |> Surface.allow_upload(unquote(upload_data))
            |> assign(unquote(defaults))}
         end
       end

--- a/test/api_test.exs
+++ b/test/api_test.exs
@@ -87,14 +87,6 @@ defmodule Surface.APITest do
     assert_raise(CompileError, message, fn -> eval(code) end)
 
     code = """
-    prop avatar, :string
-    upload avatar, accept: :any
-    """
-
-    message = ~r/cannot use name "avatar". There's already a prop/
-    assert_raise(CompileError, message, fn -> eval(code) end)
-
-    code = """
     data label, :string
     data label, :string
     """
@@ -119,40 +111,8 @@ defmodule Surface.APITest do
     assert_raise(CompileError, message, fn -> eval(code) end)
 
     code = """
-    data avatar, :string
-    upload avatar, accept: :any
-    """
-
-    message = ~r/cannot use name "avatar". There's already a data assign/
-    assert_raise(CompileError, message, fn -> eval(code) end)
-
-    code = """
     upload avatar, accept: :any
     upload avatar, accept: :any
-    """
-
-    message = ~r/cannot use name "avatar". There's already an upload assign/
-    assert_raise(CompileError, message, fn -> eval(code) end)
-
-    code = """
-    upload avatar, accept: :any
-    prop avatar, :string
-    """
-
-    message = ~r/cannot use name "avatar". There's already an upload assign/
-    assert_raise(CompileError, message, fn -> eval(code) end)
-
-    code = """
-    upload avatar, accept: :any
-    data avatar, :string
-    """
-
-    message = ~r/cannot use name "avatar". There's already an upload assign/
-    assert_raise(CompileError, message, fn -> eval(code) end)
-
-    code = """
-    upload avatar, accept: :any
-    slot avatar
     """
 
     message = ~r/cannot use name "avatar". There's already an upload assign/
@@ -195,16 +155,46 @@ defmodule Surface.APITest do
     assert_raise(CompileError, message, fn -> eval(code) end)
 
     code = """
+    prop avatar, :string
+    upload avatar, accept: :any
+    """
+
+    assert {:ok, _} = eval(code)
+
+    code = """
+    data avatar, :string
+    upload avatar, accept: :any
+    """
+
+    assert {:ok, _} = eval(code)
+
+    code = """
+    upload avatar, accept: :any
+    prop avatar, :string
+    """
+
+    assert {:ok, _} = eval(code)
+
+    code = """
+    upload avatar, accept: :any
+    data avatar, :string
+    """
+
+    assert {:ok, _} = eval(code)
+
+    code = """
+    upload avatar, accept: :any
+    slot avatar
+    """
+
+    assert {:ok, _} = eval(code)
+
+    code = """
     slot avatar
     upload avatar, accept: :any
     """
 
-    message = ~r"""
-    cannot use name "avatar". There's already a slot assign with the same name at line \d.
-    You could use the optional ':as' option in slot macro to name the related assigns.
-    """
-
-    assert_raise(CompileError, message, fn -> eval(code) end)
+    assert {:ok, _} = eval(code)
 
     code = """
     slot label, as: :default_label

--- a/test/live_component_test.exs
+++ b/test/live_component_test.exs
@@ -34,6 +34,75 @@ defmodule LiveComponentTest do
     end
   end
 
+  defmodule StatefulUploadComponent do
+    use Surface.LiveComponent
+
+    data uploads, :struct
+    upload avatar, accept: :any, progress: &__MODULE__.handle_progress/3
+    upload icon, accept: :any, progress: &handle_progress/3
+    upload photo, accept: :any, progress: &priv_handle_progress/3
+    upload logo, accept: :any, external: &StatefulUploadComponent.handle_external/2
+    upload cover, accept: :any, external: &priv_handle_external/2
+
+    def render(assigns) do
+      ~H"""
+      <div>
+        <span>{{ @uploads.avatar.name }}</span>
+      </div>
+      """
+    end
+
+    def handle_progress(:upload, _entry, socket) do
+      {:noreply, socket}
+    end
+
+    def handle_external(_entry, socket) do
+      {:noreply, socket}
+    end
+
+    defp priv_handle_progress(:upload, _entry, socket) do
+      {:noreply, socket}
+    end
+
+    defp priv_handle_external(_entry, socket) do
+      {:noreply, socket}
+    end
+  end
+
+  defmodule LiveViewUploadComponent do
+    use Surface.LiveView
+
+    upload avatar, accept: :any, progress: &__MODULE__.handle_progress/3
+    upload icon, accept: :any, progress: &handle_progress/3
+    upload photo, accept: :any, progress: &priv_handle_progress/3
+    upload logo, accept: :any, external: &StatefulUploadComponent.handle_external/2
+    upload cover, accept: :any, external: &priv_handle_external/2
+
+    def render(assigns) do
+      ~H"""
+      <div>
+        <span>{{ @uploads.avatar.name }}</span>
+      </div>
+      """
+    end
+
+    def handle_progress(:upload, _entry, socket) do
+      {:noreply, socket}
+    end
+
+    def handle_external(_entry, socket) do
+      {:noreply, socket}
+    end
+
+    defp priv_handle_progress(:upload, _entry, socket) do
+      {:noreply, socket}
+    end
+
+    defp priv_handle_external(_entry, socket) do
+      {:noreply, socket}
+    end
+  end
+
   defmodule View do
     use Surface.LiveView
     alias LiveComponentTest.StatelessComponent
@@ -187,5 +256,26 @@ defmodule LiveComponentTest do
   test "handle events in LiveComponent (handled by the component itself)" do
     {:ok, view, _html} = live_isolated(build_conn(), View)
     assert render_click(element(view, "#theDiv")) =~ "Updated stateful"
+  end
+
+  test "render stateful upload component" do
+    html =
+      render_surface do
+        ~H"""
+        <StatefulUploadComponent id="upload_component" />
+        """
+      end
+
+    assert html =~ """
+           <div>
+             <span>avatar</span>
+           </div>
+           """
+  end
+
+  test "render live view upload component" do
+    {:ok, _view, html} = live_isolated(build_conn(), LiveViewUploadComponent)
+
+    assert html =~ "<span>avatar</span>"
   end
 end


### PR DESCRIPTION
See #298 for the initial discussion.

This is a first implementation. Feedback are welcomed!

Todo:

- [x] Check the usage of the required option `:accept` or raise a `CompileError`
- [x] Validate upload options types
- [x] Add test to check multiple uploads
- [x] Add ability to pass "local" function to `:external` and `:progress` options
- [x] Validate the arity of function passed through `:external` and `:progress` options
- [ ] Wait for #307 to be merged and update it according to these changes
- [ ] ~~Consider to be able to pass a prop `event` to `progress` and `external` option~~
- [ ] Update the doc
- [ ] Update surface_catalogue to take into account the new `upload` macro
- [ ] Update VSCode Surface extension to handle the new `upload` macro 