### PR TITLE
Warn if given default value doesn't exist in values list

### DIFF
--- a/test/properties_test.exs
+++ b/test/properties_test.exs
@@ -664,4 +664,50 @@ defmodule Surface.PropertiesSyncTest do
              code.exs:8:\
            """
   end
+
+  test "warn if given default value doesn't exist in values list" do
+    id = :erlang.unique_integer([:positive]) |> to_string()
+    module = "TestComponentWithDefaultValueThatDoesntExistInValues_#{id}"
+
+    code = """
+    defmodule #{module} do
+      use Surface.Component
+
+      prop type, :string, values: ["small", "medium", "large"], default: "x-large"
+      data data_type, :string, values: ["small", "medium", "large"], default: "x-large"
+      prop count, :integer, default: [], values: [0, 1, 2]
+      prop count_acc, :integer, default: [3], values: [0, 1, 2], accumulate: true
+
+      def render(assigns) do
+        ~H""
+      end
+    end
+    """
+
+    output =
+      capture_io(:standard_error, fn ->
+        {{:module, _, _, _}, _} =
+          Code.eval_string(code, [], %{__ENV__ | file: "code.exs", line: 1})
+      end)
+
+    assert output =~ ~r"""
+           given default value doesn't exist in the :values list
+             code.exs:4:\
+           """
+
+    assert output =~ ~r"""
+           given default value doesn't exist in the :values list
+             code.exs:5:\
+           """
+
+    assert output =~ ~r"""
+           given default value doesn't exist in the :values list
+             code.exs:6:\
+           """
+
+    assert output =~ ~r"""
+           given default value\(s\) doesn't exist in the :values list
+             code.exs:7:\
+           """
+  end
 end


### PR DESCRIPTION
Hi,

This PR's scope discussed a bit in #312. I've found a couple of cases:

* We should be checking if the given default value exists in the values list (for data and prop and if not accumulated)
Example (should give warning): `prop type, :string, values: ["small", "medium", "large"], default: "x-large"`

* We should be checking if the given default value(s) exist in the value list (only for prop and if accumulated)
Example(should give warning): `prop count, :integer, default: [3], values: [0, 1, 2], accumulate: true`

* Should be valid
 `prop count, :integer, default: [], values: [0, 1, 2], accumulate: true`
 
 There are some more cases but that is the core idea.

I'm an Elixir newbie and this is why I struggled to bring idiomatic Elixir code to the table 🙈I definitely need your feedback and this code definitely needs splitting. Please, guide me through if you have time.

Thank you in advance!