### PR TITLE
Add a warning if props are specified many times, but accumulate is false

### DIFF
--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -533,13 +533,15 @@ defmodule Surface.Compiler do
     if not accumulate? and Keyword.has_key?(acc, name) do
       IOHelper.warn(
         """
-        The prop `#{name}` has been set many times, but accumulate is false.
+        The prop `#{name}` has been passed multiple times. Considering only the last value.
 
-        Hint: You can remove the multiple use of the #{name} attribute, or set accumulate to `true`:
+        Hint: Either remove all redundant definitions or set option `accumulate` to `true`:
 
         ```
-        prop #{name}, :#{type}, accumulate: true
+          prop #{name}, :#{type}, accumulate: true
         ```
+
+        This way the values will be accumulated in a list.
         """,
         meta.caller,
         fn _ -> attr_meta.line end

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -515,10 +515,36 @@ defmodule Surface.Compiler do
 
   defp process_attributes(_module, [], _meta), do: []
 
-  defp process_attributes(mod, [{name, value, attr_meta} | attrs], meta) do
+  defp process_attributes(mod, attrs, meta), do: process_attributes(mod, attrs, meta, [])
+
+  defp process_attributes(_module, [], _meta, acc) do
+    acc
+    |> Keyword.values()
+    |> Enum.reverse()
+  end
+
+  defp process_attributes(mod, [{name, value, attr_meta} | attrs], meta, acc) do
     name = String.to_atom(name)
     attr_meta = Helpers.to_meta(attr_meta, meta)
     {type, type_opts} = Surface.TypeHandler.attribute_type_and_opts(mod, name, attr_meta)
+
+    accumulate? = Keyword.get(type_opts, :accumulate, false)
+
+    if not accumulate? and Keyword.has_key?(acc, name) do
+      IOHelper.warn(
+        """
+        The prop `#{name}` has been set many times, but accumulate is false.
+
+        Hint: You can remove the multiple use of the #{name} attribute, or set accumulate to `true`:
+
+        ```
+        prop #{name}, :#{type}, accumulate: true
+        ```
+        """,
+        meta.caller,
+        fn _ -> meta.line end
+      )
+    end
 
     node = %AST.Attribute{
       type: type,
@@ -528,7 +554,7 @@ defmodule Surface.Compiler do
       meta: attr_meta
     }
 
-    [node | process_attributes(mod, attrs, meta)]
+    process_attributes(mod, attrs, meta, [{name, node} | acc])
   end
 
   defp attr_value(name, type, values, attr_meta) when is_list(values) do

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -542,7 +542,7 @@ defmodule Surface.Compiler do
         ```
         """,
         meta.caller,
-        fn _ -> meta.line end
+        fn _ -> attr_meta.line end
       )
     end
 

--- a/test/properties_test.exs
+++ b/test/properties_test.exs
@@ -635,7 +635,10 @@ defmodule Surface.PropertiesSyncTest do
 
       def render(assigns) do
         ~H"\""
-        <StringProp label="first label" label="second label" />
+        <StringProp
+          label="first
+          label" label="second label"
+        />
         "\""
       end
     end
@@ -657,6 +660,7 @@ defmodule Surface.PropertiesSyncTest do
            ```
 
              code.exs:6:\
+             code.exs:8:\
            """
   end
 end

--- a/test/properties_test.exs
+++ b/test/properties_test.exs
@@ -651,15 +651,16 @@ defmodule Surface.PropertiesSyncTest do
       end)
 
     assert output =~ ~r"""
-           The prop `label` has been set many times, but accumulate is false.
+           The prop `label` has been passed multiple times. Considering only the last value.
 
-           Hint: You can remove the multiple use of the label attribute, or set accumulate to `true`:
+           Hint: Either remove all redundant definitions or set option `accumulate` to `true`:
 
            ```
-           prop label, :string, accumulate: true
+             prop label, :string, accumulate: true
            ```
 
-             code.exs:6:\
+           This way the values will be accumulated in a list.
+
              code.exs:8:\
            """
   end

--- a/test/properties_test.exs
+++ b/test/properties_test.exs
@@ -624,4 +624,39 @@ defmodule Surface.PropertiesSyncTest do
              code.exs:4:\
            """
   end
+
+  test "warn if props are specified multiple times, but accumulate is false" do
+    id = :erlang.unique_integer([:positive]) |> to_string()
+    module = "TestComponentWithPropSpecifiedMultipleTimes_#{id}"
+
+    code = """
+    defmodule #{module} do
+      use Surface.Component
+
+      def render(assigns) do
+        ~H"\""
+        <StringProp label="first label" label="second label" />
+        "\""
+      end
+    end
+    """
+
+    output =
+      capture_io(:standard_error, fn ->
+        {{:module, _, _, _}, _} =
+          Code.eval_string(code, [], %{__ENV__ | file: "code.exs", line: 1})
+      end)
+
+    assert output =~ ~r"""
+           The prop `label` has been set many times, but accumulate is false.
+
+           Hint: You can remove the multiple use of the label attribute, or set accumulate to `true`:
+
+           ```
+           prop label, :string, accumulate: true
+           ```
+
+             code.exs:6:\
+           """
+  end
 end


### PR DESCRIPTION
FIxes #302 