### PR TITLE
Do not encode attr value if it's a literal string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog
 
 ## v0.4.0 (WIP)
-  
+
   * Call render when defined in slotable components (#283)
-  * Support defining form fields as strings. Consequently, fields defined as literal strings will 
+  * Support defining form fields as strings. Consequently, fields defined as literal strings will
     no longer be auto-converted to `:atom` and will keep the original value (#319)
+  * Do not encode HTML entities when passing attribute values as string literals (#323)
+
 ## v0.3.2 (2021-03-19)
 
   * Warn if prop is required and has default value (#282)

--- a/lib/surface/compiler/eex_engine.ex
+++ b/lib/surface/compiler/eex_engine.ex
@@ -624,6 +624,14 @@ defmodule Surface.Compiler.EExEngine do
   defp to_html_attributes([]), do: []
 
   defp to_html_attributes([
+         %AST.Attribute{name: name, type: :string, value: %AST.Literal{value: value}}
+         | attributes
+       ])
+       when is_binary(value) do
+    [[" ", to_string(name), "=", ~S("), value, ~S(")], to_html_attributes(attributes)]
+  end
+
+  defp to_html_attributes([
          %AST.Attribute{name: name, type: type, value: %AST.Literal{value: value}}
          | attributes
        ]) do

--- a/test/html_tag_test.exs
+++ b/test/html_tag_test.exs
@@ -113,7 +113,7 @@ defmodule HtmlTagTest do
   end
 
   describe "basic attibutes" do
-    test "as string" do
+    test "as literal string" do
       html =
         render_surface do
           ~H"""
@@ -123,6 +123,19 @@ defmodule HtmlTagTest do
 
       assert html =~ """
              <div title="My title"></div>
+             """
+    end
+
+    test "as literal string don't encode HTML entities" do
+      html =
+        render_surface do
+          ~H"""
+          <div title="1 < 2"/>
+          """
+        end
+
+      assert html =~ """
+             <div title="1 < 2"></div>
              """
     end
 


### PR DESCRIPTION
Fixes #323.