### PR TITLE
Reimplement form Submit component

### DIFF
--- a/lib/surface/components/form/submit.ex
+++ b/lib/surface/components/form/submit.ex
@@ -8,8 +8,7 @@ defmodule Surface.Components.Form.Submit do
   use Surface.Component
   use Surface.Components.Events
 
-  import Phoenix.HTML.Form, only: [submit: 2]
-  import Surface.Components.Utils, only: [events_to_opts: 1]
+  import Surface.Components.Utils, only: [events_to_opts: 1, opts_to_attrs: 1]
 
   @doc "The label to be used in the button"
   prop label, :string
@@ -24,11 +23,13 @@ defmodule Surface.Components.Form.Submit do
   slot default
 
   def render(assigns) do
-    children = ~H"<slot>{{ @label }}</slot>"
-    event_opts = events_to_opts(assigns)
+    opts = prop_to_attr_opts(assigns.class, :class) ++ assigns.opts ++ events_to_opts(assigns)
+    attrs = opts_to_attrs(opts)
 
     ~H"""
-    {{ submit prop_to_attr_opts(@class, :class) ++ @opts ++ event_opts, do: children }}
+    <button type="submit" :attrs={{ attrs }}>
+      <slot>{{ @label }}</slot>
+    </button>
     """
   end
 end

--- a/lib/surface/components/form/submit.ex
+++ b/lib/surface/components/form/submit.ex
@@ -27,9 +27,7 @@ defmodule Surface.Components.Form.Submit do
     attrs = opts_to_attrs(opts)
 
     ~H"""
-    <button type="submit" :attrs={{ attrs }}>
-      <slot>{{ @label }}</slot>
-    </button>
+    <button type="submit" :attrs={{ attrs }}><slot>{{ @label }}</slot></button>
     """
   end
 end

--- a/test/components/form/submit_test.exs
+++ b/test/components/form/submit_test.exs
@@ -11,11 +11,7 @@ defmodule Surface.Components.Form.SubmitTest do
         """
       end
 
-    assert html =~ """
-           <button type="submit">
-             Submit
-           </button>
-           """
+    assert html =~ ~s(<button type="submit">Submit</button>)
   end
 
   test "with class" do
@@ -48,11 +44,7 @@ defmodule Surface.Components.Form.SubmitTest do
         """
       end
 
-    assert html =~ """
-           <button class="btn" id="submit-btn" type="submit">
-             Submit
-           </button>
-           """
+    assert html =~ ~s(<button class="btn" id="submit-btn" type="submit">Submit</button>)
   end
 
   test "with children" do
@@ -91,12 +83,7 @@ defmodule Surface.Components.Form.SubmitTest do
         """
       end
 
-    assert html =~
-             """
-             <button type="submit">
-               &lt;Submit&gt;
-             </button>
-             """
+    assert html =~ ~s(<button type="submit">&lt;Submit&gt;</button>)
 
     html =
       render_surface do

--- a/test/components/form/submit_test.exs
+++ b/test/components/form/submit_test.exs
@@ -12,7 +12,9 @@ defmodule Surface.Components.Form.SubmitTest do
       end
 
     assert html =~ """
-           <button type="submit">Submit</button>
+           <button type="submit">
+             Submit
+           </button>
            """
   end
 
@@ -47,7 +49,9 @@ defmodule Surface.Components.Form.SubmitTest do
       end
 
     assert html =~ """
-           <button class="btn" id="submit-btn" type="submit">Submit</button>
+           <button class="btn" id="submit-btn" type="submit">
+             Submit
+           </button>
            """
   end
 

--- a/test/components/form/submit_test.exs
+++ b/test/components/form/submit_test.exs
@@ -78,4 +78,35 @@ defmodule Surface.Components.Form.SubmitTest do
 
     assert html =~ ~s(phx-click="my_click")
   end
+
+  test "is compatible with phoenix submit/2" do
+    html =
+      render_surface do
+        ~H"""
+        <Submit label="<Submit>" />
+        """
+      end
+
+    assert html =~
+             """
+             <button type="submit">
+               &lt;Submit&gt;
+             </button>
+             """
+
+    html =
+      render_surface do
+        ~H"""
+        <Submit>
+          {{ "<Submit>" }}
+        </Submit>
+        """
+      end
+
+    assert html =~ """
+           <button type="submit">
+             &lt;Submit&gt;
+           </button>
+           """
+  end
 end


### PR DESCRIPTION
Related to #342.

Reimplement the form `<Submit>` instead of relying on Phoenix's `button/2`.
The `button/2` function uses `content_tag/2` under the hood and prevents us from passing custom components to `<Submit>`.