### PR TITLE
Parser adjustments

### DIFF
--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -208,8 +208,10 @@ defmodule Surface.Compiler do
   end
 
   defp to_ast(nodes, compile_meta) do
-    for node <- nodes do
-      case convert_node_to_ast(node_type(node), node, compile_meta) do
+    for node <- nodes,
+        result = convert_node_to_ast(node_type(node), node, compile_meta),
+        result != :ignore do
+      case result do
         {:ok, ast} ->
           process_directives(ast)
 
@@ -232,6 +234,7 @@ defmodule Surface.Compiler do
   defp node_type({name, _, _, _}) when name in @void_elements, do: :void_tag
   defp node_type({_, _, _, _}), do: :tag
   defp node_type({:interpolation, _, _}), do: :interpolation
+  defp node_type({:comment, _}), do: :comment
   defp node_type(_), do: :text
 
   defp process_directives(%{directives: directives} = node) do
@@ -243,6 +246,8 @@ defmodule Surface.Compiler do
   end
 
   defp process_directives(node), do: node
+
+  defp convert_node_to_ast(:comment, _, _), do: :ignore
 
   defp convert_node_to_ast(:text, text, _),
     do: {:ok, %AST.Literal{value: text}}

--- a/lib/surface/compiler/parser.ex
+++ b/lib/surface/compiler/parser.ex
@@ -78,7 +78,7 @@ defmodule Surface.Compiler.Parser do
     |> optional(string("}}"))
 
   tag =
-    ascii_char([?a..?z, ?A..?Z])
+    ascii_char([?a..?z, ?A..?Z, ?:])
     |> ascii_string([?a..?z, ?A..?Z, ?0..?9, ?-, ?., ?_], min: 0)
     |> reduce({List, :to_string, []})
 

--- a/lib/surface/compiler/parser.ex
+++ b/lib/surface/compiler/parser.ex
@@ -129,10 +129,10 @@ defmodule Surface.Compiler.Parser do
     |> wrap()
 
   comment =
-    ignore(string("<!--"))
+    string("<!--")
     |> repeat(lookahead_not(string("-->")) |> utf8_char([]))
-    |> ignore(string("-->"))
-    |> ignore()
+    |> string("-->")
+    |> post_traverse(:comment)
 
   ## Void element node
 
@@ -222,6 +222,11 @@ defmodule Surface.Compiler.Parser do
     |> wrap()
     |> optional(closing_tag)
     |> post_traverse(:match_tags)
+
+  defp comment(_rest, ["-->" | _] = nodes, context, _line, _offset) do
+    comment = nodes |> Enum.reverse() |> IO.chardata_to_string()
+    {[{:comment, comment}], context}
+  end
 
   defp match_tags(
          _rest,

--- a/test/compiler_test.exs
+++ b/test/compiler_test.exs
@@ -88,6 +88,24 @@ defmodule Surface.CompilerTest do
     end
   end
 
+  test "ignore comments" do
+    code = """
+    <br>
+    <!-- comment -->
+    <hr>
+    """
+
+    nodes = Surface.Compiler.compile(code, 1, __ENV__)
+
+    assert [
+             %Surface.AST.VoidTag{element: "br"},
+             %Surface.AST.Literal{value: "\n"},
+             %Surface.AST.Literal{value: "\n"},
+             %Surface.AST.VoidTag{element: "hr"},
+             %Surface.AST.Literal{value: "\n"}
+           ] = nodes
+  end
+
   test "component with expression" do
     code = """
     <Button label={{ @label }}/>

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -105,30 +105,25 @@ defmodule Surface.Compiler.ParserTest do
            ]
   end
 
-  test "ignore comments" do
+  test "comments" do
     code = """
     <div>
-      <!-- This will be ignored -->
+    <!--
+    This is
+    a comment
+    -->
       <span/>
     </div>
     """
 
-    assert parse(code) ==
-             {:ok,
-              [
-                {
-                  "div",
-                  '',
-                  [
-                    "\n  ",
-                    "\n  ",
-                    {"span", [], [], %{line: 3, space: ""}},
-                    "\n"
-                  ],
-                  %{line: 1, space: ""}
-                },
-                "\n"
-              ]}
+    {:ok, [{"div", _, [_, {:comment, comment}, _, {"span", _, _, _}, _], _}, _]} = parse(code)
+
+    assert comment == """
+           <!--
+           This is
+           a comment
+           -->\
+           """
   end
 
   describe "void elements" do

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -69,6 +69,13 @@ defmodule Surface.Compiler.ParserTest do
               ], [], %{line: 1, space: ""}}
   end
 
+  test "slot shorthand" do
+    code = ~S(<:footer :let={{ a: 1 }}/>)
+    {:ok, [node]} = parse(code)
+
+    assert {":footer", [{":let", _, _}], [], _} = node
+  end
+
   test "spaces and line break between children" do
     code = """
     <div>


### PR DESCRIPTION
Closes #258.

  * Allow new slot shorthand notation, e.g. `<:header>`
  * Don't ignore comments at the parser level
  * Make the compiler ignore comment nodes