### PR TITLE
Improve the error message when missing `id` on a LiveComponent

### DIFF
--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -615,9 +615,7 @@ defmodule Surface.Compiler do
 
   defp validate_tag_children([%AST.Template{name: name} | _]) do
     {:error,
-     "templates are only allowed as children elements of components, but found template for #{
-       name
-     }"}
+     "templates are only allowed as children elements of components, but found template for #{name}"}
   end
 
   defp validate_tag_children([_ | nodes]), do: validate_tag_children(nodes)
@@ -719,6 +717,14 @@ defmodule Surface.Compiler do
 
       for prop_name <- missing_props_names do
         message = "Missing required property \"#{prop_name}\" for component <#{meta.node_alias}>"
+
+        message =
+          if prop_name == :id do
+            message <> "\n\nDid you mean to `use Surface.Component`?"
+          else
+            message
+          end
+
         IOHelper.warn(message, meta.caller, fn _ -> meta.line end)
       end
     end

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -615,9 +615,7 @@ defmodule Surface.Compiler do
 
   defp validate_tag_children([%AST.Template{name: name} | _]) do
     {:error,
-     "templates are only allowed as children elements of components, but found template for #{
-       name
-     }"}
+     "templates are only allowed as children elements of components, but found template for #{name}"}
   end
 
   defp validate_tag_children([_ | nodes]), do: validate_tag_children(nodes)
@@ -721,7 +719,7 @@ defmodule Surface.Compiler do
         message = "Missing required property \"#{prop_name}\" for component <#{meta.node_alias}>"
 
         message =
-          if prop_name == :id do
+          if prop_name == :id and is_stateful_component(module) do
             message <>
               """
               \n\nHint: Components using `Surface.LiveComponent` automatically define a required `id` prop to make them stateful.

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -722,7 +722,11 @@ defmodule Surface.Compiler do
 
         message =
           if prop_name == :id do
-            message <> "\n\nDid you mean to `use Surface.Component`?"
+            message <>
+              """
+              \n\nHint: Components using `Surface.LiveComponent` automatically define a required `id` prop to make them stateful.
+              If you meant to create a stateless component, you can switch to `use Surface.Component`.
+              """
           else
             message
           end

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -615,7 +615,9 @@ defmodule Surface.Compiler do
 
   defp validate_tag_children([%AST.Template{name: name} | _]) do
     {:error,
-     "templates are only allowed as children elements of components, but found template for #{name}"}
+     "templates are only allowed as children elements of components, but found template for #{
+       name
+     }"}
   end
 
   defp validate_tag_children([_ | nodes]), do: validate_tag_children(nodes)

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -724,7 +724,7 @@ defmodule Surface.Compiler do
           if prop_name == :id and is_stateful_component(module) do
             message <>
               """
-              \n\nHint: Components using `Surface.LiveComponent` automatically defines a required `id` prop to make them stateful.
+              \n\nHint: Components using `Surface.LiveComponent` automatically define a required `id` prop to make them stateful.
               If you meant to create a stateless component, you can switch to `use Surface.Component`.
               """
           else

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -615,7 +615,9 @@ defmodule Surface.Compiler do
 
   defp validate_tag_children([%AST.Template{name: name} | _]) do
     {:error,
-     "templates are only allowed as children elements of components, but found template for #{name}"}
+     "templates are only allowed as children elements of components, but found template for #{
+       name
+     }"}
   end
 
   defp validate_tag_children([_ | nodes]), do: validate_tag_children(nodes)
@@ -722,7 +724,7 @@ defmodule Surface.Compiler do
           if prop_name == :id and is_stateful_component(module) do
             message <>
               """
-              \n\nHint: Components using `Surface.LiveComponent` automatically define a required `id` prop to make them stateful.
+              \n\nHint: Components using `Surface.LiveComponent` automatically defines a required `id` prop to make them stateful.
               If you meant to create a stateless component, you can switch to `use Surface.Component`.
               """
           else

--- a/lib/surface/type_handler/list.ex
+++ b/lib/surface/type_handler/list.ex
@@ -35,9 +35,7 @@ defmodule Surface.TypeHandler.List do
           value
 
         value ->
-          raise "invalid value for property \"#{unquote(name)}\". Expected a :list, got: #{
-                  inspect(value)
-                }"
+          raise "invalid value for property \"#{unquote(name)}\". Expected a :list, got: #{inspect(value)}"
       end
     end
   end

--- a/lib/surface/type_handler/list.ex
+++ b/lib/surface/type_handler/list.ex
@@ -35,7 +35,9 @@ defmodule Surface.TypeHandler.List do
           value
 
         value ->
-          raise "invalid value for property \"#{unquote(name)}\". Expected a :list, got: #{inspect(value)}"
+          raise "invalid value for property \"#{unquote(name)}\". Expected a :list, got: #{
+                  inspect(value)
+                }"
       end
     end
   end

--- a/test/compiler_test.exs
+++ b/test/compiler_test.exs
@@ -616,7 +616,7 @@ defmodule Surface.CompilerSyncTest do
 
   import ExUnit.CaptureIO
 
-  alias Surface.CompilerTest.{Button, Column}, warn: false
+  alias Surface.CompilerTest.{Button, Column, GridLive}, warn: false
 
   test "warning when a aliased component cannot be loaded" do
     alias Components.But, warn: false
@@ -722,6 +722,22 @@ defmodule Surface.CompilerSyncTest do
     {:warn, line, message} = run_compile(code, __ENV__)
 
     assert message =~ ~S(Missing required property "title" for component <Column>)
+    assert line == 1
+  end
+
+  test "warning on missing id for LiveComponent" do
+    code = """
+    <GridLive />
+    """
+
+    {:warn, line, message} = run_compile(code, __ENV__)
+
+    assert message =~ ~S"""
+           Missing required property "id" for component <GridLive>
+
+           Did you mean to `use Surface.Component`?
+           """
+
     assert line == 1
   end
 

--- a/test/compiler_test.exs
+++ b/test/compiler_test.exs
@@ -735,7 +735,8 @@ defmodule Surface.CompilerSyncTest do
     assert message =~ ~S"""
            Missing required property "id" for component <GridLive>
 
-           Did you mean to `use Surface.Component`?
+           Hint: Components using `Surface.LiveComponent` automatically define a required `id` prop to make them stateful.
+           If you meant to create a stateless component, you can switch to `use Surface.Component`.
            """
 
     assert line == 1


### PR DESCRIPTION
This should point new users in the direction that they may be using `Surface.LiveComponent` instead of `Surface.Component`