### PR TITLE
Set .tool-versions for asdf

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,3 @@
+elixir 1.11.1-otp-23
+erlang 23.1.2
+nodejs 14.5.0


### PR DESCRIPTION
These match what your CI is using. We can bump to 1.11.4 as well

Noticed in #347 