### PR TITLE
Add support for phx-value-*

### DIFF
--- a/lib/surface/components/events.ex
+++ b/lib/surface/components/events.ex
@@ -32,6 +32,9 @@ defmodule Surface.Components.Events do
 
       @doc "Triggered when a key on the keyboard is pressed"
       prop keydown, :event
+
+      @doc "List values that will be sent as part of the payload triggered by an event"
+      prop values, :keyword, default: []
     end
   end
 end

--- a/lib/surface/components/utils.ex
+++ b/lib/surface/components/utils.ex
@@ -126,6 +126,10 @@ defmodule Surface.Components.Utils do
     |> List.flatten()
   end
 
+  defp values_to_opts([]) do
+    []
+  end
+
   defp values_to_opts(values) when is_list(values) do
     {:values, values}
   end

--- a/lib/surface/components/utils.ex
+++ b/lib/surface/components/utils.ex
@@ -90,6 +90,7 @@ defmodule Surface.Components.Utils do
         :phx_keydown -> {:"phx-keydown", value}
         :phx_target -> {:"phx-target", value}
         :data -> data_to_attrs(value)
+        :values -> values_to_attrs(value)
         _ -> {key, value}
       end
     end
@@ -99,6 +100,12 @@ defmodule Surface.Components.Utils do
   defp data_to_attrs(data) when is_list(data) do
     for {key, value} <- data do
       {:"data-#{key}", value}
+    end
+  end
+
+  defp values_to_attrs(values) when is_list(values) do
+    for {key, value} <- values do
+      {:"phx-value-#{key}", value}
     end
   end
 
@@ -113,8 +120,17 @@ defmodule Surface.Components.Utils do
       event_to_opts(assigns.window_keyup, :phx_window_keyup),
       event_to_opts(assigns.window_keydown, :phx_window_keydown),
       event_to_opts(assigns.keyup, :phx_keyup),
-      event_to_opts(assigns.keydown, :phx_keydown)
+      event_to_opts(assigns.keydown, :phx_keydown),
+      values_to_opts(assigns.values)
     ]
     |> List.flatten()
+  end
+
+  defp values_to_opts(values) when is_list(values) do
+    {:values, values}
+  end
+
+  defp values_to_opts(_values) do
+    []
   end
 end

--- a/test/components/events_test.exs
+++ b/test/components/events_test.exs
@@ -188,7 +188,7 @@ defmodule Surface.Components.EventsTest do
     html =
       render_surface do
         ~H"""
-        <ComponentWithEvents click="my_click" values={{ hello: :world, foo: "bar", one: 2 }} />
+        <ComponentWithEvents click="my_click" values={ hello: :world, foo: "bar", one: 2 } />
         """
       end
 

--- a/test/components/events_test.exs
+++ b/test/components/events_test.exs
@@ -183,4 +183,17 @@ defmodule Surface.Components.EventsTest do
            </div>
            """
   end
+
+  test "event with values" do
+    html =
+      render_surface do
+        ~H"""
+        <ComponentWithEvents click="my_click" values={{ hello: :world, foo: "bar", one: 2 }} />
+        """
+      end
+
+    assert html =~ """
+           <div phx-click="my_click" phx-value-foo="bar" phx-value-hello="world" phx-value-one="2"></div>
+           """
+  end
 end


### PR DESCRIPTION
Related to #330.

Discussion about the name of the prop is still open. Options so far are:
- `values`
- `event_values`
- `events_values`

Please let me know if you have any other suggestions and which option you prefer.