### PR TITLE
Support Range in :values

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,15 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - elixir: 1.8.2
-            otp: 21.3.8.17
-          - elixir: 1.9.4
-            otp: 21.3.8.17
-            warnings_as_errors: true # not 1.10 as its --warnigs-as-errors has bugs https://github.com/elixir-lang/elixir/issues/10073
-          - elixir: 1.10.4
-            otp: 21.3.8.17
-          - elixir: 1.10.4
-            otp: 23.1.1
           - elixir: 1.11.1
             otp: 21.3.8.17
           - elixir: 1.11.4

--- a/lib/surface/api.ex
+++ b/lib/surface/api.ex
@@ -421,9 +421,11 @@ defmodule Surface.API do
   end
 
   defp validate_opt(_func, _name, _type, _opts, :values, value, _caller)
-       when not is_list(value) do
+       when not is_list(value) and not is_struct(value, Range) do
     {:error,
-     "invalid value for option :values. Expected a list of values, got: #{inspect(value)}"}
+     "invalid value for option :values. Expected a list of values or a Range, got: #{
+       inspect(value)
+     }"}
   end
 
   defp validate_opt(:prop, _name, _type, _opts, :accumulate, value, _caller)

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Surface.MixProject do
     [
       app: :surface,
       version: @version,
-      elixir: "~> 1.8",
+      elixir: "~> 1.11",
       description: "A component based library for Phoenix LiveView",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix] ++ Mix.compilers(),

--- a/test/api_test.exs
+++ b/test/api_test.exs
@@ -50,6 +50,12 @@ defmodule Surface.APITest do
     assert_raise(CompileError, message, fn -> eval(code) end)
   end
 
+  test "validate :values when using a range" do
+    code = "prop age, :integer, values: 1..100"
+
+    {:ok, _module} = eval(code)
+  end
+
   test "validate :as in slot" do
     code = "slot label, as: \"default_label\""
     message = ~r/invalid value for option :as in slot. Expected an atom, got: \"default_label\"/

--- a/test/api_test.exs
+++ b/test/api_test.exs
@@ -45,7 +45,7 @@ defmodule Surface.APITest do
 
   test "validate :values" do
     code = "prop label, :string, values: 1"
-    message = ~r/invalid value for option :values. Expected a list of values, got: 1/
+    message = ~r/invalid value for option :values. Expected a list of values or a Range, got: 1/
 
     assert_raise(CompileError, message, fn -> eval(code) end)
   end

--- a/test/api_test.exs
+++ b/test/api_test.exs
@@ -51,7 +51,10 @@ defmodule Surface.APITest do
   end
 
   test "validate :values when using a range" do
-    code = "prop age, :integer, values: 1..100"
+    code = """
+    prop age, :integer, values: 1..100
+    data items, :integer, values: 1..3
+    """
 
     {:ok, _module} = eval(code)
   end

--- a/test/components/form/label_test.exs
+++ b/test/components/form/label_test.exs
@@ -98,17 +98,13 @@ defmodule Surface.Components.Form.LabelTest do
       html = render_surface(do: ~H[<Label form={:search} field={:key} />])
       assert html =~ ~r[<label for="search_key">(.*)Key(.*)</label>]s
 
-      html =
-        render_surface(
-          do: ~H[<Label form={:search} field={:key} opts={for: "test_key"} />]
-        )
+      html = render_surface(do: ~H[<Label form={:search} field={:key} opts={for: "test_key"} />])
 
       assert html =~ ~r[<label for="test_key">(.*)Key(.*)</label>]s
 
       html =
         render_surface(
-          do:
-            ~H[<Label form={:search} field={:key} class="foo" opts={for: "test_key"} />]
+          do: ~H[<Label form={:search} field={:key} class="foo" opts={for: "test_key"} />]
         )
 
       assert html =~ ~r[<label class="foo" for="test_key">(.*)Key(.*)</label>]s
@@ -120,8 +116,7 @@ defmodule Surface.Components.Form.LabelTest do
 
       html =
         render_surface(
-          do:
-            ~H[<Label text="Search" form={:search} field={:key} opts={for: "test_key"} />]
+          do: ~H[<Label text="Search" form={:search} field={:key} opts={for: "test_key"} />]
         )
 
       assert html =~ ~r[<label for="test_key">(.*)Search(.*)</label>]s
@@ -169,8 +164,7 @@ defmodule Surface.Components.Form.LabelTest do
     test "with field and inline safe content" do
       html =
         render_surface(
-          do:
-            ~H[<Label text={{:safe, "<em>Search</em>"}} form={:search} field={:key} />]
+          do: ~H[<Label text={{:safe, "<em>Search</em>"}} form={:search} field={:key} />]
         )
 
       assert html =~ ~r[<label for="search_key">(.*)<em>Search</em>(.*)</label>]s

--- a/test/components/link_test.exs
+++ b/test/components/link_test.exs
@@ -171,8 +171,7 @@ defmodule Surface.Components.LinkTest do
       html = render_surface(do: ~H[<Link label="foo" to="/javascript:alert(<1>)" />])
       assert html =~ ~s[<a href="/javascript:alert(&lt;1&gt;)">foo</a>]
 
-      html =
-        render_surface(do: ~H[<Link label="foo" to={{:safe, "/javascript:alert(<1>)"}} />])
+      html = render_surface(do: ~H[<Link label="foo" to={{:safe, "/javascript:alert(<1>)"}} />])
 
       assert html =~ ~s[<a href="/javascript:alert(<1>)">foo</a>]
 


### PR DESCRIPTION
This PR adds support to prop `:values` such that a range can be used to communicate the possible values.

### Example
```elixir
defmodule MyComponent do
  use Surface.Component
  
  prop age, :integer, values: 1..100, default: 1
  
  ...
end
```

### Considerations
This adds `is_struct/2` as a guard, which was added in Elixir 1.11. I'm not sure which version we're looking to support. If we need to support earlier versions, then I believe I'll need to refactor `validate_opt/7` as the way it currently works only supports rejecting values

### Follow ups
If this PR is accepted, I will also PR to update the docs and the catalogue to support this new feature