### PR TITLE
Add :values directive

### DIFF
--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -21,7 +21,8 @@ defmodule Surface.Compiler do
     Surface.Directive.If,
     Surface.Directive.For,
     Surface.Directive.Debug,
-    Surface.Directive.Hook
+    Surface.Directive.Hook,
+    Surface.Directive.Values
   ]
 
   @component_directive_handlers [

--- a/lib/surface/directive/values.ex
+++ b/lib/surface/directive/values.ex
@@ -30,17 +30,7 @@ defmodule Surface.Directive.Values do
         for {name, value} <- unquote(value) || [],
             attr_name = :"phx-value-#{name}",
             not Enum.member?(unquote(Macro.escape(attr_names)), attr_name) do
-          unless String.Chars.impl_for(value) do
-            message = """
-            invalid value for key "#{inspect(name)}" in attribute ":values".
-
-            Expected a type that implements the String.Chars protocol (e.g. string, boolean, integer, atom, ...), \
-            got: #{inspect(unquote(value))}\
-            """
-
-            IOHelper.runtime_error(message)
-          end
-
+          unquote(__MODULE__).validate_value!(name, value)
           {attr_name, {Surface.TypeHandler.attribute_type_and_opts(attr_name), to_string(value)}}
         end
       end
@@ -64,5 +54,18 @@ defmodule Surface.Directive.Values do
       value: Surface.TypeHandler.expr_to_quoted!(value, ":values", :map, meta),
       meta: meta
     }
+  end
+
+  def validate_value!(name, value) do
+    unless String.Chars.impl_for(value) do
+      message = """
+      invalid value for key "#{inspect(name)}" in attribute ":values".
+
+      Expected a type that implements the String.Chars protocol (e.g. string, boolean, integer, atom, ...), \
+      got: #{inspect(value)}\
+      """
+
+      IOHelper.runtime_error(message)
+    end
   end
 end

--- a/lib/surface/directive/values.ex
+++ b/lib/surface/directive/values.ex
@@ -1,0 +1,56 @@
+defmodule Surface.Directive.Values do
+  use Surface.Directive
+
+  def extract({":values", {:attribute_expr, value, expr_meta}, attr_meta}, meta) do
+    expr_meta = Helpers.to_meta(expr_meta, meta)
+    attr_meta = Helpers.to_meta(attr_meta, meta)
+
+    %AST.Directive{
+      module: __MODULE__,
+      name: :values,
+      value: directive_value(value, expr_meta),
+      meta: attr_meta
+    }
+  end
+
+  def extract(_, _), do: []
+
+  def process(
+        %AST.Directive{value: %AST.AttributeExpr{value: value} = expr, meta: meta},
+        %type{attributes: attributes} = node
+      )
+      when type in [AST.Tag, AST.VoidTag] do
+    attr_names =
+      attributes
+      |> Enum.filter(fn
+        %AST.Attribute{} -> true
+        _ -> false
+      end)
+      |> Enum.map(fn %AST.Attribute{name: name} -> name end)
+
+    new_expr =
+      quote generated: true do
+        for {name, value} <- unquote(value) || [],
+            attr_name = :"phx-value-#{name}",
+            not Enum.member?(unquote(Macro.escape(attr_names)), attr_name) do
+          {attr_name, {Surface.TypeHandler.attribute_type_and_opts(attr_name), to_string(value)}}
+        end
+      end
+
+    %{
+      node
+      | attributes: [
+          %AST.DynamicAttribute{name: :attrs, meta: meta, expr: %{expr | value: new_expr}}
+          | attributes
+        ]
+    }
+  end
+
+  defp directive_value(value, meta) do
+    %AST.AttributeExpr{
+      original: value,
+      value: Surface.TypeHandler.expr_to_quoted!(value, ":values", :map, meta),
+      meta: meta
+    }
+  end
+end

--- a/test/directives_test.exs
+++ b/test/directives_test.exs
@@ -761,7 +761,7 @@ defmodule Surface.DirectivesTest do
       html =
         render_surface do
           ~H"""
-          <div :values={{ hello: :world, foo: "bar", one: 2, yes: true }}>
+          <div :values={hello: :world, foo: "bar", one: 2, yes: true}>
             Some Text
           </div>
           """
@@ -778,7 +778,7 @@ defmodule Surface.DirectivesTest do
       html =
         render_surface do
           ~H"""
-          <div :values={{ %{hello: :world, foo: "bar", one: 2, yes: true} }}>
+          <div :values={%{hello: :world, foo: "bar", one: 2, yes: true}}>
             Some Text
           </div>
           """
@@ -795,7 +795,7 @@ defmodule Surface.DirectivesTest do
       assert_raise(RuntimeError, ~r(invalid value for key ":map" in attribute ":values".), fn ->
         render_surface do
           ~H"""
-          <div :values={{ map: %{}, tuple: {} }}>
+          <div :values={map: %{}, tuple: {}}>
             Some Text
           </div>
           """
@@ -809,7 +809,7 @@ defmodule Surface.DirectivesTest do
       html =
         render_surface do
           ~H"""
-          <div :values={{ @values }}>
+          <div :values={@values}>
             Some Text
           </div>
           """
@@ -826,7 +826,7 @@ defmodule Surface.DirectivesTest do
       html =
         render_surface do
           ~H"""
-          <div phx-value-hello="static-world" :values={{ hello: "dynamic-world" }}>
+          <div phx-value-hello="static-world" :values={hello: "dynamic-world"}>
             Some Text
           </div>
           """

--- a/test/directives_test.exs
+++ b/test/directives_test.exs
@@ -188,7 +188,7 @@ defmodule Surface.DirectivesTest do
              """
     end
 
-    test "static properties override dyanmic properties" do
+    test "static properties override dynamic properties" do
       html =
         render_surface do
           ~H"""
@@ -752,6 +752,78 @@ defmodule Surface.DirectivesTest do
 
       assert html =~ """
              <div></div>
+             """
+    end
+  end
+
+  describe ":values" do
+    test "passing a keyword list" do
+      html =
+        render_surface do
+          ~H"""
+          <div :values={{ hello: :world, foo: "bar", one: 2, yes: true }}>
+            Some Text
+          </div>
+          """
+        end
+
+      assert html =~ """
+             <div phx-value-foo="bar" phx-value-hello="world" phx-value-one="2" phx-value-yes="true">
+               Some Text
+             </div>
+             """
+    end
+
+    test "passing a map" do
+      html =
+        render_surface do
+          ~H"""
+          <div :values={{ %{hello: :world, foo: "bar", one: 2, yes: true} }}>
+            Some Text
+          </div>
+          """
+        end
+
+      assert html =~ """
+             <div phx-value-foo="bar" phx-value-hello="world" phx-value-one="2" phx-value-yes="true">
+               Some Text
+             </div>
+             """
+    end
+
+    test "using an assign" do
+      assigns = %{values: [hello: :world, foo: "bar", one: 2, yes: true]}
+
+      html =
+        render_surface do
+          ~H"""
+          <div :values={{ @values }}>
+            Some Text
+          </div>
+          """
+        end
+
+      assert html =~ """
+             <div phx-value-foo="bar" phx-value-hello="world" phx-value-one="2" phx-value-yes="true">
+               Some Text
+             </div>
+             """
+    end
+
+    test "static properties override dynamic properties" do
+      html =
+        render_surface do
+          ~H"""
+          <div phx-value-hello="static-world" :values={{ hello: "dynamic-world" }}>
+            Some Text
+          </div>
+          """
+        end
+
+      assert html =~ """
+             <div phx-value-hello="static-world">
+               Some Text
+             </div>
              """
     end
   end

--- a/test/directives_test.exs
+++ b/test/directives_test.exs
@@ -791,6 +791,18 @@ defmodule Surface.DirectivesTest do
              """
     end
 
+    test "passing unsupported types" do
+      assert_raise(RuntimeError, ~r(invalid value for key ":map" in attribute ":values".), fn ->
+        render_surface do
+          ~H"""
+          <div :values={{ map: %{}, tuple: {} }}>
+            Some Text
+          </div>
+          """
+        end
+      end)
+    end
+
     test "using an assign" do
       assigns = %{values: [hello: :world, foo: "bar", one: 2, yes: true]}
 


### PR DESCRIPTION
Related to #354.

Adds the `:values` directive for generating `phx-value-*` attributes.

#### Example
```elixir
<div :values={{ hello: :world, foo: "bar", one: 2, yes: true }}>
  Some Text
</div>
```
```html
<div phx-value-foo="bar" phx-value-hello="world" phx-value-one="2" phx-value-yes="true">
  Some Text
</div>
```
