### PR TITLE
workaround for :attribute_expr in event name

### DIFF
--- a/lib/surface/directive/events.ex
+++ b/lib/surface/directive/events.ex
@@ -71,6 +71,10 @@ defmodule Surface.Directive.Events do
     }
   end
 
+  defp to_quoted_expr(name, [{:attribute_expr, original, expr_meta} = value], meta) do
+    to_quoted_expr(name, value, meta)
+  end
+
   defp to_quoted_expr(name, value, meta) when is_list(value) do
     to_quoted_expr(name, to_string(value), meta)
   end


### PR DESCRIPTION
Hello,
Had an issue where I was getting the following error for [this component](https://github.com/bonfire-networks/bonfire_ui_social/tree/main/lib/web/components/multiselect), and this addition to Surface made it go away. Not sure if it's a desirable change though, happy to discuss...

```
== Compilation error in file lib/web/components/multiselect/multiselect_live.ex ==
** (ArgumentError) cannot convert the given list to a string.

To be converted to a string, a list must either be empty or only
contain the following elements:

  * strings
  * integers representing Unicode code points
  * a list containing one of these three elements

Please check the given list or call inspect/1 to get the list representation, got:

[{:attribute_expr, " @remove_event ", %{line: 16}}]

    (elixir 1.11.4) lib/list.ex:925: List.to_string/1
    (surface 0.3.2) lib/surface/directive/events.ex:75: Surface.Directive.Events.to_quoted_expr/3
    (surface 0.3.2) lib/surface/directive/events.ex:30: Surface.Directive.Events.extract/2
    (elixir 1.11.4) lib/enum.ex:1411: Enum."-map/2-lists^map/1-0-"/2
    (elixir 1.11.4) lib/enum.ex:1411: Enum."-map/2-lists^map/1-0-"/2
    (surface 0.3.2) lib/surface/compiler.ex:644: Surface.Compiler.collect_directives/3
    (surface 0.3.2) lib/surface/compiler.ex:329: Surface.Compiler.convert_node_to_ast/3
    (surface 0.3.2) lib/surface/compiler.ex:212: anonymous fn/3 in Surface.Compiler.to_ast/2
```