### PR TITLE
Allow ranges to be passed for :list props

### DIFF
--- a/lib/surface/type_handler/list.ex
+++ b/lib/surface/type_handler/list.ex
@@ -32,7 +32,7 @@ defmodule Surface.TypeHandler.List do
     quote generated: true do
       case unquote(expr) do
         value when is_list(value) or is_struct(value, Range) ->
-          value
+          Enum.to_list(value)
 
         value ->
           raise "invalid value for property \"#{unquote(name)}\". Expected a :list, got: #{

--- a/lib/surface/type_handler/list.ex
+++ b/lib/surface/type_handler/list.ex
@@ -31,7 +31,7 @@ defmodule Surface.TypeHandler.List do
   defp handle_list_expr(name, expr) do
     quote generated: true do
       case unquote(expr) do
-        value when is_list(value) ->
+        value when is_list(value) or is_struct(value, Range) ->
           value
 
         value ->

--- a/test/properties_test.exs
+++ b/test/properties_test.exs
@@ -45,7 +45,7 @@ defmodule Surface.PropertiesTest do
 
     def render(assigns) do
       ~H"""
-      List?: { is_list(@prop) }
+      List?: {is_list(@prop)}
       <span :for={v <- @prop}>value: {inspect(v)}</span>
       """
     end
@@ -421,7 +421,7 @@ defmodule Surface.PropertiesTest do
       html =
         render_surface do
           ~H"""
-          <ListProp prop={ 1..3 }/>
+          <ListProp prop={1..3}/>
           """
         end
 

--- a/test/properties_test.exs
+++ b/test/properties_test.exs
@@ -426,7 +426,7 @@ defmodule Surface.PropertiesTest do
       html =
         render_surface do
           ~H"""
-          <ListProp prop={{ 1..3 }}/>
+          <ListProp prop={ 1..3 }/>
           """
         end
 

--- a/test/properties_test.exs
+++ b/test/properties_test.exs
@@ -46,7 +46,6 @@ defmodule Surface.PropertiesTest do
     def render(assigns) do
       ~H"""
       List?: { is_list(@prop) }
-      Range?: { is_struct(@prop, Range) }
       <span :for={v <- @prop}>value: {inspect(v)}</span>
       """
     end
@@ -339,7 +338,6 @@ defmodule Surface.PropertiesTest do
 
       assert html =~ """
              List?: true
-             Range?: false
              <span>value: 1</span>\
              <span>value: 2</span>
              """
@@ -357,7 +355,6 @@ defmodule Surface.PropertiesTest do
 
       assert html =~ """
              List?: true
-             Range?: false
              <span>value: 1</span>\
              <span>value: 2</span>
              """
@@ -375,7 +372,6 @@ defmodule Surface.PropertiesTest do
 
       assert html =~ """
              List?: true
-             Range?: false
              <span>value: 1</span>
              """
     end
@@ -417,7 +413,6 @@ defmodule Surface.PropertiesTest do
 
       assert html =~ """
              List?: true
-             Range?: false
              <span>value: {:a, 1}</span><span>value: {:b, 2}</span>
              """
     end
@@ -431,8 +426,7 @@ defmodule Surface.PropertiesTest do
         end
 
       assert html =~ """
-             List?: false
-             Range?: true
+             List?: true
              <span>value: 1</span><span>value: 2</span><span>value: 3</span>
              """
     end
@@ -447,7 +441,6 @@ defmodule Surface.PropertiesTest do
 
       assert html =~ """
              List?: true
-             Range?: false
              <span>value: {:a, 1}</span><span>value: {:b, 2}</span>
              """
     end

--- a/test/properties_test.exs
+++ b/test/properties_test.exs
@@ -45,7 +45,8 @@ defmodule Surface.PropertiesTest do
 
     def render(assigns) do
       ~H"""
-      List?: {is_list(@prop)}
+      List?: { is_list(@prop) }
+      Range?: { is_struct(@prop, Range) }
       <span :for={v <- @prop}>value: {inspect(v)}</span>
       """
     end
@@ -338,6 +339,7 @@ defmodule Surface.PropertiesTest do
 
       assert html =~ """
              List?: true
+             Range?: false
              <span>value: 1</span>\
              <span>value: 2</span>
              """
@@ -355,6 +357,7 @@ defmodule Surface.PropertiesTest do
 
       assert html =~ """
              List?: true
+             Range?: false
              <span>value: 1</span>\
              <span>value: 2</span>
              """
@@ -372,6 +375,7 @@ defmodule Surface.PropertiesTest do
 
       assert html =~ """
              List?: true
+             Range?: false
              <span>value: 1</span>
              """
     end
@@ -413,7 +417,23 @@ defmodule Surface.PropertiesTest do
 
       assert html =~ """
              List?: true
+             Range?: false
              <span>value: {:a, 1}</span><span>value: {:b, 2}</span>
+             """
+    end
+
+    test "passing a range" do
+      html =
+        render_surface do
+          ~H"""
+          <ListProp prop={{ 1..3 }}/>
+          """
+        end
+
+      assert html =~ """
+             List?: false
+             Range?: true
+             <span>value: 1</span><span>value: 2</span><span>value: 3</span>
              """
     end
 
@@ -427,6 +447,7 @@ defmodule Surface.PropertiesTest do
 
       assert html =~ """
              List?: true
+             Range?: false
              <span>value: {:a, 1}</span><span>value: {:b, 2}</span>
              """
     end


### PR DESCRIPTION
Similar to #355, allows ranges to be passed for `:list` values. This is particularly useful when you have a fixed number of components that would be generated from within the prop. I found the need for this when implementing a `RadioGroup` component that composes `Surface.Components.Form.RadioButton`

There is an argument for allowing any enumerable to be passed as a list, I'm not sure if that's a good idea or not.

## Example

```elixir
<MyComponent list={ 1..4 } />
```
