### PR TITLE
Implement shorthand notation for assigning slots

### DIFF
--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -629,7 +629,9 @@ defmodule Surface.Compiler do
 
   defp validate_tag_children([%AST.Template{name: name} | _]) do
     {:error,
-     "templates are only allowed as children elements of components, but found template for #{name}"}
+     "templates are only allowed as children elements of components, but found template for #{
+       name
+     }"}
   end
 
   defp validate_tag_children([_ | nodes]), do: validate_tag_children(nodes)

--- a/lib/surface/compiler/converter_0_5.ex
+++ b/lib/surface/compiler/converter_0_5.ex
@@ -13,15 +13,15 @@ defmodule Surface.Compiler.Converter_0_5 do
     "{#{value}}"
   end
 
+  def convert(:tag_name, "template", _state, _opts) do
+    "#template"
+  end
+
+  def convert(:tag_name, "slot", _state, _opts) do
+    "#slot"
+  end
+
   ## Planned changes. Uncomment as the related implementation gets merged
-
-  # def convert(:tag_name, "template", _state, _opts) do
-  #   "#template"
-  # end
-
-  # def convert(:tag_name, "slot", _state, _opts) do
-  #   "#slot"
-  # end
 
   # def convert(:tag_name, "If", _state, _opts) do
   #   "#if"

--- a/test/compiler/converter_0_5_test.exs
+++ b/test/compiler/converter_0_5_test.exs
@@ -69,45 +69,45 @@ defmodule Surface.Compiler.Converter_0_5Test do
            """
   end
 
+  test "convert <template> into <#template>" do
+    expected =
+      convert("""
+      <div>
+        <template slot="footer">
+          Footer
+        </template>
+      </div>
+      """)
+
+    assert expected == """
+           <div>
+             <#template slot="footer">
+               Footer
+             </#template>
+           </div>
+           """
+  end
+
+  test "convert <slot> into <#slot>" do
+    expected =
+      convert("""
+      <div>
+        <slot name="footer">
+          Footer
+        </slot>
+      </div>
+      """)
+
+    assert expected == """
+           <div>
+             <#slot name="footer">
+               Footer
+             </#slot>
+           </div>
+           """
+  end
+
   ## Planned changes. Uncomment as the related implementation gets merged
-
-  # test "convert <template> into <#template>" do
-  #   expected =
-  #     convert("""
-  #     <div>
-  #       <template slot="footer">
-  #         Footer
-  #       </template>
-  #     </div>
-  #     """)
-
-  #   assert expected == """
-  #          <div>
-  #            <#template slot="footer">
-  #              Footer
-  #            </#template>
-  #          </div>
-  #          """
-  # end
-
-  # test "convert <slot> into <#slot>" do
-  #   expected =
-  #     convert("""
-  #     <div>
-  #       <slot name="footer">
-  #         Footer
-  #       </slot>
-  #     </div>
-  #     """)
-
-  #   assert expected == """
-  #          <div>
-  #            <#slot name="footer">
-  #              Footer
-  #            </#slot>
-  #          </div>
-  #          """
-  # end
 
   # test "convert <If> into <#if>" do
   #   expected =

--- a/test/slot_test.exs
+++ b/test/slot_test.exs
@@ -862,6 +862,76 @@ defmodule Surface.SlotTest do
            </div>
            """
   end
+
+  describe "Shorthand notatation for assigning slots" do
+    test "assign named slots without props" do
+      html =
+        render_surface do
+          ~H"""
+          <OuterWithNamedSlot>
+            <:header>
+              My header
+            </:header>
+            My body
+            <:footer>
+              My footer
+            </:footer>
+          </OuterWithNamedSlot>
+          """
+        end
+
+      assert html =~ """
+             <div>
+                 My header
+               My body
+                 My footer
+             </div>
+             """
+    end
+
+    test "does not render slot if slot_assigned? returns false" do
+      html =
+        render_surface do
+          ~H"""
+          <OuterWithOptionalNamedSlot>
+            <:header>
+              My Header
+            </:header>
+          </OuterWithOptionalNamedSlot>
+          """
+        end
+
+      assert html =~ """
+             <div>
+               <header>
+                 My Header
+               </header>
+               <footer>
+                 Footer fallback
+               </footer>
+             </div>
+             """
+    end
+
+    test "assign named slots with props" do
+      html =
+        render_surface do
+          ~H"""
+          <OuterWithNamedSlotAndProps>
+            <:body :let={info: my_info}>
+              Info: {my_info}
+            </:body>
+          </OuterWithNamedSlotAndProps>
+          """
+        end
+
+      assert html =~ """
+             <div>
+                 Info: Info from slot
+             </div>
+             """
+    end
+  end
 end
 
 defmodule Surface.SlotSyncTest do


### PR DESCRIPTION
This pull request implements the new syntax for assigning slots:

Instead of 
```
<Card>
  <template slot="header">
    ...
  </template>
  <template slot="footer">
    ...
  </template>
</Card>
```
You will be able to use the following syntax:
```
<Card>
  <:header>
    ...
  </:header>
  <:footer>
    ...
  </:footer>
</Card>
```

@msaraiva a couple of questions still need an answer:
- Should we deprecate the syntax `<#template name="">`?
- Should we use the new syntax in the built-in Surface components?
- Should we use the new syntax in the tests that are not directly related to the old syntax?
- Should I wrote a convert function to handle convert old syntax to the new one? Which one are the old one, `<template>` or `<#template>` or both?