### PR TITLE
refactoring parse error handling

### DIFF
--- a/lib/surface.ex
+++ b/lib/surface.ex
@@ -104,20 +104,24 @@ defmodule Surface do
   Translates Surface code into Phoenix templates.
   """
   defmacro sigil_H({:<<>>, meta, [string]}, opts) do
-    line_offset = __CALLER__.line + compute_line_offset(meta)
+    line = __CALLER__.line + compute_line_offset(meta)
+    # TODO: column or indentation here?
+    # i couldn't really figure out how to find the column for non heredoc usage
+    column = meta[:indentation] || 1
 
     caller_is_surface_component =
       Module.open?(__CALLER__.module) &&
         Module.get_attribute(__CALLER__.module, :component_type) != nil
 
     string
-    |> Surface.Compiler.compile(line_offset, __CALLER__, __CALLER__.file,
-      checks: [no_undefined_assigns: caller_is_surface_component]
+    |> Surface.Compiler.compile(line, __CALLER__, __CALLER__.file,
+      checks: [no_undefined_assigns: caller_is_surface_component],
+      column: column
     )
     |> Surface.Compiler.to_live_struct(
       debug: Enum.member?(opts, ?d),
       file: __CALLER__.file,
-      line: __CALLER__.line
+      line: line
     )
   end
 

--- a/lib/surface.ex
+++ b/lib/surface.ex
@@ -106,7 +106,6 @@ defmodule Surface do
   defmacro sigil_H({:<<>>, meta, [string]}, opts) do
     line = __CALLER__.line + compute_line_offset(meta)
     indentation = meta[:indentation] || 0
-    # TODO: is there a way to actually grab the column from the caller/compiler meta?
     column = meta[:column] || 1
 
     caller_is_surface_component =

--- a/lib/surface.ex
+++ b/lib/surface.ex
@@ -105,9 +105,9 @@ defmodule Surface do
   """
   defmacro sigil_H({:<<>>, meta, [string]}, opts) do
     line = __CALLER__.line + compute_line_offset(meta)
-    # TODO: column or indentation here?
-    # i couldn't really figure out how to find the column for non heredoc usage
-    column = meta[:indentation] || 1
+    indentation = meta[:indentation] || 0
+    # TODO: is there a way to actually grab the column from the caller/compiler meta?
+    column = meta[:column] || 1
 
     caller_is_surface_component =
       Module.open?(__CALLER__.module) &&
@@ -116,6 +116,7 @@ defmodule Surface do
     string
     |> Surface.Compiler.compile(line, __CALLER__, __CALLER__.file,
       checks: [no_undefined_assigns: caller_is_surface_component],
+      indentation: indentation,
       column: column
     )
     |> Surface.Compiler.to_live_struct(

--- a/lib/surface/ast.ex
+++ b/lib/surface/ast.ex
@@ -65,11 +65,12 @@ defmodule Surface.AST.Meta do
       * `:file` - the file from which the source was extracted
       * `:caller` - a Macro.Env struct representing the caller
   """
-  @derive {Inspect, only: [:line, :module, :node_alias, :file, :checks]}
-  defstruct [:line, :module, :node_alias, :file, :caller, :checks]
+  @derive {Inspect, only: [:line, :column, :module, :node_alias, :file, :checks]}
+  defstruct [:line, :column, :module, :node_alias, :file, :caller, :checks]
 
   @type t :: %__MODULE__{
           line: non_neg_integer(),
+          column: non_neg_integer(),
           module: atom(),
           node_alias: binary() | nil,
           caller: Macro.Env.t(),

--- a/lib/surface/ast.ex
+++ b/lib/surface/ast.ex
@@ -63,15 +63,13 @@ defmodule Surface.AST.Meta do
       * `:module` - the component module (e.g. `Surface.Components.LivePatch`)
       * `:node_alias` - the alias used inside the source code (e.g. `LivePatch`)
       * `:file` - the file from which the source was extracted
-      * `:line_offset` - the line offset from the caller's line to the start of this source
       * `:caller` - a Macro.Env struct representing the caller
   """
   @derive {Inspect, only: [:line, :module, :node_alias, :file, :checks]}
-  defstruct [:line, :module, :node_alias, :line_offset, :file, :caller, :checks]
+  defstruct [:line, :module, :node_alias, :file, :caller, :checks]
 
   @type t :: %__MODULE__{
           line: non_neg_integer(),
-          line_offset: non_neg_integer(),
           module: atom(),
           node_alias: binary() | nil,
           caller: Macro.Env.t(),

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -6,6 +6,7 @@ defmodule Surface.Compiler do
   """
 
   alias Surface.Compiler.Parser
+  alias Surface.Compiler.ParseError
   alias Surface.IOHelper
   alias Surface.AST
   alias Surface.Compiler.Helpers
@@ -68,15 +69,6 @@ defmodule Surface.Compiler do
     "wbr"
   ]
 
-  defmodule ParseError do
-    defexception file: "", line: 0, message: "error parsing HTML/Surface"
-
-    @impl true
-    def message(exception) do
-      "#{Path.relative_to_cwd(exception.file)}:#{exception.line}: #{exception.message}"
-    end
-  end
-
   defmodule CompileMeta do
     defstruct [:line, :file, :caller, :checks]
 
@@ -111,6 +103,9 @@ defmodule Surface.Compiler do
     |> case do
       {:ok, nodes} ->
         nodes
+
+      {:error, error} ->
+        raise error
 
       {:error, message, line} ->
         raise %ParseError{line: line, file: file, message: message}

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -98,7 +98,7 @@ defmodule Surface.Compiler do
     }
 
     string
-    |> Parser.parse!(file: file, line: line)
+    |> Parser.parse!(file: file, line: line, column: opts[:column] || 1)
     |> to_ast(compile_meta)
     |> validate_component_structure(compile_meta, caller.module)
   end

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -98,7 +98,12 @@ defmodule Surface.Compiler do
     }
 
     string
-    |> Parser.parse!(file: file, line: line, column: opts[:column] || 1)
+    |> Parser.parse!(
+      file: file,
+      line: line,
+      column: Keyword.get(opts, :column, 1),
+      indentation: Keyword.get(opts, :indentation, 0)
+    )
     |> to_ast(compile_meta)
     |> validate_component_structure(compile_meta, caller.module)
   end

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -78,10 +78,10 @@ defmodule Surface.Compiler do
   end
 
   defmodule CompileMeta do
-    defstruct [:line_offset, :file, :caller, :checks]
+    defstruct [:line, :file, :caller, :checks]
 
     @type t :: %__MODULE__{
-            line_offset: non_neg_integer(),
+            line: non_neg_integer(),
             file: binary(),
             caller: Macro.Env.t(),
             checks: Keyword.t(boolean())
@@ -91,29 +91,29 @@ defmodule Surface.Compiler do
   @doc """
   This function compiles a string into the Surface AST.This is used by ~H and Surface.Renderer to parse and compile templates.
 
-  A special note for line_offset: This is considered the line number for the first line in the string. If the first line of the
+  A special note for line: This is considered the line number for the first line in the string. If the first line of the
   string is also the first line of the file, then this should be 1. If this is being called within a macro (say to process a heredoc
   passed to ~H), this should be __CALLER__.line + 1.
   """
   @spec compile(binary, non_neg_integer(), Macro.Env.t(), binary(), Keyword.t()) :: [
           Surface.AST.t()
         ]
-  def compile(string, line_offset, caller, file \\ "nofile", opts \\ []) do
+  def compile(string, line, caller, file \\ "nofile", opts \\ []) do
     compile_meta = %CompileMeta{
-      line_offset: line_offset,
+      line: line,
       file: file,
       caller: caller,
       checks: opts[:checks] || []
     }
 
     string
-    |> Parser.parse(file: file)
+    |> Parser.parse(file: file, line: line)
     |> case do
       {:ok, nodes} ->
         nodes
 
       {:error, message, line} ->
-        raise %ParseError{line: line + line_offset - 1, file: file, message: message}
+        raise %ParseError{line: line, file: file, message: message}
     end
     |> to_ast(compile_meta)
     |> validate_component_structure(compile_meta, caller.module)
@@ -140,10 +140,10 @@ defmodule Surface.Compiler do
     end
   end
 
-  defp validate_stateful_component(ast, %CompileMeta{
-         line_offset: offset,
-         caller: %{function: {:render, _}} = caller
-       }) do
+  defp validate_stateful_component(
+         ast,
+         %CompileMeta{caller: %{function: {:render, _}}} = compile_meta
+       ) do
     num_tags =
       ast
       |> Enum.filter(fn
@@ -154,7 +154,7 @@ defmodule Surface.Compiler do
           true
 
         %AST.Component{type: Surface.LiveComponent, meta: meta} ->
-          warn_live_component_as_root_node_of_another_live_component(meta, caller, offset)
+          warn_live_component_as_root_node_of_another_live_component(meta, compile_meta.caller)
 
           true
 
@@ -170,15 +170,15 @@ defmodule Surface.Compiler do
       num_tags == 0 ->
         IOHelper.warn(
           "stateful live components must have a HTML root element",
-          caller,
-          fn _ -> offset end
+          compile_meta.caller,
+          fn _ -> compile_meta.line end
         )
 
       num_tags > 1 ->
         IOHelper.warn(
           "stateful live components must have a single HTML root element",
-          caller,
-          fn _ -> offset end
+          compile_meta.caller,
+          fn _ -> compile_meta.line end
         )
 
       true ->
@@ -188,7 +188,7 @@ defmodule Surface.Compiler do
 
   defp validate_stateful_component(_ast, %CompileMeta{}), do: nil
 
-  defp warn_live_component_as_root_node_of_another_live_component(meta, caller, offset) do
+  defp warn_live_component_as_root_node_of_another_live_component(meta, caller) do
     IOHelper.warn(
       """
       cannot have a LiveComponent as root node of another LiveComponent.
@@ -206,7 +206,7 @@ defmodule Surface.Compiler do
         end
       """,
       caller,
-      fn _ -> offset end
+      fn _ -> meta.line end
     )
   end
 
@@ -981,7 +981,7 @@ defmodule Surface.Compiler do
       Hint: replace `<slot>` with `<#slot>`
       """
 
-      IOHelper.warn(message, compile_meta.caller, &(&1 + line))
+      IOHelper.warn(message, compile_meta.caller, fn _ -> line end)
     end
   end
 end

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -6,7 +6,6 @@ defmodule Surface.Compiler do
   """
 
   alias Surface.Compiler.Parser
-  alias Surface.Compiler.ParseError
   alias Surface.IOHelper
   alias Surface.AST
   alias Surface.Compiler.Helpers
@@ -99,17 +98,7 @@ defmodule Surface.Compiler do
     }
 
     string
-    |> Parser.parse(file: file, line: line)
-    |> case do
-      {:ok, nodes} ->
-        nodes
-
-      {:error, error} ->
-        raise error
-
-      {:error, message, line} ->
-        raise %ParseError{line: line, file: file, message: message}
-    end
+    |> Parser.parse!(file: file, line: line)
     |> to_ast(compile_meta)
     |> validate_component_structure(compile_meta, caller.module)
   end

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -107,7 +107,7 @@ defmodule Surface.Compiler do
     }
 
     string
-    |> Parser.parse()
+    |> Parser.parse(file: file)
     |> case do
       {:ok, nodes} ->
         nodes

--- a/lib/surface/compiler/converter.ex
+++ b/lib/surface/compiler/converter.ex
@@ -11,7 +11,7 @@ defmodule Surface.Compiler.Converter do
   def convert(text, opts) do
     metas =
       text
-      |> Tokenizer.tokenize()
+      |> Tokenizer.tokenize!()
       |> extract_meta([])
 
     state = %{tag_name: nil}

--- a/lib/surface/compiler/helpers.ex
+++ b/lib/surface/compiler/helpers.ex
@@ -98,10 +98,7 @@ defmodule Surface.Compiler.Helpers do
     assigns
   end
 
-  def to_meta(tree_meta, %CompileMeta{
-        caller: caller,
-        checks: checks
-      }) do
+  def to_meta(tree_meta, %CompileMeta{caller: caller, checks: checks}) do
     %AST.Meta{
       line: tree_meta.line,
       column: tree_meta.column,

--- a/lib/surface/compiler/helpers.ex
+++ b/lib/surface/compiler/helpers.ex
@@ -98,23 +98,18 @@ defmodule Surface.Compiler.Helpers do
     assigns
   end
 
-  def to_meta(%{line: line} = tree_meta, %CompileMeta{
-        file: file,
+  def to_meta(tree_meta, %CompileMeta{
         caller: caller,
         checks: checks
       }) do
     AST.Meta
     |> Kernel.struct(tree_meta)
-    |> Map.put(:line, line)
-    |> Map.put(:file, file)
     |> Map.put(:caller, caller)
     |> Map.put(:checks, checks)
   end
 
-  def to_meta(%{line: line} = tree_meta, %AST.Meta{} = parent_meta) do
-    parent_meta
-    |> Map.merge(tree_meta)
-    |> Map.put(:line, line)
+  def to_meta(tree_meta, %AST.Meta{} = parent_meta) do
+    Map.merge(parent_meta, tree_meta)
   end
 
   def did_you_mean(target, list) do

--- a/lib/surface/compiler/helpers.ex
+++ b/lib/surface/compiler/helpers.ex
@@ -102,14 +102,17 @@ defmodule Surface.Compiler.Helpers do
         caller: caller,
         checks: checks
       }) do
-    AST.Meta
-    |> Kernel.struct(tree_meta)
-    |> Map.put(:caller, caller)
-    |> Map.put(:checks, checks)
+    %AST.Meta{
+      line: tree_meta.line,
+      column: tree_meta.column,
+      file: tree_meta.file,
+      caller: caller,
+      checks: checks
+    }
   end
 
   def to_meta(tree_meta, %AST.Meta{} = parent_meta) do
-    Map.merge(parent_meta, tree_meta)
+    %{parent_meta | line: tree_meta.line, column: tree_meta.column}
   end
 
   def did_you_mean(target, list) do

--- a/lib/surface/compiler/helpers.ex
+++ b/lib/surface/compiler/helpers.ex
@@ -99,26 +99,22 @@ defmodule Surface.Compiler.Helpers do
   end
 
   def to_meta(%{line: line} = tree_meta, %CompileMeta{
-        line_offset: offset,
         file: file,
         caller: caller,
         checks: checks
       }) do
     AST.Meta
     |> Kernel.struct(tree_meta)
-    # The rational here is that offset is the offset from the start of the file to the first line in the
-    # surface expression.
-    |> Map.put(:line, line + offset - 1)
-    |> Map.put(:line_offset, offset)
+    |> Map.put(:line, line)
     |> Map.put(:file, file)
     |> Map.put(:caller, caller)
     |> Map.put(:checks, checks)
   end
 
-  def to_meta(%{line: line} = tree_meta, %AST.Meta{line_offset: offset} = parent_meta) do
+  def to_meta(%{line: line} = tree_meta, %AST.Meta{} = parent_meta) do
     parent_meta
     |> Map.merge(tree_meta)
-    |> Map.put(:line, line + offset - 1)
+    |> Map.put(:line, line)
   end
 
   def did_you_mean(target, list) do

--- a/lib/surface/compiler/parse_error.ex
+++ b/lib/surface/compiler/parse_error.ex
@@ -1,5 +1,5 @@
 defmodule Surface.Compiler.ParseError do
-  defexception file: "nofile", line: 0, column: 1, message: "error parsing HTML/Surface"
+  defexception [:file, :line, :column, :message]
 
   @impl true
   def message(exception) do

--- a/lib/surface/compiler/parse_error.ex
+++ b/lib/surface/compiler/parse_error.ex
@@ -1,0 +1,13 @@
+defmodule Surface.Compiler.ParseError do
+  defexception file: "nofile", line: 0, column: 1, message: "error parsing HTML/Surface"
+
+  @impl true
+  def message(exception) do
+    location =
+      exception.file
+      |> Path.relative_to_cwd()
+      |> Exception.format_file_line_column(exception.line, exception.column)
+
+    "#{location} #{exception.message}"
+  end
+end

--- a/lib/surface/compiler/parser.ex
+++ b/lib/surface/compiler/parser.ex
@@ -275,14 +275,13 @@ defmodule Surface.Compiler.Parser do
     {:ok, {tag, %{state | tags: tags}}}
   end
 
-  defp pop_matching_tag(%{tags: [{:tag_open, tag_name, _attrs, meta} | _]}, _closed_node_name) do
-    # TODO: change message to "expected closing tag for <bar> defined at line 4, got </foo>"
+  defp pop_matching_tag(%{tags: [{:tag_open, tag_name, _attrs, meta} | _]}, closed_node_name) do
     {:error,
      %ParseError{
        line: meta.line,
        column: meta.column,
        file: meta.file,
-       message: "expected closing tag for <#{tag_name}>"
+       message: "expected closing tag for <#{tag_name}> defined on line #{meta.line}, got </#{closed_node_name}>"
      }}
   end
 end

--- a/lib/surface/compiler/parser.ex
+++ b/lib/surface/compiler/parser.ex
@@ -2,7 +2,7 @@ defmodule Surface.Compiler.Parser do
   @moduledoc false
 
   alias Surface.Compiler.Tokenizer
-  alias Surface.Compiler.Tokenizer.ParseError
+  alias Surface.Compiler.ParseError
   alias Surface.Compiler.Helpers
 
   @void_elements [
@@ -37,9 +37,6 @@ defmodule Surface.Compiler.Parser do
     with tokens when is_list(tokens) <- Tokenizer.tokenize(code, opts),
          ast when is_list(ast) <- handle_token(tokens) do
       {:ok, ast}
-    else
-      {:error, %ParseError{line: line, message: message}} ->
-        {:error, message, line}
     end
   end
 
@@ -52,12 +49,13 @@ defmodule Surface.Compiler.Parser do
   end
 
   defp handle_token([], _buffers, %{tags: [{:tag_open, tag_name, _attrs, meta} | _]}) do
+    #TODO: EOF, or something better to indicate end of input?
     {:error,
      %ParseError{
        line: meta.line,
        column: meta.column,
        file: meta.file,
-       message: "expected closing tag for <#{tag_name}>"
+       message: "expected closing tag for <#{tag_name}> defined on line #{meta.line}, got EOF"
      }}
   end
 

--- a/lib/surface/compiler/parser.ex
+++ b/lib/surface/compiler/parser.ex
@@ -33,8 +33,8 @@ defmodule Surface.Compiler.Parser do
     "#match" => ["#case"]
   }
 
-  def parse(code) do
-    with tokens when is_list(tokens) <- Tokenizer.tokenize(code),
+  def parse(code, opts \\ []) do
+    with tokens when is_list(tokens) <- Tokenizer.tokenize(code, opts),
          ast when is_list(ast) <- handle_token(tokens) do
       {:ok, ast}
     else

--- a/lib/surface/compiler/parser.ex
+++ b/lib/surface/compiler/parser.ex
@@ -33,6 +33,13 @@ defmodule Surface.Compiler.Parser do
     "#match" => ["#case"]
   }
 
+  def parse!(code, opts \\ []) do
+    case parse(code, opts) do
+      {:ok, nodes} -> nodes
+      {:error, error} -> raise error
+    end
+  end
+
   def parse(code, opts \\ []) do
     with tokens when is_list(tokens) <- Tokenizer.tokenize(code, opts),
          ast when is_list(ast) <- handle_token(tokens) do
@@ -49,7 +56,7 @@ defmodule Surface.Compiler.Parser do
   end
 
   defp handle_token([], _buffers, %{tags: [{:tag_open, tag_name, _attrs, meta} | _]}) do
-    #TODO: EOF, or something better to indicate end of input?
+    # TODO: EOF, or something better to indicate end of input?
     {:error,
      %ParseError{
        line: meta.line,

--- a/lib/surface/compiler/parser.ex
+++ b/lib/surface/compiler/parser.ex
@@ -281,7 +281,10 @@ defmodule Surface.Compiler.Parser do
        line: meta.line,
        column: meta.column,
        file: meta.file,
-       message: "expected closing tag for <#{tag_name}> defined on line #{meta.line}, got </#{closed_node_name}>"
+       message:
+         "expected closing tag for <#{tag_name}> defined on line #{meta.line}, got </#{
+           closed_node_name
+         }>"
      }}
   end
 end

--- a/lib/surface/compiler/tokenizer.ex
+++ b/lib/surface/compiler/tokenizer.ex
@@ -5,19 +5,7 @@ defmodule Surface.Compiler.Tokenizer do
   @unquoted_value_invalid_chars '"\'=<`'
   @unquoted_value_stop_chars @space_chars ++ '>'
 
-  defmodule ParseError do
-    defexception [:file, :line, :column, :message]
-
-    @impl true
-    def message(exception) do
-      location =
-        exception.file
-        |> Path.relative_to_cwd()
-        |> Exception.format_file_line_column(exception.line, exception.column)
-
-      "#{location} #{exception.message}"
-    end
-  end
+  alias Surface.Compiler.ParseError
 
   def tokenize!(text, opts \\ []) do
     case tokenize(text, opts) do

--- a/lib/surface/compiler/tokenizer.ex
+++ b/lib/surface/compiler/tokenizer.ex
@@ -9,8 +9,16 @@ defmodule Surface.Compiler.Tokenizer do
 
   def tokenize!(text, opts \\ []) do
     case tokenize(text, opts) do
-      nodes when is_list(nodes) -> nodes
-      {:error, error} -> raise error
+      nodes when is_list(nodes) ->
+        nodes
+
+      {:error, message, meta} ->
+        raise %ParseError{
+          file: meta.file,
+          line: meta.line,
+          column: meta.column,
+          message: message
+        }
     end
   end
 
@@ -27,7 +35,7 @@ defmodule Surface.Compiler.Tokenizer do
         nodes
 
       {:error, message, line, column} ->
-        {:error, %ParseError{file: file, line: line, column: column, message: message}}
+        {:error, message, %{file: file, line: line, column: column}}
     end
   end
 

--- a/lib/surface/compiler/tokenizer.ex
+++ b/lib/surface/compiler/tokenizer.ex
@@ -265,13 +265,7 @@ defmodule Surface.Compiler.Tokenizer do
   defp handle_attribute(text, line, column, acc, state) do
     {name, new_column, rest} = handle_attr_name(text, line, column, [], state)
 
-    meta = %{
-      line: line,
-      column: column,
-      line_end: line,
-      column_end: new_column,
-      file: state.file
-    }
+    meta = %{line: line, column: column, line_end: line, column_end: new_column, file: state.file}
 
     acc = put_attr(acc, name, nil, meta)
     handle_maybe_attr_value(rest, line, new_column, acc, state)

--- a/test/compiler/tokenizer_test.exs
+++ b/test/compiler/tokenizer_test.exs
@@ -2,7 +2,7 @@ defmodule Surface.Compiler.TokenizerTest do
   use ExUnit.Case, async: true
 
   import Surface.Compiler.Tokenizer
-  alias Surface.Compiler.Tokenizer.ParseError
+  alias Surface.Compiler.ParseError
 
   describe "text" do
     test "represented as {:text, value}" do

--- a/test/compiler/tokenizer_test.exs
+++ b/test/compiler/tokenizer_test.exs
@@ -6,12 +6,12 @@ defmodule Surface.Compiler.TokenizerTest do
 
   describe "text" do
     test "represented as {:text, value}" do
-      assert tokenize("Hello") == [{:text, "Hello"}]
+      assert tokenize!("Hello") == [{:text, "Hello"}]
     end
 
     test "with multiple lines" do
       tokens =
-        tokenize("""
+        tokenize!("""
         first
         second
         third
@@ -21,13 +21,13 @@ defmodule Surface.Compiler.TokenizerTest do
     end
 
     test "keep line breaks unchanged" do
-      assert tokenize("first\nsecond\r\nthird") == [{:text, "first\nsecond\r\nthird"}]
+      assert tokenize!("first\nsecond\r\nthird") == [{:text, "first\nsecond\r\nthird"}]
     end
   end
 
   describe "comment" do
     test "represented as {:comment, comment}" do
-      assert tokenize("Begin<!-- comment -->End") ==
+      assert tokenize!("Begin<!-- comment -->End") ==
                [{:text, "Begin"}, {:comment, "<!-- comment -->"}, {:text, "End"}]
     end
 
@@ -47,12 +47,12 @@ defmodule Surface.Compiler.TokenizerTest do
                {:text, "\n"},
                {:tag_close, "p", %{line: 5, column: 3}},
                {:tag_open, "br", [], %{line: 5, column: 6}}
-             ] = tokenize(code)
+             ] = tokenize!(code)
     end
 
     test "raise on incomplete comment (EOF)" do
       assert_raise ParseError, "nofile:3:7: expected closing `-->` for comment", fn ->
-        tokenize("""
+        tokenize!("""
         <div>
         <!-- a comment)
         </div>\
@@ -63,23 +63,24 @@ defmodule Surface.Compiler.TokenizerTest do
 
   describe "interpolation in body" do
     test "represented as {:interpolation, value, meta}" do
-      assert tokenize("""
+      assert tokenize!("""
              before
              ={1} after\
              """) == [
                {:text, "before\n="},
-               {:interpolation, "1", %{column: 3, line: 2, column_end: 4, line_end: 2}},
+               {:interpolation, "1",
+                %{column: 3, line: 2, column_end: 4, line_end: 2, file: "nofile"}},
                {:text, " after"}
              ]
     end
 
     test "value containing curly braces" do
-      tokens = tokenize("before{func({1, 3})}after")
+      tokens = tokenize!("before{func({1, 3})}after")
 
       assert tokens == [
                {:text, "before"},
                {:interpolation, "func({1, 3})",
-                %{column: 8, line: 1, column_end: 20, line_end: 1}},
+                %{column: 8, line: 1, column_end: 20, line_end: 1, file: "nofile"}},
                {:text, "after"}
              ]
     end
@@ -87,28 +88,28 @@ defmodule Surface.Compiler.TokenizerTest do
 
   describe "opening tag" do
     test "represented as {:tag_open, name, attrs, meta}" do
-      tokens = tokenize("<div>")
+      tokens = tokenize!("<div>")
       assert [{:tag_open, "div", [], %{}}] = tokens
     end
 
     test "with space after name" do
-      tokens = tokenize("<div >")
+      tokens = tokenize!("<div >")
       assert [{:tag_open, "div", [], %{}}] = tokens
     end
 
     test "with line break after name" do
-      tokens = tokenize("<div\n>")
+      tokens = tokenize!("<div\n>")
       assert [{:tag_open, "div", [], %{}}] = tokens
     end
 
     test "self close" do
-      tokens = tokenize("<div/>")
+      tokens = tokenize!("<div/>")
       assert [{:tag_open, "div", [], %{self_close: true}}] = tokens
     end
 
     test "compute line and column" do
       tokens =
-        tokenize("""
+        tokenize!("""
         <div>
           <span>
 
@@ -126,7 +127,7 @@ defmodule Surface.Compiler.TokenizerTest do
 
     test "compute line and column with multiple tags on the same line" do
       tokens =
-        tokenize("""
+        tokenize!("""
         <div>
           <span/> <span/>
 
@@ -146,14 +147,14 @@ defmodule Surface.Compiler.TokenizerTest do
 
     test "raise on missing tag name" do
       assert_raise ParseError, "nofile:2:4: expected tag name", fn ->
-        tokenize("""
+        tokenize!("""
         <div>
           <>\
         """)
       end
 
       assert_raise ParseError, "nofile:2:5: expected tag name", fn ->
-        tokenize("""
+        tokenize!("""
         <div>
           </>\
         """)
@@ -226,7 +227,7 @@ defmodule Surface.Compiler.TokenizerTest do
       message = "nofile:2:9: expected attribute value or expression after `=`"
 
       assert_raise ParseError, message, fn ->
-        tokenize("""
+        tokenize!("""
         <div
           class=>\
         """)
@@ -235,30 +236,30 @@ defmodule Surface.Compiler.TokenizerTest do
       message = "nofile:1:13: expected attribute value or expression after `=`"
 
       assert_raise ParseError, message, fn ->
-        tokenize(~S(<div class= >))
+        tokenize!(~S(<div class= >))
       end
 
       message = "nofile:1:12: expected attribute value or expression after `=`"
 
       assert_raise ParseError, message, fn ->
-        tokenize("<div class=")
+        tokenize!("<div class=")
       end
     end
 
     test "raise on missing attribure name" do
       assert_raise ParseError, "nofile:2:8: expected attribute name", fn ->
-        tokenize("""
+        tokenize!("""
         <div>
           <div ="panel">\
         """)
       end
 
       assert_raise ParseError, "nofile:1:6: expected attribute name", fn ->
-        tokenize(~S(<div = >))
+        tokenize!(~S(<div = >))
       end
 
       assert_raise ParseError, "nofile:1:6: expected attribute name", fn ->
-        tokenize(~S(<div / >))
+        tokenize!(~S(<div / >))
       end
     end
   end
@@ -319,7 +320,7 @@ defmodule Surface.Compiler.TokenizerTest do
 
     test "value containing line breaks" do
       tokens =
-        tokenize("""
+        tokenize!("""
         <div title="first
           second
         third"><span>\
@@ -334,7 +335,7 @@ defmodule Surface.Compiler.TokenizerTest do
 
     test "raise on incomplete attribute value (EOF)" do
       assert_raise ParseError, "nofile:2:15: expected closing `\"` for attribute value", fn ->
-        tokenize("""
+        tokenize!("""
         <div
           class="panel\
         """)
@@ -366,7 +367,7 @@ defmodule Surface.Compiler.TokenizerTest do
 
     test "value containing line breaks" do
       tokens =
-        tokenize("""
+        tokenize!("""
         <div title='first
           second
         third'><span>\
@@ -381,7 +382,7 @@ defmodule Surface.Compiler.TokenizerTest do
 
     test "raise on incomplete attribute value (EOF)" do
       assert_raise ParseError, "nofile:2:15: expected closing `\'` for attribute value", fn ->
-        tokenize("""
+        tokenize!("""
         <div
           class='panel\
         """)
@@ -472,7 +473,7 @@ defmodule Surface.Compiler.TokenizerTest do
 
     test "raise on incomplete attribute expression (EOF)" do
       assert_raise ParseError, "nofile:2:15: expected closing `}` for expression", fn ->
-        tokenize("""
+        tokenize!("""
         <div
           class={panel\
         """)
@@ -543,7 +544,7 @@ defmodule Surface.Compiler.TokenizerTest do
 
     test "raise on incomplete expression (EOF)" do
       assert_raise ParseError, "nofile:2:10: expected closing `}` for expression", fn ->
-        tokenize("""
+        tokenize!("""
         <div
           {@attrs\
         """)
@@ -553,13 +554,13 @@ defmodule Surface.Compiler.TokenizerTest do
 
   describe "closing tag" do
     test "represented as {:tag_close, name, meta}" do
-      tokens = tokenize("</div>")
+      tokens = tokenize!("</div>")
       assert [{:tag_close, "div", %{column: 3, line: 1}}] = tokens
     end
 
     test "compute line and columns" do
       tokens =
-        tokenize("""
+        tokenize!("""
         <div>
         </div><br>\
         """)
@@ -574,7 +575,7 @@ defmodule Surface.Compiler.TokenizerTest do
 
     test "raise on missing closing `>`" do
       assert_raise ParseError, "nofile:2:6: expected closing `>`", fn ->
-        tokenize("""
+        tokenize!("""
         <div>
         </div text\
         """)
@@ -584,7 +585,7 @@ defmodule Surface.Compiler.TokenizerTest do
 
   test "mixing text and tags" do
     tokens =
-      tokenize("""
+      tokenize!("""
       text before
       <div>
         text
@@ -602,7 +603,7 @@ defmodule Surface.Compiler.TokenizerTest do
   end
 
   defp tokenize_attrs(code) do
-    [{:tag_open, "div", attrs, %{}}] = tokenize(code)
+    [{:tag_open, "div", attrs, %{}}] = tokenize!(code)
     attrs
   end
 end

--- a/test/constructs/for_test.exs
+++ b/test/constructs/for_test.exs
@@ -43,7 +43,7 @@ defmodule Surface.Constructs.ForTest do
         """
       end
 
-    message = ~S(code:2: expected closing tag for <span>)
+    message = ~S(code:2: expected closing tag for <span> defined on line 2, got </For>)
 
     assert_raise(Surface.Compiler.ParseError, message, fn ->
       compile_surface(code)

--- a/test/constructs/for_test.exs
+++ b/test/constructs/for_test.exs
@@ -43,7 +43,7 @@ defmodule Surface.Constructs.ForTest do
         """
       end
 
-    message = ~S(code:2: expected closing tag for <span> defined on line 2, got </For>)
+    message = ~S(code:2:4: expected closing tag for <span> defined on line 2, got </For>)
 
     assert_raise(Surface.Compiler.ParseError, message, fn ->
       compile_surface(code)

--- a/test/constructs/for_test.exs
+++ b/test/constructs/for_test.exs
@@ -43,7 +43,7 @@ defmodule Surface.Constructs.ForTest do
         """
       end
 
-    message = ~S(code:2:4: expected closing tag for <span> defined on line 2, got </For>)
+    message = ~S(code:2:12: expected closing tag for <span> defined on line 2, got </For>)
 
     assert_raise(Surface.Compiler.ParseError, message, fn ->
       compile_surface(code)

--- a/test/constructs/if_test.exs
+++ b/test/constructs/if_test.exs
@@ -43,7 +43,7 @@ defmodule Surface.Constructs.IfTest do
         """
       end
 
-    message = ~S(code:2: expected closing tag for <span> defined on line 2, got </If>)
+    message = ~S(code:2:4: expected closing tag for <span> defined on line 2, got </If>)
 
     assert_raise(Surface.Compiler.ParseError, message, fn ->
       compile_surface(code)

--- a/test/constructs/if_test.exs
+++ b/test/constructs/if_test.exs
@@ -43,7 +43,7 @@ defmodule Surface.Constructs.IfTest do
         """
       end
 
-    message = ~S(code:2: expected closing tag for <span>)
+    message = ~S(code:2: expected closing tag for <span> defined on line 2, got </If>)
 
     assert_raise(Surface.Compiler.ParseError, message, fn ->
       compile_surface(code)

--- a/test/constructs/if_test.exs
+++ b/test/constructs/if_test.exs
@@ -43,7 +43,7 @@ defmodule Surface.Constructs.IfTest do
         """
       end
 
-    message = ~S(code:2:4: expected closing tag for <span> defined on line 2, got </If>)
+    message = ~S(code:2:12: expected closing tag for <span> defined on line 2, got </If>)
 
     assert_raise(Surface.Compiler.ParseError, message, fn ->
       compile_surface(code)

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -2,37 +2,34 @@ defmodule Surface.Compiler.ParserTest do
   use ExUnit.Case, async: true
 
   import Surface.Compiler.Parser
-
   alias Surface.Compiler.ParseError
 
   test "empty node" do
-    assert parse("") == {:ok, []}
+    assert parse!("") == []
   end
 
   test "only text" do
-    assert parse("Some text") == {:ok, ["Some text"]}
+    assert parse!("Some text") == ["Some text"]
   end
 
   test "keep spaces before node" do
-    assert parse("\n<div></div>") ==
-             {:ok,
-              [
-                "\n",
-                {"div", [], [], %{line: 2, file: "nofile", column: 2}}
-              ]}
+    assert parse!("\n<div></div>") ==
+             [
+               "\n",
+               {"div", [], [], %{line: 2, file: "nofile", column: 2}}
+             ]
   end
 
   test "keep spaces after node" do
-    assert parse("<div></div>\n") ==
-             {:ok,
-              [
-                {"div", [], [], %{line: 1, file: "nofile", column: 2}},
-                "\n"
-              ]}
+    assert parse!("<div></div>\n") ==
+             [
+               {"div", [], [], %{line: 1, file: "nofile", column: 2}},
+               "\n"
+             ]
   end
 
   test "keep blank chars" do
-    assert parse("\n\r\t\v\b\f\e\d\a") == {:ok, ["\n\r\t\v\b\f\e\d\a"]}
+    assert parse!("\n\r\t\v\b\f\e\d\a") == ["\n\r\t\v\b\f\e\d\a"]
   end
 
   test "multiple nodes" do
@@ -45,25 +42,23 @@ defmodule Surface.Compiler.ParserTest do
     </div>
     """
 
-    assert parse(code) ==
-             {:ok,
-              [
-                {"div", [], ["\n  Div 1\n"], %{line: 1, file: "nofile", column: 2}},
-                "\n",
-                {"div", [], ["\n  Div 2\n"], %{line: 4, file: "nofile", column: 2}},
-                "\n"
-              ]}
+    assert parse!(code) ==
+             [
+               {"div", [], ["\n  Div 1\n"], %{line: 1, file: "nofile", column: 2}},
+               "\n",
+               {"div", [], ["\n  Div 2\n"], %{line: 4, file: "nofile", column: 2}},
+               "\n"
+             ]
   end
 
   test "text before and after" do
-    assert parse("hello<foo>bar</foo>world") ==
-             {:ok,
-              ["hello", {"foo", [], ["bar"], %{line: 1, file: "nofile", column: 7}}, "world"]}
+    assert parse!("hello<foo>bar</foo>world") ==
+             ["hello", {"foo", [], ["bar"], %{line: 1, file: "nofile", column: 7}}, "world"]
   end
 
   test "component" do
     code = ~S(<MyComponent label="My label"/>)
-    {:ok, [node]} = parse(code)
+    [node] = parse!(code)
 
     assert node ==
              {"MyComponent",
@@ -74,7 +69,7 @@ defmodule Surface.Compiler.ParserTest do
 
   test "slot shorthand" do
     code = ~S(<:footer :let={ a: 1 }/>)
-    {:ok, [node]} = parse(code)
+    [node] = parse!(code)
 
     assert {":footer", [{":let", _, _}], [], _} = node
   end
@@ -87,7 +82,7 @@ defmodule Surface.Compiler.ParserTest do
     </div>
     """
 
-    {:ok, tree} = parse(code)
+    tree = parse!(code)
 
     assert tree == [
              {
@@ -119,7 +114,7 @@ defmodule Surface.Compiler.ParserTest do
     </div>
     """
 
-    {:ok, [{"div", _, [_, {:comment, comment}, _, {"span", _, _, _}, _], _}, _]} = parse(code)
+    [{"div", _, [_, {:comment, comment}, _, {"span", _, _, _}, _], _}, _] = parse!(code)
 
     assert comment == """
            <!--
@@ -137,7 +132,7 @@ defmodule Surface.Compiler.ParserTest do
       </div>
       """
 
-      {:ok, [{"div", [], ["\n  ", node, "\n"], _}, "\n"]} = parse(code)
+      [{"div", [], ["\n  ", node, "\n"], _}, "\n"] = parse!(code)
       assert node == {"hr", [], [], %{line: 2, file: "nofile", column: 4}}
     end
 
@@ -151,7 +146,7 @@ defmodule Surface.Compiler.ParserTest do
       </div>
       """
 
-      {:ok, [{"div", [], ["\n  ", node, "\n"], _}, "\n"]} = parse(code)
+      [{"div", [], ["\n  ", node, "\n"], _}, "\n"] = parse!(code)
 
       assert node ==
                {"img",
@@ -164,193 +159,181 @@ defmodule Surface.Compiler.ParserTest do
 
   describe "HTML only" do
     test "single node" do
-      assert parse("<foo>bar</foo>") ==
-               {:ok, [{"foo", [], ["bar"], %{line: 1, file: "nofile", column: 2}}]}
+      assert parse!("<foo>bar</foo>") ==
+               [{"foo", [], ["bar"], %{line: 1, file: "nofile", column: 2}}]
     end
 
     test "Elixir node" do
-      assert parse("<Foo.Bar>bar</Foo.Bar>") ==
-               {:ok, [{"Foo.Bar", [], ["bar"], %{line: 1, file: "nofile", column: 2}}]}
+      assert parse!("<Foo.Bar>bar</Foo.Bar>") ==
+               [{"Foo.Bar", [], ["bar"], %{line: 1, file: "nofile", column: 2}}]
     end
 
     test "mixed nodes" do
-      assert parse("<foo>one<bar>two</bar>three</foo>") ==
-               {:ok,
-                [
-                  {"foo", [],
-                   ["one", {"bar", [], ["two"], %{line: 1, file: "nofile", column: 10}}, "three"],
-                   %{line: 1, file: "nofile", column: 2}}
-                ]}
+      assert parse!("<foo>one<bar>two</bar>three</foo>") ==
+               [
+                 {"foo", [],
+                  ["one", {"bar", [], ["two"], %{line: 1, file: "nofile", column: 10}}, "three"],
+                  %{line: 1, file: "nofile", column: 2}}
+               ]
     end
 
     test "self-closing nodes" do
-      assert parse("<foo>one<bar><bat/></bar>three</foo>") ==
-               {:ok,
-                [
-                  {"foo", [],
-                   [
-                     "one",
-                     {"bar", [], [{"bat", [], [], %{line: 1, file: "nofile", column: 15}}],
-                      %{line: 1, file: "nofile", column: 10}},
-                     "three"
-                   ], %{line: 1, file: "nofile", column: 2}}
-                ]}
+      assert parse!("<foo>one<bar><bat/></bar>three</foo>") ==
+               [
+                 {"foo", [],
+                  [
+                    "one",
+                    {"bar", [], [{"bat", [], [], %{line: 1, file: "nofile", column: 15}}],
+                     %{line: 1, file: "nofile", column: 10}},
+                    "three"
+                  ], %{line: 1, file: "nofile", column: 2}}
+               ]
     end
   end
 
   describe "interpolation" do
     test "as root" do
-      assert parse("{baz}") ==
-               {:ok, [{:interpolation, "baz", %{line: 1, file: "nofile", column: 2}}]}
+      assert parse!("{baz}") ==
+               [{:interpolation, "baz", %{line: 1, file: "nofile", column: 2}}]
     end
 
     test "with curlies embedded" do
-      assert parse("{ {1, 3} }") ==
-               {:ok, [{:interpolation, " {1, 3} ", %{line: 1, file: "nofile", column: 2}}]}
+      assert parse!("{ {1, 3} }") ==
+               [{:interpolation, " {1, 3} ", %{line: 1, file: "nofile", column: 2}}]
     end
 
     test "with deeply nested curlies" do
-      assert parse("{{{{{{{{{{{}}}}}}}}}}}") ==
-               {:ok,
-                [{:interpolation, "{{{{{{{{{{}}}}}}}}}}", %{line: 1, file: "nofile", column: 2}}]}
+      assert parse!("{{{{{{{{{{{}}}}}}}}}}}") ==
+               [{:interpolation, "{{{{{{{{{{}}}}}}}}}}", %{line: 1, file: "nofile", column: 2}}]
     end
 
     test "matched curlies for a map expression" do
-      assert parse("{ %{a: %{b: 1}} }") ==
-               {:ok, [{:interpolation, " %{a: %{b: 1}} ", %{line: 1, file: "nofile", column: 2}}]}
+      assert parse!("{ %{a: %{b: 1}} }") ==
+               [{:interpolation, " %{a: %{b: 1}} ", %{line: 1, file: "nofile", column: 2}}]
     end
 
     test "tuple without spaces between enclosing curlies" do
-      assert parse("{{:a, :b}}") ==
-               {:ok, [{:interpolation, "{:a, :b}", %{line: 1, file: "nofile", column: 2}}]}
+      assert parse!("{{:a, :b}}") ==
+               [{:interpolation, "{:a, :b}", %{line: 1, file: "nofile", column: 2}}]
     end
 
     test "without root node but with text" do
-      assert parse("foo {baz} bar") ==
-               {:ok,
-                ["foo ", {:interpolation, "baz", %{line: 1, file: "nofile", column: 6}}, " bar"]}
+      assert parse!("foo {baz} bar") ==
+               ["foo ", {:interpolation, "baz", %{line: 1, file: "nofile", column: 6}}, " bar"]
     end
 
     test "with root node" do
-      assert parse("<foo>{baz}</foo>") ==
-               {:ok,
-                [
-                  {"foo", '', [{:interpolation, "baz", %{line: 1, file: "nofile", column: 7}}],
-                   %{line: 1, file: "nofile", column: 2}}
-                ]}
+      assert parse!("<foo>{baz}</foo>") ==
+               [
+                 {"foo", '', [{:interpolation, "baz", %{line: 1, file: "nofile", column: 7}}],
+                  %{line: 1, file: "nofile", column: 2}}
+               ]
     end
 
     test "mixed curly bracket" do
-      assert parse("<foo>bar{baz}bat</foo>") ==
-               {:ok,
-                [
-                  {"foo", '',
-                   [
-                     "bar",
-                     {:interpolation, "baz", %{line: 1, file: "nofile", column: 10}},
-                     "bat"
-                   ], %{line: 1, file: "nofile", column: 2}}
-                ]}
+      assert parse!("<foo>bar{baz}bat</foo>") ==
+               [
+                 {"foo", '',
+                  [
+                    "bar",
+                    {:interpolation, "baz", %{line: 1, file: "nofile", column: 10}},
+                    "bat"
+                  ], %{line: 1, file: "nofile", column: 2}}
+               ]
     end
 
     #  test "single-closing curly bracket" do
-    #    assert parse("<foo>bar{ 'a}b' }bat</foo>") ==
-    #             {:ok,
+    #    assert parse!("<foo>bar{ 'a}b' }bat</foo>") ==
+    #
     #              [
     #                {"foo", [], ["bar", {:interpolation, " 'a}b' ", %{line: 1}}, "bat"],
     #                 %{line: 1}}
-    #              ]}
+    #              ]
     #  end
 
     #  test "charlist with closing curly in tuple" do
-    #    assert parse("{{ 'a}}b' }}") ==
-    #             {:ok, [{:interpolation, " 'a}}b' ", %{line: 1}}]}
+    #    assert parse!("{{ 'a}}b' }}") ==
+    #              [{:interpolation, " 'a}}b' ", %{line: 1}}]
     #  end
 
     #   test "binary with closing curly in tuple" do
-    #     assert parse("{{ {{'a}}b'}} }}") ==
-    #              {:ok, [{:interpolation, " {{'a}}b'}} ", %{line: 1}}]}
+    #     assert parse!("{{ {{'a}}b'}} }}") ==
+    #               [{:interpolation, " {{'a}}b'}} ", %{line: 1}}]
     #   end
 
     #   test "double closing curly brace inside charlist" do
-    #     assert parse("{{ {{\"a}}b\"}} }}") ==
-    #              {:ok, [{:interpolation, " {{\"a}}b\"}} ", %{line: 1}}]}
+    #     assert parse!("{{ {{\"a}}b\"}} }}") ==
+    #               [{:interpolation, " {{\"a}}b\"}} ", %{line: 1}}]
     #   end
 
     #   test "double closing curly brace inside binary" do
-    #     assert parse("{{ \"a}}b\" }}") ==
-    #              {:ok, [{:interpolation, " \"a}}b\" ", %{line: 1}}]}
+    #     assert parse!("{{ \"a}}b\" }}") ==
+    #               [{:interpolation, " \"a}}b\" ", %{line: 1}}]
     #   end
 
     #   test "single-opening curly bracket inside single quotes" do
-    #     assert parse("{{ 'a{b' }}") ==
-    #              {:ok, [{:interpolation, " 'a{b' ", %{line: 1}}]}
+    #     assert parse!("{{ 'a{b' }}") ==
+    #               [{:interpolation, " 'a{b' ", %{line: 1}}]
     #   end
 
     #   test "single-opening curly bracket inside double quotes" do
-    #     assert parse("{{ \"a{b\" }}") ==
-    #              {:ok, [{:interpolation, " \"a{b\" ", %{line: 1}}]}
+    #     assert parse!("{{ \"a{b\" }}") ==
+    #               [{:interpolation, " \"a{b\" ", %{line: 1}}]
     #   end
 
     test "containing a charlist with escaped single quote" do
-      assert parse("{ 'a\\'b' }") ==
-               {:ok, [{:interpolation, " 'a\\'b' ", %{line: 1, file: "nofile", column: 2}}]}
+      assert parse!("{ 'a\\'b' }") ==
+               [{:interpolation, " 'a\\'b' ", %{line: 1, file: "nofile", column: 2}}]
     end
 
     test "containing a binary with escaped double quote" do
-      assert parse("{ \"a\\\"b\" }") ==
-               {:ok, [{:interpolation, " \"a\\\"b\" ", %{line: 1, file: "nofile", column: 2}}]}
+      assert parse!("{ \"a\\\"b\" }") ==
+               [{:interpolation, " \"a\\\"b\" ", %{line: 1, file: "nofile", column: 2}}]
     end
 
     test "nested multi-element tuples" do
-      assert parse("""
+      assert parse!("""
              { {a, {b, c}} <- [{"a", {"b", "c"}}]}
              """) ==
-               {:ok,
-                [
-                  {:interpolation, " {a, {b, c}} <- [{\"a\", {\"b\", \"c\"}}]",
-                   %{line: 1, file: "nofile", column: 2}},
-                  "\n"
-                ]}
+               [
+                 {:interpolation, " {a, {b, c}} <- [{\"a\", {\"b\", \"c\"}}]",
+                  %{line: 1, file: "nofile", column: 2}},
+                 "\n"
+               ]
     end
   end
 
   describe "with macros" do
     test "single node" do
-      assert parse("<#Foo>bar</#Foo>") ==
-               {:ok, [{"#Foo", [], ["bar"], %{line: 1, file: "nofile", column: 2}}]}
+      assert parse!("<#Foo>bar</#Foo>") ==
+               [{"#Foo", [], ["bar"], %{line: 1, file: "nofile", column: 2}}]
     end
 
     test "mixed nodes" do
-      assert parse("<#Foo>one<bar>two</baz>three</#Foo>") ==
-               {:ok,
-                [{"#Foo", [], ["one<bar>two</baz>three"], %{line: 1, file: "nofile", column: 2}}]}
+      assert parse!("<#Foo>one<bar>two</baz>three</#Foo>") ==
+               [{"#Foo", [], ["one<bar>two</baz>three"], %{line: 1, file: "nofile", column: 2}}]
     end
 
     test "inner text has macro-like tag" do
-      assert parse("<#Foo>one<#bar>two</#baz>three</#Foo>") ==
-               {:ok,
-                [
-                  {"#Foo", [], ["one<#bar>two</#baz>three"],
-                   %{line: 1, file: "nofile", column: 2}}
-                ]}
+      assert parse!("<#Foo>one<#bar>two</#baz>three</#Foo>") ==
+               [
+                 {"#Foo", [], ["one<#bar>two</#baz>three"], %{line: 1, file: "nofile", column: 2}}
+               ]
     end
 
     test "inner text has only open tags (invalid html)" do
-      assert parse("<#Foo>one<bar>two<baz>three</#Foo>") ==
-               {:ok,
-                [{"#Foo", [], ["one<bar>two<baz>three"], %{line: 1, file: "nofile", column: 2}}]}
+      assert parse!("<#Foo>one<bar>two<baz>three</#Foo>") ==
+               [{"#Foo", [], ["one<bar>two<baz>three"], %{line: 1, file: "nofile", column: 2}}]
     end
 
     test "inner text has all closing tags (invalid html)" do
-      assert parse("<#Foo>one</bar>two</baz>three</#Foo>") ==
-               {:ok,
-                [{"#Foo", [], ["one</bar>two</baz>three"], %{line: 1, file: "nofile", column: 2}}]}
+      assert parse!("<#Foo>one</bar>two</baz>three</#Foo>") ==
+               [{"#Foo", [], ["one</bar>two</baz>three"], %{line: 1, file: "nofile", column: 2}}]
     end
 
     test "self-closing macro" do
-      assert parse("<#Macro/>") ==
-               {:ok, [{"#Macro", '', [], %{line: 1, file: "nofile", column: 2}}]}
+      assert parse!("<#Macro/>") ==
+               [{"#Macro", '', [], %{line: 1, file: "nofile", column: 2}}]
     end
 
     test "keep track of the line of the definition" do
@@ -363,14 +346,14 @@ defmodule Surface.Compiler.ParserTest do
       </div>
       """
 
-      {:ok, [{_, _, children, _} | _]} = parse(code)
+      [{_, _, children, _} | _] = parse!(code)
       {_, _, _, meta} = Enum.at(children, 1)
       assert meta.line == 3
     end
 
     test "do not perform interpolation for inner content" do
-      assert parse("<#Foo>one {@var} two</#Foo>") ==
-               {:ok, [{"#Foo", [], ["one {@var} two"], %{line: 1, file: "nofile", column: 2}}]}
+      assert parse!("<#Foo>one {@var} two</#Foo>") ==
+               [{"#Foo", [], ["one {@var} two"], %{line: 1, file: "nofile", column: 2}}]
     end
   end
 
@@ -381,104 +364,82 @@ defmodule Surface.Compiler.ParserTest do
       <>bar</>
       """
 
-      assert {:error, %ParseError{column: _, file: _, message: "expected tag name", line: 2}} =
-               parse(code)
+      exception = assert_raise ParseError, fn -> parse!(code) end
+
+      assert %ParseError{message: "expected tag name", line: 2} = exception
     end
 
     test "invalid closing tag" do
       code = "<foo>bar</a></foo>"
 
-      assert {:error,
-              %ParseError{
-                column: _,
-                file: _,
-                message: "expected closing tag for <foo> defined on line 1, got </a>",
-                line: 1
-              }} = parse(code)
+      exception = assert_raise ParseError, fn -> parse!(code) end
+
+      message = "expected closing tag for <foo> defined on line 1, got </a>"
+
+      assert %ParseError{message: ^message, line: 1} = exception
     end
 
     test "missing closing tag for html node" do
       code = "<foo><bar></foo>"
 
-      assert {:error,
-              %ParseError{
-                column: _,
-                file: _,
-                message: "expected closing tag for <bar> defined on line 1, got </foo>",
-                line: 1
-              }} = parse(code)
+      exception = assert_raise ParseError, fn -> parse!(code) end
+
+      message = "expected closing tag for <bar> defined on line 1, got </foo>"
+      assert %ParseError{message: ^message, line: 1} = exception
     end
 
     test "missing closing tag for component node" do
       code = "<foo><Bar></foo>"
 
-      assert {:error,
-              %ParseError{
-                column: _,
-                file: _,
-                message: "expected closing tag for <Bar> defined on line 1, got </foo>",
-                line: 1
-              }} = parse(code)
+      exception = assert_raise ParseError, fn -> parse!(code) end
+
+      message = "expected closing tag for <Bar> defined on line 1, got </foo>"
+      assert %ParseError{message: ^message, line: 1} = exception
     end
 
     test "missing closing tag for fully specified component node" do
       code = "<foo><Bar.Baz></foo>"
 
-      assert {:error,
-              %ParseError{
-                column: _,
-                file: _,
-                message: "expected closing tag for <Bar.Baz> defined on line 1, got </foo>",
-                line: 1
-              }} = parse(code)
+      exception = assert_raise ParseError, fn -> parse!(code) end
+
+      message = "expected closing tag for <Bar.Baz> defined on line 1, got </foo>"
+      assert %ParseError{message: ^message, line: 1} = exception
     end
 
     test "missing closing tag for component node with number" do
       code = "<foo><Bar1></foo>"
 
-      assert {:error,
-              %ParseError{
-                column: _,
-                file: _,
-                message: "expected closing tag for <Bar1> defined on line 1, got </foo>",
-                line: 1
-              }} = parse(code)
+      exception = assert_raise ParseError, fn -> parse!(code) end
+
+      message = "expected closing tag for <Bar1> defined on line 1, got </foo>"
+      assert %ParseError{message: ^message, line: 1} = exception
     end
 
     test "missing closing tag for component node with underscore and number" do
       code = "<foo><Bar_1></foo>"
 
-      assert {:error,
-              %ParseError{
-                column: _,
-                file: _,
-                message: "expected closing tag for <Bar_1> defined on line 1, got </foo>",
-                line: 1
-              }} = parse(code)
+      exception = assert_raise ParseError, fn -> parse!(code) end
+
+      message = "expected closing tag for <Bar_1> defined on line 1, got </foo>"
+      assert %ParseError{message: ^message, line: 1} = exception
     end
 
     test "missing closing tag for html node with dash" do
       code = "<foo><bar-baz></foo>"
 
-      assert {:error,
-              %ParseError{
-                column: _,
-                file: _,
-                message: "expected closing tag for <bar-baz> defined on line 1, got </foo>",
-                line: 1
-              }} = parse(code)
+      exception = assert_raise ParseError, fn -> parse!(code) end
+
+      message = "expected closing tag for <bar-baz> defined on line 1, got </foo>"
+      assert %ParseError{message: ^message, line: 1} = exception
     end
 
     test "missing closing tag for macro component node" do
       code = "<foo><#Bar></foo>"
 
-      assert {:error,
-              %ParseError{
-                column: _,
-                file: _,
-                message: "expected closing tag for <#Bar> defined on line 1, got EOF",
-                line: 1
-              }} = parse(code)
+      exception = assert_raise ParseError, fn -> parse!(code) end
+
+      message = "expected closing tag for <#Bar> defined on line 1, got EOF"
+      assert %ParseError{message: ^message, line: 1} = exception
     end
 
     test "missing closing tag for html node with surrounding text" do
@@ -490,73 +451,55 @@ defmodule Surface.Compiler.ParserTest do
       </foo>
       """
 
-      assert {:error,
-              %ParseError{
-                column: _,
-                file: _,
-                message: "expected closing tag for <div> defined on line 3, got </foo>",
-                line: 3
-              }} = parse(code)
+      exception = assert_raise ParseError, fn -> parse!(code) end
+
+      message = "expected closing tag for <div> defined on line 3, got </foo>"
+      assert %ParseError{message: ^message, line: 3} = exception
     end
 
     test "tag mismatch" do
       code = "<foo>bar</baz>"
 
-      assert {:error,
-              %ParseError{
-                column: _,
-                file: _,
-                message: "expected closing tag for <foo> defined on line 1, got </baz>",
-                line: 1
-              }} = parse(code)
+      exception = assert_raise ParseError, fn -> parse!(code) end
+
+      message = "expected closing tag for <foo> defined on line 1, got </baz>"
+      assert %ParseError{message: ^message, line: 1} = exception
     end
 
     test "incomplete tag content" do
       code = "<foo>bar"
 
-      assert {:error,
-              %ParseError{
-                column: _,
-                file: _,
-                message: "expected closing tag for <foo> defined on line 1, got EOF",
-                line: 1
-              }} = parse(code)
+      exception = assert_raise ParseError, fn -> parse!(code) end
+
+      message = "expected closing tag for <foo> defined on line 1, got EOF"
+      assert %ParseError{message: ^message, line: 1} = exception
     end
 
     test "incomplete macro content" do
       code = "<#foo>bar</#bar>"
 
-      assert {:error,
-              %ParseError{
-                column: _,
-                file: _,
-                message: "expected closing tag for <#foo> defined on line 1, got </#bar>",
-                line: 1
-              }} = parse(code)
+      exception = assert_raise ParseError, fn -> parse!(code) end
+
+      message = "expected closing tag for <#foo> defined on line 1, got </#bar>"
+      assert %ParseError{message: ^message, line: 1} = exception
     end
 
     test "non-closing interpolation" do
       code = "<foo>{bar</foo>"
 
-      assert {:error,
-              %ParseError{
-                column: _,
-                file: _,
-                message: "expected closing `}` for expression",
-                line: 1
-              }} = parse(code)
+      exception = assert_raise ParseError, fn -> parse!(code) end
+
+      message = "expected closing `}` for expression"
+      assert %ParseError{message: ^message, line: 1} = exception
     end
 
     test "non-matched curlies inside interpolation" do
       code = "<foo>{bar { }</foo>"
 
-      assert {:error,
-              %ParseError{
-                column: _,
-                file: _,
-                message: "expected closing `}` for expression",
-                line: 1
-              }} = parse(code)
+      exception = assert_raise ParseError, fn -> parse!(code) end
+
+      message = "expected closing `}` for expression"
+      assert %ParseError{message: ^message, line: 1} = exception
     end
   end
 
@@ -566,7 +509,7 @@ defmodule Surface.Compiler.ParserTest do
       <foo prop1="1"\n\r\t\fprop2="2"/>\
       """
 
-      {:ok, [{_, attributes, _, _}]} = parse(code)
+      [{_, attributes, _, _}] = parse!(code)
 
       assert attributes == [
                {"prop1", "1", %{line: 1, file: "nofile", column: 6}},
@@ -597,8 +540,8 @@ defmodule Surface.Compiler.ParserTest do
         "\n"
       ]
 
-      assert parse(code) ==
-               {:ok, [{"foo", attributes, children, %{line: 1, file: "nofile", column: 2}}, "\n"]}
+      assert parse!(code) ==
+               [{"foo", attributes, children, %{line: 1, file: "nofile", column: 2}}, "\n"]
     end
 
     test "self-closing nodes" do
@@ -614,8 +557,8 @@ defmodule Surface.Compiler.ParserTest do
         {"prop2", "value2", %{line: 3, file: "nofile", column: 3}}
       ]
 
-      assert parse(code) ==
-               {:ok, [{"foo", attributes, [], %{line: 1, file: "nofile", column: 2}}, "\n"]}
+      assert parse!(code) ==
+               [{"foo", attributes, [], %{line: 1, file: "nofile", column: 2}}, "\n"]
     end
 
     test "macro nodes" do
@@ -633,9 +576,8 @@ defmodule Surface.Compiler.ParserTest do
         {"prop2", "value2", %{line: 3, file: "nofile", column: 3}}
       ]
 
-      assert parse(code) ==
-               {:ok,
-                [{"#foo", attributes, ["\n  bar\n"], %{line: 1, file: "nofile", column: 2}}, "\n"]}
+      assert parse!(code) ==
+               [{"#foo", attributes, ["\n  bar\n"], %{line: 1, file: "nofile", column: 2}}, "\n"]
     end
 
     test "regular nodes with whitespaces" do
@@ -657,8 +599,8 @@ defmodule Surface.Compiler.ParserTest do
         {"prop4", true, %{line: 6, file: "nofile", column: 3}}
       ]
 
-      assert parse(code) ==
-               {:ok, [{"foo", attributes, [], %{line: 1, file: "nofile", column: 2}}, "\n"]}
+      assert parse!(code) ==
+               [{"foo", attributes, [], %{line: 1, file: "nofile", column: 2}}, "\n"]
     end
 
     test "self-closing nodes with whitespaces" do
@@ -680,8 +622,8 @@ defmodule Surface.Compiler.ParserTest do
         {"prop4", true, %{line: 6, file: "nofile", column: 3}}
       ]
 
-      assert parse(code) ==
-               {:ok, [{"foo", attributes, [], %{line: 1, file: "nofile", column: 2}}, "\n"]}
+      assert parse!(code) ==
+               [{"foo", attributes, [], %{line: 1, file: "nofile", column: 2}}, "\n"]
     end
 
     test "value as expression" do
@@ -699,8 +641,8 @@ defmodule Surface.Compiler.ParserTest do
          %{line: 3, file: "nofile", column: 3}}
       ]
 
-      assert parse(code) ==
-               {:ok, [{"foo", attributes, [], %{line: 1, file: "nofile", column: 2}}, "\n"]}
+      assert parse!(code) ==
+               [{"foo", attributes, [], %{line: 1, file: "nofile", column: 2}}, "\n"]
     end
 
     test "integer values" do
@@ -716,8 +658,8 @@ defmodule Surface.Compiler.ParserTest do
         {"prop2", 2, %{line: 3, file: "nofile", column: 3}}
       ]
 
-      assert parse(code) ==
-               {:ok, [{"foo", attributes, [], %{line: 1, file: "nofile", column: 2}}, "\n"]}
+      assert parse!(code) ==
+               [{"foo", attributes, [], %{line: 1, file: "nofile", column: 2}}, "\n"]
     end
 
     test "boolean values" do
@@ -737,8 +679,8 @@ defmodule Surface.Compiler.ParserTest do
         {"prop4", true, %{line: 5, file: "nofile", column: 3}}
       ]
 
-      assert parse(code) ==
-               {:ok, [{"foo", attributes, [], %{line: 1, file: "nofile", column: 2}}, "\n"]}
+      assert parse!(code) ==
+               [{"foo", attributes, [], %{line: 1, file: "nofile", column: 2}}, "\n"]
     end
 
     test "string values" do
@@ -752,8 +694,8 @@ defmodule Surface.Compiler.ParserTest do
         {"prop", attr_value, %{line: 1, file: "nofile", column: 6}}
       ]
 
-      assert parse(code) ==
-               {:ok, [{"foo", attributes, [], %{line: 1, file: "nofile", column: 2}}, "\n"]}
+      assert parse!(code) ==
+               [{"foo", attributes, [], %{line: 1, file: "nofile", column: 2}}, "\n"]
     end
 
     test "empty string" do
@@ -767,8 +709,8 @@ defmodule Surface.Compiler.ParserTest do
         {"prop", attr_value, %{line: 1, file: "nofile", column: 6}}
       ]
 
-      assert parse(code) ==
-               {:ok, [{"foo", attributes, [], %{line: 1, file: "nofile", column: 2}}, "\n"]}
+      assert parse!(code) ==
+               [{"foo", attributes, [], %{line: 1, file: "nofile", column: 2}}, "\n"]
     end
 
     # test "string with embedded interpolation" do
@@ -782,7 +724,7 @@ defmodule Surface.Compiler.ParserTest do
     #     {"prop", attr_value, %{line: 1}}
     #   ]
 
-    #   assert parse(code) == {:ok, [{"foo", attributes, [], %{line: 1}}, "\n"]}
+    #   assert parse!(code) ==  [{"foo", attributes, [], %{line: 1}}, "\n"]
     # end
 
     #   test "string with only an embedded interpolation" do
@@ -796,7 +738,7 @@ defmodule Surface.Compiler.ParserTest do
     #       {"prop", attr_value, %{line: 1}}
     #     ]
 
-    #     assert parse(code) == {:ok, [{"foo", attributes, [], %{line: 1}}, "\n"]}
+    #     assert parse!(code) ==  [{"foo", attributes, [], %{line: 1}}, "\n"]
     #   end
 
     test "interpolation with nested curlies" do
@@ -810,8 +752,8 @@ defmodule Surface.Compiler.ParserTest do
         {"prop", attr_value, %{line: 1, file: "nofile", column: 6}}
       ]
 
-      assert parse(code) ==
-               {:ok, [{"foo", attributes, [], %{line: 1, file: "nofile", column: 2}}, "\n"]}
+      assert parse!(code) ==
+               [{"foo", attributes, [], %{line: 1, file: "nofile", column: 2}}, "\n"]
     end
 
     test "attribute expression with nested tuples" do
@@ -827,8 +769,8 @@ defmodule Surface.Compiler.ParserTest do
         {":for", attr_value, %{line: 1, file: "nofile", column: 5}}
       ]
 
-      assert parse(code) ==
-               {:ok, [{"li", attributes, [], %{line: 1, file: "nofile", column: 2}}, "\n"]}
+      assert parse!(code) ==
+               [{"li", attributes, [], %{line: 1, file: "nofile", column: 2}}, "\n"]
     end
   end
 
@@ -842,19 +784,18 @@ defmodule Surface.Compiler.ParserTest do
       </#if>\
       """
 
-      assert parse(code) ==
-               {:ok,
-                [
-                  {"#if",
-                   [
-                     {:root, {:attribute_expr, "true", %{line: 1, file: "nofile", column: 7}},
-                      %{line: 1, file: "nofile", column: 7}}
-                   ],
-                   [
-                     {:default, [], ["\n  1\n"], %{}},
-                     {"#else", [], ["\n  2\n"], %{line: 3, file: "nofile", column: 2}}
-                   ], %{line: 1, file: "nofile", column: 2, has_sub_blocks?: true}}
-                ]}
+      assert parse!(code) ==
+               [
+                 {"#if",
+                  [
+                    {:root, {:attribute_expr, "true", %{line: 1, file: "nofile", column: 7}},
+                     %{line: 1, file: "nofile", column: 7}}
+                  ],
+                  [
+                    {:default, [], ["\n  1\n"], %{}},
+                    {"#else", [], ["\n  2\n"], %{line: 3, file: "nofile", column: 2}}
+                  ], %{line: 1, file: "nofile", column: 2, has_sub_blocks?: true}}
+               ]
     end
 
     test "multiple sub-blocks" do
@@ -870,21 +811,20 @@ defmodule Surface.Compiler.ParserTest do
       </#if>\
       """
 
-      assert parse(code) ==
-               {:ok,
-                [
-                  {"#if",
-                   [
-                     {:root, {:attribute_expr, "true", %{line: 1, file: "nofile", column: 7}},
-                      %{line: 1, file: "nofile", column: 7}}
-                   ],
-                   [
-                     {:default, [], ["\n  1\n"], %{}},
-                     {"#elseif", [], ["\n  2\n"], %{line: 3, file: "nofile", column: 2}},
-                     {"#elseif", [], ["\n  3\n"], %{line: 5, file: "nofile", column: 2}},
-                     {"#else", [], ["\n  4\n"], %{line: 7, file: "nofile", column: 2}}
-                   ], %{line: 1, file: "nofile", column: 2, has_sub_blocks?: true}}
-                ]}
+      assert parse!(code) ==
+               [
+                 {"#if",
+                  [
+                    {:root, {:attribute_expr, "true", %{line: 1, file: "nofile", column: 7}},
+                     %{line: 1, file: "nofile", column: 7}}
+                  ],
+                  [
+                    {:default, [], ["\n  1\n"], %{}},
+                    {"#elseif", [], ["\n  2\n"], %{line: 3, file: "nofile", column: 2}},
+                    {"#elseif", [], ["\n  3\n"], %{line: 5, file: "nofile", column: 2}},
+                    {"#else", [], ["\n  4\n"], %{line: 7, file: "nofile", column: 2}}
+                  ], %{line: 1, file: "nofile", column: 2, has_sub_blocks?: true}}
+               ]
     end
 
     test "nested sub-blocks" do
@@ -903,37 +843,36 @@ defmodule Surface.Compiler.ParserTest do
       </#if>\
       """
 
-      assert parse(code) ==
-               {:ok,
-                [
-                  {"#if",
-                   [
-                     {:root, {:attribute_expr, "1", %{line: 1, file: "nofile", column: 7}},
-                      %{line: 1, file: "nofile", column: 7}}
-                   ],
-                   [
-                     {:default, [], ["\n  111\n"], %{}},
-                     {"#elseif",
-                      [
-                        {:root, {:attribute_expr, "2", %{line: 3, file: "nofile", column: 11}},
-                         %{line: 3, file: "nofile", column: 11}}
-                      ],
-                      [
-                        "\n  222\n  ",
-                        {"#if",
-                         [
-                           {:root, {:attribute_expr, "3", %{line: 5, file: "nofile", column: 9}},
-                            %{line: 5, file: "nofile", column: 9}}
-                         ],
-                         [
-                           {:default, [], ["\n    333\n  "], %{}},
-                           {"#else", [], ["\n    444\n  "], %{line: 7, file: "nofile", column: 4}}
-                         ], %{has_sub_blocks?: true, line: 5, file: "nofile", column: 4}},
-                        "\n"
-                      ], %{line: 3, file: "nofile", column: 2}},
-                     {"#else", [], ["\n  555\n"], %{line: 10, file: "nofile", column: 2}}
-                   ], %{has_sub_blocks?: true, line: 1, file: "nofile", column: 2}}
-                ]}
+      assert parse!(code) ==
+               [
+                 {"#if",
+                  [
+                    {:root, {:attribute_expr, "1", %{line: 1, file: "nofile", column: 7}},
+                     %{line: 1, file: "nofile", column: 7}}
+                  ],
+                  [
+                    {:default, [], ["\n  111\n"], %{}},
+                    {"#elseif",
+                     [
+                       {:root, {:attribute_expr, "2", %{line: 3, file: "nofile", column: 11}},
+                        %{line: 3, file: "nofile", column: 11}}
+                     ],
+                     [
+                       "\n  222\n  ",
+                       {"#if",
+                        [
+                          {:root, {:attribute_expr, "3", %{line: 5, file: "nofile", column: 9}},
+                           %{line: 5, file: "nofile", column: 9}}
+                        ],
+                        [
+                          {:default, [], ["\n    333\n  "], %{}},
+                          {"#else", [], ["\n    444\n  "], %{line: 7, file: "nofile", column: 4}}
+                        ], %{has_sub_blocks?: true, line: 5, file: "nofile", column: 4}},
+                       "\n"
+                     ], %{line: 3, file: "nofile", column: 2}},
+                    {"#else", [], ["\n  555\n"], %{line: 10, file: "nofile", column: 2}}
+                  ], %{has_sub_blocks?: true, line: 1, file: "nofile", column: 2}}
+               ]
     end
 
     test "handle invalid parents for #else" do
@@ -943,14 +882,10 @@ defmodule Surface.Compiler.ParserTest do
       </div>
       """
 
-      assert {:error,
-              %ParseError{
-                column: _,
-                file: _,
-                message:
-                  "cannot use <#else> inside <div>. Possible parents are \"<#if>\" and \"<#for>\"",
-                line: 2
-              }} = parse(code)
+      exception = assert_raise ParseError, fn -> parse!(code) end
+
+      message = "cannot use <#else> inside <div>. Possible parents are \"<#if>\" and \"<#for>\""
+      assert %ParseError{message: ^message, line: 2} = exception
     end
 
     test "handle invalid parents for #elseif" do
@@ -960,14 +895,12 @@ defmodule Surface.Compiler.ParserTest do
       </div>
       """
 
-      assert {:error,
-              %ParseError{
-                column: _,
-                file: _,
-                message:
-                  "cannot use <#elseif> inside <div>. The <#elseif> construct can only be used inside a \"<#if>\"",
-                line: 2
-              }} = parse(code)
+      exception = assert_raise ParseError, fn -> parse!(code) end
+
+      message =
+        "cannot use <#elseif> inside <div>. The <#elseif> construct can only be used inside a \"<#if>\""
+
+      assert %ParseError{message: ^message, line: 2} = exception
     end
 
     test "handle invalid parents for #match" do
@@ -977,14 +910,12 @@ defmodule Surface.Compiler.ParserTest do
       </div>
       """
 
-      assert {:error,
-              %ParseError{
-                column: _,
-                file: _,
-                message:
-                  "cannot use <#match> inside <div>. The <#match> construct can only be used inside a \"<#case>\"",
-                line: 2
-              }} = parse(code)
+      exception = assert_raise ParseError, fn -> parse!(code) end
+
+      message =
+        "cannot use <#match> inside <div>. The <#match> construct can only be used inside a \"<#case>\""
+
+      assert %ParseError{message: ^message, line: 2} = exception
     end
 
     test "raise error on sub-blocks without parent node" do
@@ -994,14 +925,12 @@ defmodule Surface.Compiler.ParserTest do
         2
       """
 
-      assert {:error,
-              %ParseError{
-                column: _,
-                file: _,
-                message:
-                  "no valid parent node defined for <#else>. Possible parents are \"<#if>\" and \"<#for>\"",
-                line: 2
-              }} = parse(code)
+      exception = assert_raise ParseError, fn -> parse!(code) end
+
+      message =
+        "no valid parent node defined for <#else>. Possible parents are \"<#if>\" and \"<#for>\""
+
+      assert %ParseError{message: ^message, line: 2} = exception
     end
   end
 end

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -473,8 +473,12 @@ defmodule Surface.Compiler.ParserTest do
       code = "<foo><#Bar></foo>"
 
       assert {:error,
-              %ParseError{column: _, file: _, message: "expected closing tag for <#Bar> defined on line 1, got EOF", line: 1}} =
-               parse(code)
+              %ParseError{
+                column: _,
+                file: _,
+                message: "expected closing tag for <#Bar> defined on line 1, got EOF",
+                line: 1
+              }} = parse(code)
     end
 
     test "missing closing tag for html node with surrounding text" do
@@ -511,8 +515,12 @@ defmodule Surface.Compiler.ParserTest do
       code = "<foo>bar"
 
       assert {:error,
-              %ParseError{column: _, file: _, message: "expected closing tag for <foo> defined on line 1, got EOF", line: 1}} =
-               parse(code)
+              %ParseError{
+                column: _,
+                file: _,
+                message: "expected closing tag for <foo> defined on line 1, got EOF",
+                line: 1
+              }} = parse(code)
     end
 
     test "incomplete macro content" do

--- a/test/transform_test.exs
+++ b/test/transform_test.exs
@@ -169,7 +169,7 @@ defmodule Surface.TransformTest do
 
     assert_raise(
       Surface.Compiler.ParseError,
-      "nofile:1: expected closing tag for <DivToSpan>",
+      "nofile:1:2: expected closing tag for <DivToSpan> defined on line 1, got EOF",
       fn ->
         Surface.Compiler.compile(code, 1, __ENV__)
       end


### PR DESCRIPTION
At a high level, this PR does the following:

- swapping out the mixture of raise/returning error tuples in the tokenizer/parser with returning error tuples and adding a bang variant (i.e. tokenize! and parse!)
- consolidating to a single ParseError struct (we had two serving the same purpose - Surface.Compiler.ParseError and Surface.Compiler.Tokenizer.ParseError)
- passing file/column/line options through the parser to the tokenizer so the line numbers were all consistent (and therefor removing the need for line_offset)
- propagating the line/column/file meta for attributes (I wasn't quite sure why we didn't have those initially, but it allows us to handle errors consistently regardless of where they come from)
- propagating column info into the ast meta (we didn't have this initially as it was added in 1.11 and we started the compiler work before that was released)
- fixed a TODO for the message we raise when a closing tag is missing
- replace all of our uses of line offset with just line