### PR TITLE
Fix macro component compile-time dependency

### DIFF
--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -467,10 +467,10 @@ defmodule Surface.Compiler do
 
       compile_dep_expr = %AST.Expr{
         value:
-          quote generated: true, line: node_meta.line do
+          quote generated: true, line: meta.line do
             require(unquote(mod)).__compile_dep__()
           end,
-        meta: %AST.Meta{}
+        meta: meta
       }
 
       {:ok,

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -465,9 +465,17 @@ defmodule Surface.Compiler do
          :ok <- validate_properties(mod, attributes, directives, meta) do
       expanded = mod.expand(attributes, children, meta)
 
+      compile_dep_expr = %AST.Expr{
+        value:
+          quote generated: true, line: node_meta.line do
+            require(unquote(mod)).__compile_dep__()
+          end,
+        meta: %AST.Meta{}
+      }
+
       {:ok,
        %AST.Container{
-         children: List.wrap(expanded),
+         children: [compile_dep_expr, expanded],
          directives: directives,
          meta: meta
        }}

--- a/lib/surface/macro_component.ex
+++ b/lib/surface/macro_component.ex
@@ -22,6 +22,9 @@ defmodule Surface.MacroComponent do
 
       use Surface.API, include: [:prop, :slot]
       @behaviour unquote(__MODULE__)
+
+      @doc false
+      defmacro __compile_dep__, do: nil
     end
   end
 

--- a/test/compiler_test.exs
+++ b/test/compiler_test.exs
@@ -397,6 +397,21 @@ defmodule Surface.CompilerTest do
   end
 
   describe "macro components" do
+    test "inject a __compile_dep__/0 macro call to force compile-time dependency" do
+      code = """
+      <#Macro />
+      """
+
+      [node | _] = Surface.Compiler.compile(code, 1, __ENV__)
+
+      assert %Surface.AST.Container{
+               children: [
+                 %Surface.AST.Expr{value: {{:., _, [{:require, _, _}, :__compile_dep__]}, _, []}},
+                 %Surface.AST.Tag{}
+               ]
+             } = node
+    end
+
     test "expanded at top level" do
       code = """
       <#Macro />
@@ -406,6 +421,7 @@ defmodule Surface.CompilerTest do
 
       assert %Surface.AST.Container{
                children: [
+                 _,
                  %Surface.AST.Tag{children: ["I'm a macro"], element: "div"}
                ]
              } = node
@@ -427,6 +443,7 @@ defmodule Surface.CompilerTest do
                      children: [
                        %Surface.AST.Container{
                          children: [
+                           _,
                            %Surface.AST.Tag{
                              children: ["I'm a macro"],
                              element: "div"
@@ -452,6 +469,7 @@ defmodule Surface.CompilerTest do
                children: [
                  %Surface.AST.Container{
                    children: [
+                     %Surface.AST.Expr{},
                      %Surface.AST.Tag{children: ["I'm a macro"], element: "div"}
                    ]
                  }


### PR DESCRIPTION
This fixes the issue of not recompiling dependent components when macro components change.

By simply injecting `require TheMacroComponent` doesn't work anymore. It used to work in the past. Either way, I couldn't see we injecting that anymore.

Injecting a call to a macro belonging to the macro component seems to be the only way to force a compile-time dependency between the caller component and the macro component.

This bug was reported by @miguel-s on slack.