### PR TITLE
Update link documentation

### DIFF
--- a/lib/surface/components/link.ex
+++ b/lib/surface/components/link.ex
@@ -13,7 +13,8 @@ defmodule Surface.Components.Link do
     label="user"
     to="/users/1"
     class="is-danger"
-    opts={{ method: :delete, data: [confirm: "Really?"] }}
+    method={{ :delete }}
+    opts={{ data: [confirm: "Really?"] }}
   />
 
   <Link


### PR DESCRIPTION
Updates the `Surface.Components.Link` documentation as it contained an outdated code example. The link `method` was put into the `opts`. However, this does not work. It is now replaced with the correct `method` property.