### PR TITLE
Warn on invalid prop/data defaults

### DIFF
--- a/lib/surface/api.ex
+++ b/lib/surface/api.ex
@@ -496,14 +496,22 @@ defmodule Surface.API do
       accumulate? and not is_nil(values!) and
           not MapSet.subset?(MapSet.new(default), MapSet.new(values!)) ->
         IOHelper.warn(
-          "#{type} `#{name}` default value `#{inspect(default)}` does not exist in `:values!`",
+          """
+          #{type} `#{name}` default value `#{inspect(default)}` does not exist in `:values!`
+
+          Hint: Either choose an existing value or replace `:values!` with `:values` to skip validation.
+          """,
           caller,
           fn _ -> caller.line end
         )
 
       not accumulate? and not is_nil(values!) and not (default in values!) ->
         IOHelper.warn(
-          "#{type} `#{name}` default value `#{inspect(default)}` does not exist in `:values!`",
+          """
+          #{type} `#{name}` default value `#{inspect(default)}` does not exist in `:values!`
+
+          Hint: Either choose an existing value or replace `:values!` with `:values` to skip validation.
+          """,
           caller,
           fn _ -> caller.line end
         )

--- a/lib/surface/api.ex
+++ b/lib/surface/api.ex
@@ -488,7 +488,7 @@ defmodule Surface.API do
     cond do
       accumulate? and not is_list(default) ->
         IOHelper.warn(
-          "#{type} `#{name}` default value #{inspect(default)} must be a list when accumulate: true",
+          "#{type} `#{name}` default value `#{inspect(default)}` must be a list when `accumulate: true`",
           caller,
           fn _ -> caller.line end
         )
@@ -496,14 +496,14 @@ defmodule Surface.API do
       accumulate? and not is_nil(values!) and
           not MapSet.subset?(MapSet.new(default), MapSet.new(values!)) ->
         IOHelper.warn(
-          "#{type} `#{name}` default value #{inspect(default)} does not exist in :values!",
+          "#{type} `#{name}` default value `#{inspect(default)}` does not exist in `:values!`",
           caller,
           fn _ -> caller.line end
         )
 
       not accumulate? and not is_nil(values!) and not (default in values!) ->
         IOHelper.warn(
-          "#{type} `#{name}` default value #{inspect(default)} does not exist in :values!",
+          "#{type} `#{name}` default value `#{inspect(default)}` does not exist in `:values!`",
           caller,
           fn _ -> caller.line end
         )

--- a/test/api_test.exs
+++ b/test/api_test.exs
@@ -289,7 +289,7 @@ defmodule Surface.APITest do
       code = "prop label, :string, a: 1"
 
       message =
-        ~r/unknown option :a. Available options: \[:required, :default, :values, :accumulate\]/
+        ~r/unknown option :a. Available options: \[:required, :default, :values, :values!, :accumulate\]/
 
       assert_raise(CompileError, message, fn ->
         eval(code)
@@ -404,7 +404,7 @@ defmodule Surface.APITest do
 
     test "validate unknown type options" do
       code = "data label, :string, a: 1"
-      message = ~r/unknown option :a. Available options: \[:default, :values\]/
+      message = ~r/unknown option :a. Available options: \[:default, :values, :values!\]/
 
       assert_raise(CompileError, message, fn ->
         eval(code)

--- a/test/properties_test.exs
+++ b/test/properties_test.exs
@@ -740,15 +740,15 @@ defmodule Surface.PropertiesSyncTest do
       end)
 
     assert output =~ ~S"""
-           prop `type` default value "x-large" does not exist in :values!
+           prop `type` default value `"x-large"` does not exist in `:values!`
            """
 
     assert output =~ ~S"""
-           data `data_type` default value "x-large" does not exist in :values!
+           data `data_type` default value `"x-large"` does not exist in `:values!`
            """
 
     assert output =~ ~S"""
-           prop `invalid_type` default value [] does not exist in :values!
+           prop `invalid_type` default value `[]` does not exist in `:values!`
            """
 
     refute output =~ ~S"""
@@ -756,11 +756,11 @@ defmodule Surface.PropertiesSyncTest do
            """
 
     assert output =~ ~S"""
-           prop `invalid_acc1` default value [3] does not exist in :values!
+           prop `invalid_acc1` default value `[3]` does not exist in `:values!`
            """
 
     assert output =~ ~S"""
-           prop `invalid_acc2` default value 3 must be a list when accumulate: true
+           prop `invalid_acc2` default value `3` must be a list when `accumulate: true`
            """
   end
 end

--- a/test/properties_test.exs
+++ b/test/properties_test.exs
@@ -706,4 +706,61 @@ defmodule Surface.PropertiesSyncTest do
              code.exs:7:\
            """
   end
+
+  test "warn if given default value doesn't exist in values list" do
+    id = :erlang.unique_integer([:positive]) |> to_string()
+    module = "TestComponentWithDefaultValueThatDoesntExistInValues_#{id}"
+
+    code = """
+    defmodule #{module} do
+      use Surface.Component
+
+      prop type, :string, values!: ["small", "medium", "large"], default: "x-large"
+
+      data data_type, :string, values!: ["small", "medium", "large"], default: "x-large"
+
+      prop invalid_type, :integer, default: [], values!: [0, 1, 2]
+
+      prop valid_acc, :integer, default: [1], values!: [0, 1, 2], accumulate: true
+
+      prop invalid_acc1, :integer, default: [3], values!: [0, 1, 2], accumulate: true
+
+      prop invalid_acc2, :string, values!: [1, 2, 3], default: 3, accumulate: true
+
+      def render(assigns) do
+        ~H""
+      end
+    end
+    """
+
+    output =
+      capture_io(:standard_error, fn ->
+        {{:module, _, _, _}, _} =
+          Code.eval_string(code, [], %{__ENV__ | file: "code.exs", line: 1})
+      end)
+
+    assert output =~ ~S"""
+           prop `type` default value "x-large" does not exist in :values!
+           """
+
+    assert output =~ ~S"""
+           data `data_type` default value "x-large" does not exist in :values!
+           """
+
+    assert output =~ ~S"""
+           prop `invalid_type` default value [] does not exist in :values!
+           """
+
+    refute output =~ ~S"""
+           prop `valid_acc`
+           """
+
+    assert output =~ ~S"""
+           prop `invalid_acc1` default value [3] does not exist in :values!
+           """
+
+    assert output =~ ~S"""
+           prop `invalid_acc2` default value 3 must be a list when accumulate: true
+           """
+  end
 end


### PR DESCRIPTION
Builds off of https://github.com/surface-ui/surface/pull/314

Warns when a prop's default value is not in the `:values!` list

- [ ] Documentation updates
- [ ] Surface site PR
- [ ] Support in the docs for :values!