### PR TITLE
Deprecated unquoted strings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,11 @@ jobs:
         include:
           - elixir: 1.11.1
             otp: 21.3.8.17
+            warnings-as-errors: true
           - elixir: 1.11.4
             otp: 23.2
             check_formatted: true
+            warnings-as-errors: true
           - elixir: 1.12.0-rc.0
             otp: 24.0-rc3
     env:

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -672,7 +672,19 @@ defmodule Surface.Compiler do
     }
   end
 
-  defp attr_value(name, type, value, meta) do
+  defp attr_value(name, type, value, meta) when is_boolean(value) or is_integer(value) do
+    message = """
+      Passing attribute values as `#{name}=#{value}` has been deprecated and will be removed in future version.
+
+      Hint: replace `#{name}=#{value}` by `#{name}={#{value}}`
+    """
+
+    IOHelper.warn(message, meta.caller, fn _ -> meta.line end)
+
+    Surface.TypeHandler.literal_to_ast_node!(type, name, value, meta)
+  end
+
+  defp attr_value(name, type, value, meta) when is_binary(value) do
     Surface.TypeHandler.literal_to_ast_node!(type, name, value, meta)
   end
 

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -605,6 +605,7 @@ defmodule Surface.Compiler do
   end
 
   defp process_attributes(mod, [{name, value, attr_meta} | attrs], meta, acc) do
+    unquoted_string? = attr_meta[:unquoted_string?]
     name = String.to_atom(name)
     attr_meta = Helpers.to_meta(attr_meta, meta)
     {type, type_opts} = Surface.TypeHandler.attribute_type_and_opts(mod, name, attr_meta)
@@ -627,6 +628,16 @@ defmodule Surface.Compiler do
         meta.caller,
         fn _ -> attr_meta.line end
       )
+    end
+
+    if unquoted_string? do
+      message = """
+        passing unquoted attribute values has been deprecated and will be removed in future versions.
+
+        Hint: replace `#{name}=#{value}` with `#{name}={#{value}}`
+      """
+
+      IOHelper.warn(message, meta.caller, fn _ -> meta.line end)
     end
 
     node = %AST.Attribute{
@@ -672,19 +683,7 @@ defmodule Surface.Compiler do
     }
   end
 
-  defp attr_value(name, type, value, meta) when is_boolean(value) or is_integer(value) do
-    message = """
-      passing unquoted attribute values has been deprecated and will be removed in future versions.
-
-      Hint: replace `#{name}=#{value}` with `#{name}={#{value}}`
-    """
-
-    IOHelper.warn(message, meta.caller, fn _ -> meta.line end)
-
-    Surface.TypeHandler.literal_to_ast_node!(type, name, value, meta)
-  end
-
-  defp attr_value(name, type, value, meta) when is_binary(value) do
+  defp attr_value(name, type, value, meta) do
     Surface.TypeHandler.literal_to_ast_node!(type, name, value, meta)
   end
 

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -674,9 +674,9 @@ defmodule Surface.Compiler do
 
   defp attr_value(name, type, value, meta) when is_boolean(value) or is_integer(value) do
     message = """
-      Passing attribute values as `#{name}=#{value}` has been deprecated and will be removed in future version.
+      passing unquoted attribute values has been deprecated and will be removed in future versions.
 
-      Hint: replace `#{name}=#{value}` by `#{name}={#{value}}`
+      Hint: replace `#{name}=#{value}` with `#{name}={#{value}}`
     """
 
     IOHelper.warn(message, meta.caller, fn _ -> meta.line end)

--- a/lib/surface/compiler/parser.ex
+++ b/lib/surface/compiler/parser.ex
@@ -200,16 +200,19 @@ defmodule Surface.Compiler.Parser do
   end
 
   defp translate_attr({name, {:string, "true", %{delimiter: nil}}, meta}) do
+    meta = Map.put(meta, :unquoted_string?, true)
     {name, true, to_meta(meta)}
   end
 
   defp translate_attr({name, {:string, "false", %{delimiter: nil}}, meta}) do
+    meta = Map.put(meta, :unquoted_string?, true)
     {name, false, to_meta(meta)}
   end
 
   defp translate_attr({name, {:string, value, %{delimiter: nil}}, meta}) do
     case Integer.parse(value) do
       {int_value, ""} ->
+        meta = Map.put(meta, :unquoted_string?, true)
         {name, int_value, to_meta(meta)}
 
       _ ->

--- a/test/compiler_test.exs
+++ b/test/compiler_test.exs
@@ -683,6 +683,48 @@ defmodule Surface.CompilerSyncTest do
 
   alias Surface.CompilerTest.{Button, Column, GridLive}, warn: false
 
+  test "warning when passing integer attribute values that are not enclosed by {}" do
+    code = """
+    <div>
+      <div tabindex=1 />
+    </div>
+    """
+
+    {:warn, line, message} = run_compile(code, __ENV__)
+
+    assert message =~ """
+            Passing attribute values as `tabindex=1` has been deprecated and will be removed in future version.
+
+             Hint: replace `tabindex=1` by `tabindex={1}`
+           """
+
+    assert line == 2
+  end
+
+  test "warning when passing boolean attribute values that are not enclosed by {}" do
+    code = """
+    <div>
+      <div selected=true checked=false />
+    </div>
+    """
+
+    {:warn, line, message} = run_compile(code, __ENV__)
+
+    assert message =~ """
+            Passing attribute values as `selected=true` has been deprecated and will be removed in future version.
+
+             Hint: replace `selected=true` by `selected={true}`
+           """
+
+    assert message =~ """
+            Passing attribute values as `checked=false` has been deprecated and will be removed in future version.
+
+             Hint: replace `checked=false` by `checked={false}`
+           """
+
+    assert line == 2
+  end
+
   test "warning when a aliased component cannot be loaded" do
     alias Components.But, warn: false
 

--- a/test/compiler_test.exs
+++ b/test/compiler_test.exs
@@ -693,9 +693,9 @@ defmodule Surface.CompilerSyncTest do
     {:warn, line, message} = run_compile(code, __ENV__)
 
     assert message =~ """
-            Passing attribute values as `tabindex=1` has been deprecated and will be removed in future version.
+            passing unquoted attribute values has been deprecated and will be removed in future versions.
 
-             Hint: replace `tabindex=1` by `tabindex={1}`
+             Hint: replace `tabindex=1` with `tabindex={1}`
            """
 
     assert line == 2
@@ -711,15 +711,15 @@ defmodule Surface.CompilerSyncTest do
     {:warn, line, message} = run_compile(code, __ENV__)
 
     assert message =~ """
-            Passing attribute values as `selected=true` has been deprecated and will be removed in future version.
+            passing unquoted attribute values has been deprecated and will be removed in future versions.
 
-             Hint: replace `selected=true` by `selected={true}`
+             Hint: replace `selected=true` with `selected={true}`
            """
 
     assert message =~ """
-            Passing attribute values as `checked=false` has been deprecated and will be removed in future version.
+            passing unquoted attribute values has been deprecated and will be removed in future versions.
 
-             Hint: replace `checked=false` by `checked={false}`
+             Hint: replace `checked=false` with `checked={false}`
            """
 
     assert line == 2

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -654,8 +654,8 @@ defmodule Surface.Compiler.ParserTest do
       """
 
       attributes = [
-        {"prop1", 1, %{line: 2, file: "nofile", column: 3}},
-        {"prop2", 2, %{line: 3, file: "nofile", column: 3}}
+        {"prop1", 1, %{line: 2, file: "nofile", column: 3, unquoted_string?: true}},
+        {"prop2", 2, %{line: 3, file: "nofile", column: 3, unquoted_string?: true}}
       ]
 
       assert parse!(code) ==
@@ -674,8 +674,8 @@ defmodule Surface.Compiler.ParserTest do
 
       attributes = [
         {"prop1", true, %{line: 2, file: "nofile", column: 3}},
-        {"prop2", true, %{line: 3, file: "nofile", column: 3}},
-        {"prop3", false, %{line: 4, file: "nofile", column: 3}},
+        {"prop2", true, %{line: 3, file: "nofile", column: 3, unquoted_string?: true}},
+        {"prop3", false, %{line: 4, file: "nofile", column: 3, unquoted_string?: true}},
         {"prop4", true, %{line: 5, file: "nofile", column: 3}}
       ]
 


### PR DESCRIPTION
Related to #340 

~~My first attempt was to add handle this in the `parser` but I believe it is not the role of the parser and it. I was able to move this warning to the `TypeHandler` or directly to the `Compiler`. From my point of view, it makes more sense to handle it in the compiler, so I decided to catch it in the `attr_value` function when the `attr_value` is not a string. If it is not a string, even if the type is `:string`, it means that the value as been converted before to something else, boolean or integer.~~

Ok, this will teach me not to run all the tests before pushing...
