### PR TITLE
Remove `phx_` prefix from props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.0 (WIP)
+
+  * [components] ErrorTag: Renamed prop `phx_trigger_action` to `trigger_action`
+
 ## v0.4.0 (2021-05-01)
 
   * Call render when defined in slotable components (#283)

--- a/lib/surface/components/form/error_tag.ex
+++ b/lib/surface/components/form/error_tag.ex
@@ -37,7 +37,7 @@ defmodule Surface.Components.Form.ErrorTag do
   ```
 
   ```surface
-  <ErrorTag phx_feedback_for="confirm_password_for_reset" />
+  <ErrorTag feedback_for="confirm_password_for_reset" />
   ```
 
   ```surface
@@ -97,7 +97,7 @@ defmodule Surface.Components.Form.ErrorTag do
   with an input of the same name. LiveView will exhibit buggy behavior
   without assigning separate id's to each.)
   """
-  prop phx_feedback_for, :string
+  prop feedback_for, :string
 
   def render(assigns) do
     translate_error = assigns.translator || translator_from_config() || (&translate_error/1)
@@ -108,7 +108,7 @@ defmodule Surface.Components.Form.ErrorTag do
       <span
         :for={error <- Keyword.get_values(form.errors, field)}
         class={class}
-        phx-feedback-for={@phx_feedback_for || input_id(form, field)}
+        phx-feedback-for={@feedback_for || input_id(form, field)}
       >{translate_error.(error)}</span>
     </InputContext>
     """

--- a/test/components/form/error_tag_test.exs
+++ b/test/components/form/error_tag_test.exs
@@ -66,7 +66,7 @@ defmodule Surface.Components.Form.ErrorTagTest do
     refute html =~ "another test error"
   end
 
-  test "prop phx_feedback_for", %{changeset: changeset} do
+  test "prop feedback_for", %{changeset: changeset} do
     assigns = %{changeset: changeset}
 
     html =
@@ -74,7 +74,7 @@ defmodule Surface.Components.Form.ErrorTagTest do
         ~H"""
         <Form for={@changeset} opts={as: :user}>
           <Field name={:name}>
-            <ErrorTag phx_feedback_for="test-id" />
+            <ErrorTag feedback_for="test-id" />
           </Field>
         </Form>
         """


### PR DESCRIPTION
Remove `phx_` prefix from props for consistent naming of props in builtin components.

Only affects the `phx_trigger_action` prop in `<ErrorTag>`