### PR TITLE
Support dynamic attributes shorthand notation

### DIFF
--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -299,7 +299,10 @@ defmodule Surface.Compiler do
        ) do
     meta = Helpers.to_meta(node_meta, compile_meta)
     default = %AST.AttributeExpr{value: false, original: "", meta: node_meta}
-    condition = attribute_value_as_ast(attributes, "condition", default, compile_meta)
+
+    condition =
+      attribute_value_as_ast(attributes, :root, nil, compile_meta) ||
+        attribute_value_as_ast(attributes, "condition", default, compile_meta)
 
     [if_children, else_children] =
       case children do

--- a/lib/surface/compiler/parser.ex
+++ b/lib/surface/compiler/parser.ex
@@ -220,7 +220,24 @@ defmodule Surface.Compiler.Parser do
     end
   end
 
+  defp translate_attr({:root, {:expr, "..." <> value, expr_meta}, _attr_meta}) do
+    {tag_name, expr_meta} = Map.pop!(expr_meta, :tag_name)
+    meta = to_meta(expr_meta)
+
+    directive =
+      case tag_name do
+        <<first, _::binary>> when first in ?A..?Z ->
+          ":props"
+
+        _ ->
+          ":attrs"
+      end
+
+    {directive, {:attribute_expr, value, meta}, meta}
+  end
+
   defp translate_attr({:root, {:expr, value, expr_meta}, _attr_meta}) do
+    {_tag_name, expr_meta} = Map.pop!(expr_meta, :tag_name)
     meta = to_meta(expr_meta)
     {:root, {:attribute_expr, value, meta}, meta}
   end

--- a/lib/surface/compiler/tokenizer.ex
+++ b/lib/surface/compiler/tokenizer.ex
@@ -281,12 +281,15 @@ defmodule Surface.Compiler.Tokenizer do
   defp handle_root_attribute(text, line, column, acc, state) do
     case handle_interpolation(text, line, column, [], state) do
       {:ok, value, new_line, new_column, rest, state} ->
+        [{:tag_open, tag_name, _attrs, _meta} | _] = acc
+
         meta = %{
           line: line,
           column: column,
           line_end: new_line,
           column_end: new_column - 1,
-          file: state.file
+          file: state.file,
+          tag_name: tag_name
         }
 
         acc = put_attr(acc, :root, {:expr, value, meta}, %{})

--- a/test/constructs/if_test.exs
+++ b/test/constructs/if_test.exs
@@ -77,6 +77,35 @@ defmodule Surface.Constructs.IfTest do
   end
 
   describe "#if language structure" do
+    test "using root prop" do
+      html =
+        render_surface do
+          ~H"""
+          <#if {true}>
+          <span>The inner content</span>
+          <span>with multiple tags</span>
+          </#if>
+          """
+        end
+
+      assert html =~ """
+             <span>The inner content</span>
+             <span>with multiple tags</span>
+             """
+
+      html =
+        render_surface do
+          ~H"""
+          <#if {false}>
+          <span>The inner content</span>
+          <span>with multiple tags</span>
+          </#if>
+          """
+        end
+
+      assert html =~ "\n"
+    end
+
     test "renders inner if condition is truthy" do
       html =
         render_surface do
@@ -173,6 +202,25 @@ defmodule Surface.Constructs.IfTest do
   end
 
   describe "#elseif language structure" do
+    test "using root prop" do
+      html =
+        render_surface do
+          ~H"""
+          <#if {false}>
+            IF
+          <#elseif {true}>
+            ELSEIF TRUE
+          <#else>
+            ELSE
+          </#if>
+          """
+        end
+
+      assert html =~ """
+             ELSEIF TRUE
+             """
+    end
+
     test "renders inner `elseif` condition if condition is truthy" do
       html =
         render_surface do

--- a/test/directives_test.exs
+++ b/test/directives_test.exs
@@ -137,6 +137,23 @@ defmodule Surface.DirectivesTest do
              </div>
              """
     end
+
+    test "shorthand notation `{...@props}`" do
+      assigns = %{props: %{class: "text-xs", hidden: false, content: "dynamic props content"}}
+
+      html =
+        render_surface do
+          ~H"""
+          <DivWithProps {...@props} />
+          """
+        end
+
+      assert html =~ """
+             <div class="text-xs block">
+               dynamic props content
+             </div>
+             """
+    end
   end
 
   describe ":attrs in html tags" do
@@ -225,6 +242,19 @@ defmodule Surface.DirectivesTest do
                Some Text
              </div>
              """
+    end
+
+    test "shorthand notation `{...@attrs}`" do
+      assigns = %{attrs: [class: "text-xs", style: "color: black;"]}
+
+      html =
+        render_surface do
+          ~H"""
+          <div {...@attrs}/>
+          """
+        end
+
+      assert html =~ ~s(<div class="text-xs" style="color: black;"></div>)
     end
   end
 


### PR DESCRIPTION
This is minimal implementation to accept `{...@attrs}` as a shorthand notation to `:attrs` and `:props`. As you can see, moving the implementation to the parser level makes everything extremely simple as it just converts the `:root` node into the respective `:attrs` and `:props` directives. However, going in this direction assumes we should keep the directives and consider the new syntax as a shorthand notation, not the only notation. I'm not sure yet this is a good idea or not.

I also implemented the root prop for `<#if>`, which was also extremely easy, however, as I said on Slack, having two different ways to handle root props (one for components, one for constructs) feels a bit odd. It would be nice to be able to define the root prop for the constructs, the same way we do for components using the same API. That would also avoid duplication of common validation. For instance, required root prop:

```elixir

demodule Surface.Constructs.If do
  use Surface.Construct

  prop condition, :boolean, root: true, required: true

  ...
end
```

I believe the current implementation of `<#if>` does not validate that yet and I wonder if we should do it already or try to come up with a more unified API for constructs before we move on. The old `<If>` component would be able to do that just fine so it seems we took a step back in that regard.

@lnr0626 I'm not sure if it would be better to wait for #378 to be finished to move on with this PR. Would the way it's been implemented change a lot with the new approach? Would it also in any way help with the concerns I just presented? 
