### PR TITLE
Treat embedded Elixir like a Comment

### DIFF
--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -235,6 +235,7 @@ defmodule Surface.Compiler do
   defp node_type({_, _, _, _}), do: :tag
   defp node_type({:interpolation, _, _}), do: :interpolation
   defp node_type({:comment, _}), do: :comment
+  defp node_type({:embedded_elixir, _}), do: :embedded_elixir
   defp node_type(_), do: :text
 
   defp process_directives(%{directives: directives} = node) do
@@ -248,6 +249,8 @@ defmodule Surface.Compiler do
   defp process_directives(node), do: node
 
   defp convert_node_to_ast(:comment, _, _), do: :ignore
+
+  defp convert_node_to_ast(:embedded_elixir, _, _), do: :ignore
 
   defp convert_node_to_ast(:text, text, _),
     do: {:ok, %AST.Literal{value: text}}

--- a/test/compiler_test.exs
+++ b/test/compiler_test.exs
@@ -106,6 +106,24 @@ defmodule Surface.CompilerTest do
            ] = nodes
   end
 
+  test "ignore embedded elixir" do
+    code = """
+    <br>
+    <%= foo = :bar %>
+    <hr>
+    """
+
+    nodes = Surface.Compiler.compile(code, 1, __ENV__)
+
+    assert [
+             %Surface.AST.VoidTag{element: "br"},
+             %Surface.AST.Literal{value: "\n"},
+             %Surface.AST.Literal{value: "\n"},
+             %Surface.AST.VoidTag{element: "hr"},
+             %Surface.AST.Literal{value: "\n"}
+           ] = nodes
+  end
+
   test "component with expression" do
     code = """
     <Button label={{ @label }}/>


### PR DESCRIPTION
In the process of converting LiveView components and views into Surface, developers can run into somewhat confusing parsing errors if they fail to convert their Embedded Elixir `<%= foo = :bar %>` into the Surface Elixir interpolation syntax `{{ foo = :bar }}`.

I bumped into this a couple of times and the "missing closing tag foo" errors had me initially scratching my head until I realized that the parser died due to some embedded Elixir that I had not converted to `{{ }}`.  My first thought was to raise a more descriptive error but then realized that just printing the code to the screen might be better - it should be fairly obvious at that point to the developer what to change.

In any case, thanks for this library, love it!