### PR TITLE
New notation for constructs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,20 +18,20 @@ jobs:
             otp: 21.3.8.17
             warnings-as-errors: true
           - elixir: 1.11.4
-            otp: 23.2
+            otp: 23.3.4
+            warnings-as-errors: true
+          - elixir: 1.12.0
+            otp: 24.0
             check_formatted: true
             warnings-as-errors: true
-          - elixir: 1.12.0-rc.0
-            otp: 24.0-rc3
     env:
       MIX_ENV: test
     steps:
-      - uses: actions/checkout@v2.3.2
-      - uses: actions/setup-elixir@v1.5.0
+      - uses: actions/checkout@v2
+      - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
-          experimental-otp: true
       - name: Install packages
         run: |
           sudo apt-get install -y -qq inotify-tools

--- a/lib/surface/api.ex
+++ b/lib/surface/api.ex
@@ -469,9 +469,7 @@ defmodule Surface.API do
   defp validate_opt(_func, _name, _type, _opts, :values, value, _line, _env)
        when not is_list(value) and not is_struct(value, Range) do
     {:error,
-     "invalid value for option :values. Expected a list of values or a Range, got: #{
-       inspect(value)
-     }"}
+     "invalid value for option :values. Expected a list of values or a Range, got: #{inspect(value)}"}
   end
 
   defp validate_opt(:prop, _name, _type, _opts, :accumulate, value, _line, _env)
@@ -544,7 +542,7 @@ defmodule Surface.API do
           fn _ -> line end
         )
 
-      not accumulate? and not is_nil(values!) and not (default in values!) ->
+      not accumulate? and not is_nil(values!) and default not in values! ->
         IOHelper.warn(
           """
           #{type} `#{name}` default value `#{inspect(default)}` does not exist in `:values!`

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -243,7 +243,7 @@ defmodule Surface.Compiler do
   defp node_type({name, _, _, _}) when name in @void_elements, do: :void_tag
   defp node_type({_, _, _, _}), do: :tag
   defp node_type({:interpolation, _, _}), do: :interpolation
-  defp node_type({:comment, _}), do: :comment
+  defp node_type({:comment, _, _}), do: :comment
   defp node_type(_), do: :text
 
   defp process_directives(%{directives: directives} = node) do
@@ -256,7 +256,10 @@ defmodule Surface.Compiler do
 
   defp process_directives(node), do: node
 
-  defp convert_node_to_ast(:comment, _, _), do: :ignore
+  defp convert_node_to_ast(:comment, {_, _comment, %{visibility: :private}}, _), do: :ignore
+
+  defp convert_node_to_ast(:comment, {_, comment, %{visibility: :public}}, _),
+    do: {:ok, %AST.Literal{value: comment}}
 
   defp convert_node_to_ast(:text, text, _),
     do: {:ok, %AST.Literal{value: text}}

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -242,7 +242,7 @@ defmodule Surface.Compiler do
   defp node_type({<<first, _::binary>>, _, _, _}) when first in ?A..?Z, do: :component
   defp node_type({name, _, _, _}) when name in @void_elements, do: :void_tag
   defp node_type({_, _, _, _}), do: :tag
-  defp node_type({:interpolation, _, _}), do: :interpolation
+  defp node_type({:expr, _, _}), do: :interpolation
   defp node_type({:comment, _, _}), do: :comment
   defp node_type(_), do: :text
 

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -772,9 +772,7 @@ defmodule Surface.Compiler do
 
   defp validate_tag_children([%AST.Template{name: name} | _]) do
     {:error,
-     "templates are only allowed as children elements of components, but found template for #{
-       name
-     }"}
+     "templates are only allowed as children elements of components, but found template for #{name}"}
   end
 
   defp validate_tag_children([_ | nodes]), do: validate_tag_children(nodes)

--- a/lib/surface/compiler/converter.ex
+++ b/lib/surface/compiler/converter.ex
@@ -1,7 +1,7 @@
 defmodule Surface.Compiler.Converter do
   @moduledoc false
 
-  @type subject :: :interpolation | :tag_name | :attr_name
+  @type subject :: :expr | :tag_name | :attr_name
 
   @callback convert(subject :: subject(), text :: binary(), state :: map(), opts :: keyword()) ::
               binary()
@@ -127,17 +127,13 @@ defmodule Surface.Compiler.Converter do
     extract_meta(node, acc)
   end
 
-  defp extract_meta({:interpolation, _value, meta}, acc) do
-    [{:interpolation, meta} | acc]
+  defp extract_meta({:expr, _value, meta}, acc) do
+    [{:expr, meta} | acc]
   end
 
   defp extract_meta({attr, value, meta}, acc) when is_binary(attr) do
     acc = extract_meta(value, acc)
     [{:attr_name, meta} | acc]
-  end
-
-  defp extract_meta({:expr, _value, meta}, acc) do
-    [{:interpolation, meta} | acc]
   end
 
   defp extract_meta({:tag_open, _name, attrs, meta}, acc) do

--- a/lib/surface/compiler/converter_0_5.ex
+++ b/lib/surface/compiler/converter_0_5.ex
@@ -3,7 +3,7 @@ defmodule Surface.Compiler.Converter_0_5 do
 
   @behaviour Surface.Compiler.Converter
 
-  def convert(:interpolation, text, _state, _opts) do
+  def convert(:expr, text, _state, _opts) do
     if String.starts_with?(text, "{") and String.ends_with?(text, "}") do
       String.slice(text, 1..-2)
     else

--- a/lib/surface/compiler/parser.ex
+++ b/lib/surface/compiler/parser.ex
@@ -69,8 +69,8 @@ defmodule Surface.Compiler.Parser do
     handle_token(rest, buffers, state)
   end
 
-  defp handle_token([{:comment, comment} | rest], buffers, state) do
-    buffers = push_node_to_current_buffer({:comment, comment}, buffers)
+  defp handle_token([{:comment, comment, meta} | rest], buffers, state) do
+    buffers = push_node_to_current_buffer({:comment, comment, meta}, buffers)
     handle_token(rest, buffers, state)
   end
 

--- a/lib/surface/compiler/parser.ex
+++ b/lib/surface/compiler/parser.ex
@@ -78,7 +78,11 @@ defmodule Surface.Compiler.Parser do
   # should be moved to the tokenizer or not. We could also hold the expression
   # directly instead of using the :root attribute.
   for block <- @blocks do
-    defp handle_token([{:interpolation, "#" <> unquote(block) <> " " <> expr, meta} | rest], buffers, state) do
+    defp handle_token(
+           [{:interpolation, "#" <> unquote(block) <> " " <> expr, meta} | rest],
+           buffers,
+           state
+         ) do
       expr_meta = %{meta | column: meta.column + String.length(unquote(block)) + 2}
       attrs = [{:root, {:expr, expr, expr_meta}, expr_meta}]
       handle_token([{:block_open, unquote(block), attrs, meta} | rest], buffers, state)
@@ -169,7 +173,11 @@ defmodule Surface.Compiler.Parser do
   end
 
   # If there's a previous sub-block defined. Close it.
-  defp close_sub_block(_token, buffers, %{tags: [{:block_open, name, attrs, meta} | tags]} = state)
+  defp close_sub_block(
+         _token,
+         buffers,
+         %{tags: [{:block_open, name, attrs, meta} | tags]} = state
+       )
        when name in @sub_blocks do
     # pop the current buffer and use it as children for the sub-block node
     [buffer | buffers] = buffers
@@ -284,11 +292,17 @@ defmodule Surface.Compiler.Parser do
     %{state | tags: [token | state.tags]}
   end
 
-  defp pop_matching_tag(%{tags: [{:tag_open, tag_name, _, _} = tag | tags]} = state, {:tag_close, tag_name, _}) do
+  defp pop_matching_tag(
+         %{tags: [{:tag_open, tag_name, _, _} = tag | tags]} = state,
+         {:tag_close, tag_name, _}
+       ) do
     {tag, %{state | tags: tags}}
   end
 
-  defp pop_matching_tag(%{tags: [{:block_open, name, _, _} = tag | tags]} = state, {:block_close, name, _}) do
+  defp pop_matching_tag(
+         %{tags: [{:block_open, name, _, _} = tag | tags]} = state,
+         {:block_close, name, _}
+       ) do
     {tag, %{state | tags: tags}}
   end
 

--- a/lib/surface/compiler/parser.ex
+++ b/lib/surface/compiler/parser.ex
@@ -21,16 +21,26 @@ defmodule Surface.Compiler.Parser do
     "source"
   ]
 
+  @blocks [
+    "if",
+    "unless",
+    "for",
+    "case",
+    "else",
+    "elseif",
+    "match"
+  ]
+
   @sub_blocks [
-    "#else",
-    "#elseif",
-    "#match"
+    "else",
+    "elseif",
+    "match"
   ]
 
   @sub_blocks_valid_parents %{
-    "#else" => ["#if", "#for"],
-    "#elseif" => ["#if"],
-    "#match" => ["#case"]
+    "else" => ["if", "for"],
+    "elseif" => ["if"],
+    "match" => ["case"]
   }
 
   def parse!(code, opts \\ []) do
@@ -47,9 +57,9 @@ defmodule Surface.Compiler.Parser do
     Enum.reverse(buffer)
   end
 
-  defp handle_token([], _buffers, %{tags: [{:tag_open, tag_name, _attrs, meta} | _]}) do
+  defp handle_token([], _buffers, %{tags: [{_, _name, _attrs, meta} = node | _]}) do
     raise parse_error(
-            "expected closing tag for <#{tag_name}> defined on line #{meta.line}, got EOF",
+            "expected closing node for #{format_node(node)} defined on line #{meta.line}, got EOF",
             meta
           )
   end
@@ -64,17 +74,36 @@ defmodule Surface.Compiler.Parser do
     handle_token(rest, buffers, state)
   end
 
+  # This is mostly a temporary solution until we decide whether this logic
+  # should be moved to the tokenizer or not. We could also hold the expression
+  # directly instead of using the :root attribute.
+  for block <- @blocks do
+    defp handle_token([{:interpolation, "#" <> unquote(block) <> " " <> expr, meta} | rest], buffers, state) do
+      expr_meta = %{meta | column: meta.column + String.length(unquote(block)) + 2}
+      attrs = [{:root, {:expr, expr, expr_meta}, expr_meta}]
+      handle_token([{:block_open, unquote(block), attrs, meta} | rest], buffers, state)
+    end
+
+    defp handle_token([{:interpolation, "#" <> unquote(block), meta} | rest], buffers, state) do
+      handle_token([{:block_open, unquote(block), [], meta} | rest], buffers, state)
+    end
+
+    defp handle_token([{:interpolation, "/" <> unquote(block), meta} | rest], buffers, state) do
+      handle_token([{:block_close, unquote(block), meta} | rest], buffers, state)
+    end
+  end
+
   defp handle_token([{:interpolation, expr, meta} | rest], buffers, state) do
     buffers = push_node_to_current_buffer({:interpolation, expr, to_meta(meta)}, buffers)
     handle_token(rest, buffers, state)
   end
 
-  defp handle_token([{:tag_open, name, attrs, meta} = token | rest], buffers, state)
+  defp handle_token([{:block_open, name, attrs, meta} = token | rest], buffers, state)
        when name in @sub_blocks do
     {buffers, state} = close_sub_block(token, buffers, state)
 
     # push the current sub-block token to state
-    state = push_tag(state, {:tag_open, name, attrs, meta})
+    state = push_tag(state, {:block_open, name, attrs, meta})
 
     # create a new buffer for the current sub-block
     buffers = [[] | buffers]
@@ -102,18 +131,25 @@ defmodule Surface.Compiler.Parser do
     handle_token(rest, buffers, state)
   end
 
+  defp handle_token([{:block_open, _name, _attrs, _meta} = token | rest], buffers, state) do
+    state = push_tag(state, token)
+    # create a new buffer for the node
+    buffers = [[] | buffers]
+    handle_token(rest, buffers, state)
+  end
+
   defp handle_token(
-         [{:tag_close, _name, _meta} = token | _] = tokens,
+         [{:block_close, _name, _meta} = token | _] = tokens,
          buffers,
-         %{tags: [{:tag_open, name, _, _} | _]} = state
+         %{tags: [{:block_open, name, _, _} | _]} = state
        )
        when name in @sub_blocks do
     {buffers, state} = close_sub_block(token, buffers, state)
     handle_token(tokens, buffers, state)
   end
 
-  defp handle_token([{:tag_close, name, _meta} | rest], buffers, state) do
-    {{:tag_open, _name, attrs, meta}, state} = pop_matching_tag(state, name)
+  defp handle_token([{:tag_close, name, _meta} = token | rest], buffers, state) do
+    {{:tag_open, _name, attrs, meta}, state} = pop_matching_tag(state, token)
 
     # pop the current buffer and use it as children for the node
     [buffer | buffers] = buffers
@@ -122,12 +158,22 @@ defmodule Surface.Compiler.Parser do
     handle_token(rest, buffers, state)
   end
 
-  # IF there's a previous sub-block defined. Close it.
-  defp close_sub_block(_token, buffers, %{tags: [{:tag_open, name, attrs, meta} | tags]} = state)
+  defp handle_token([{:block_close, name, _meta} = token | rest], buffers, state) do
+    {{:block_open, _name, attrs, meta}, state} = pop_matching_tag(state, token)
+
+    # pop the current buffer and use it as children for the node
+    [buffer | buffers] = buffers
+    node = {:block, name, transtate_attrs(attrs), Enum.reverse(buffer), to_meta(meta)}
+    buffers = push_node_to_current_buffer(node, buffers)
+    handle_token(rest, buffers, state)
+  end
+
+  # If there's a previous sub-block defined. Close it.
+  defp close_sub_block(_token, buffers, %{tags: [{:block_open, name, attrs, meta} | tags]} = state)
        when name in @sub_blocks do
     # pop the current buffer and use it as children for the sub-block node
     [buffer | buffers] = buffers
-    node = {name, transtate_attrs(attrs), Enum.reverse(buffer), to_meta(meta)}
+    node = {:block, name, transtate_attrs(attrs), Enum.reverse(buffer), to_meta(meta)}
     buffers = push_node_to_current_buffer(node, buffers)
     state = %{state | tags: tags}
 
@@ -136,12 +182,12 @@ defmodule Surface.Compiler.Parser do
 
   # If there's no previous sub-block defined. Create a :default sub-block,
   # move the buffer there and close it.
-  defp close_sub_block(token, buffers, %{tags: [{:tag_open, name, attrs, meta} | tags]} = state) do
+  defp close_sub_block(token, buffers, %{tags: [{:block_open, name, attrs, meta} | tags]} = state) do
     validate_sub_block!(token, name)
 
     # pop the current buffer and use it as children for the :default sub-block node
     [buffer | buffers] = buffers
-    node = {:default, [], Enum.reverse(buffer), %{}}
+    node = {:block, :default, [], Enum.reverse(buffer), %{}}
 
     # create a new buffer for the parent node to replace the one that was popped
     buffers = [[] | buffers]
@@ -149,37 +195,34 @@ defmodule Surface.Compiler.Parser do
 
     # push back the parent token to state
     meta = Map.put(meta, :has_sub_blocks?, true)
-    state = %{state | tags: [{:tag_open, name, attrs, meta} | tags]}
+    state = %{state | tags: [{:block_open, name, attrs, meta} | tags]}
 
     {buffers, state}
   end
 
-  defp close_sub_block({:tag_open, name, _attrs, meta}, _buffers, _state) do
-    valid_parents_str = message_for_invalid_sub_block_parent(name)
-
-    raise parse_error("no valid parent node defined for <#{name}>. #{valid_parents_str}", meta)
+  # If there's no parent node
+  defp close_sub_block({:block_open, name, _attrs, meta}, _buffers, _state) do
+    message = message_for_invalid_sub_block_parent(name)
+    raise parse_error(message, meta)
   end
 
-  defp validate_sub_block!({:tag_open, name, _attrs, meta}, parent_name) do
-    valid_parents_str = message_for_invalid_sub_block_parent(name)
-
+  defp validate_sub_block!({:block_open, name, _attrs, meta}, parent_name) do
     if parent_name not in @sub_blocks_valid_parents[name] do
-      raise parse_error(
-              "cannot use <#{name}> inside <#{parent_name}>. #{valid_parents_str}",
-              meta
-            )
+      message = message_for_invalid_sub_block_parent(name)
+      raise parse_error(message, meta)
     end
   end
 
   defp message_for_invalid_sub_block_parent(name) do
     valid_parents = @sub_blocks_valid_parents[name]
-    valid_parents_tags = Enum.map(valid_parents, &"<#{&1}>")
+    valid_parents_tags = Enum.map(valid_parents, &"{##{&1}}")
 
-    Helpers.list_to_string(
-      "The <#{name}> construct can only be used inside a",
-      "Possible parents are",
-      valid_parents_tags
-    )
+    "no valid parent node defined for {##{name}}. " <>
+      Helpers.list_to_string(
+        "The {##{name}} construct can only be used inside a",
+        "Possible parents are",
+        valid_parents_tags
+      )
   end
 
   defp to_meta(meta) do
@@ -241,13 +284,18 @@ defmodule Surface.Compiler.Parser do
     %{state | tags: [token | state.tags]}
   end
 
-  defp pop_matching_tag(%{tags: [{:tag_open, tag_name, _, _} = tag | tags]} = state, tag_name) do
+  defp pop_matching_tag(%{tags: [{:tag_open, tag_name, _, _} = tag | tags]} = state, {:tag_close, tag_name, _}) do
     {tag, %{state | tags: tags}}
   end
 
-  defp pop_matching_tag(%{tags: [{:tag_open, tag_name, _attrs, meta} | _]}, closed_node_name) do
+  defp pop_matching_tag(%{tags: [{:block_open, name, _, _} = tag | tags]} = state, {:block_close, name, _}) do
+    {tag, %{state | tags: tags}}
+  end
+
+  defp pop_matching_tag(%{tags: [{_, _, _, meta} = token_open | _]}, token_close) do
     message = """
-    expected closing tag for <#{tag_name}> defined on line #{meta.line}, got </#{closed_node_name}>\
+    expected closing node for #{format_node(token_open)} defined on line #{meta.line}, \
+    got #{format_node(token_close)}\
     """
 
     raise parse_error(message, meta)
@@ -261,4 +309,9 @@ defmodule Surface.Compiler.Parser do
       column: meta.column
     }
   end
+
+  defp format_node({:tag_open, name, _attrs, _meta}), do: "<#{name}>"
+  defp format_node({:tag_close, name, _meta}), do: "</#{name}>"
+  defp format_node({:block_open, name, _attrs, _meta}), do: "{##{name}}"
+  defp format_node({:block_close, name, _meta}), do: "{/#{name}}"
 end

--- a/lib/surface/compiler/parser.ex
+++ b/lib/surface/compiler/parser.ex
@@ -170,7 +170,7 @@ defmodule Surface.Compiler.Parser do
   end
 
   defp handle_token([{:block_close, name, meta} | _], _buffers, _state) do
-    blocks = Helpers.list_to_string("block is", "blocks are", @blocks ++ @sub_blocks)
+    blocks = Helpers.list_to_string("block is", "blocks are", @blocks)
     raise parse_error("unknown `{/#{name}}` block. Available #{blocks}", meta)
   end
 

--- a/lib/surface/compiler/parser.ex
+++ b/lib/surface/compiler/parser.ex
@@ -71,8 +71,8 @@ defmodule Surface.Compiler.Parser do
     handle_token(rest, buffers, state)
   end
 
-  defp handle_token([{:interpolation, expr, meta} | rest], buffers, state) do
-    buffers = push_node_to_current_buffer({:interpolation, expr, to_meta(meta)}, buffers)
+  defp handle_token([{:expr, expr, meta} | rest], buffers, state) do
+    buffers = push_node_to_current_buffer({:expr, expr, to_meta(meta)}, buffers)
     handle_token(rest, buffers, state)
   end
 

--- a/lib/surface/compiler/tokenizer.ex
+++ b/lib/surface/compiler/tokenizer.ex
@@ -114,7 +114,7 @@ defmodule Surface.Compiler.Tokenizer do
   end
 
   # handle_tagged_expression
-  defp handle_tagged_expression(text, line, column, acc, state)  do
+  defp handle_tagged_expression(text, line, column, acc, state) do
     {text, line, column} = ignore_spaces(text, line, column, state)
 
     case handle_interpolation(text, line, column, [], state) do

--- a/lib/surface/constructs/for.ex
+++ b/lib/surface/constructs/for.ex
@@ -52,7 +52,7 @@ defmodule Surface.Constructs.For do
     using <For> to wrap elements in a for expression has been deprecated and will be removed in \
     future versions.
 
-    Hint: replace `<For>` with `<#for>`
+    Hint: replace `<For>` with `{#for}`
     """
 
     IOHelper.warn(message, node.meta.caller, fn _ -> node.meta.line end)

--- a/lib/surface/constructs/if.ex
+++ b/lib/surface/constructs/if.ex
@@ -52,7 +52,7 @@ defmodule Surface.Constructs.If do
     using <If> to wrap elements in an if expression has been deprecated and will be removed in \
     future versions.
 
-    Hint: replace `<If>` with `<#if>`
+    Hint: replace `<If>` with `{#if}`
     """
 
     IOHelper.warn(message, node.meta.caller, fn _ -> node.meta.line end)

--- a/lib/surface/type_handler/list.ex
+++ b/lib/surface/type_handler/list.ex
@@ -35,9 +35,7 @@ defmodule Surface.TypeHandler.List do
           Enum.to_list(value)
 
         value ->
-          raise "invalid value for property \"#{unquote(name)}\". Expected a :list, got: #{
-                  inspect(value)
-                }"
+          raise "invalid value for property \"#{unquote(name)}\". Expected a :list, got: #{inspect(value)}"
       end
     end
   end

--- a/test/compiler/tokenizer_test.exs
+++ b/test/compiler/tokenizer_test.exs
@@ -274,50 +274,57 @@ defmodule Surface.Compiler.TokenizerTest do
       tokens = tokenize!("{=@class}")
 
       assert [
-        {:tagged_expr, "=", {:expr, "@class", %{line: 1, column: 3, line_end: 1, column_end: 9}},
-          %{line: 1, column: 2, line_end: 1, column_end: 3}}
-      ] = tokens
+               {:tagged_expr, "=",
+                {:expr, "@class", %{line: 1, column: 3, line_end: 1, column_end: 9}},
+                %{line: 1, column: 2, line_end: 1, column_end: 3}}
+             ] = tokens
 
       tokens = tokenize!("{~@class}")
 
       assert [
-        {:tagged_expr, "~", {:expr, "@class", %{line: 1, column: 3, line_end: 1, column_end: 9}},
-          %{line: 1, column: 2, line_end: 1, column_end: 3}}
-      ] = tokens
+               {:tagged_expr, "~",
+                {:expr, "@class", %{line: 1, column: 3, line_end: 1, column_end: 9}},
+                %{line: 1, column: 2, line_end: 1, column_end: 3}}
+             ] = tokens
 
       tokens = tokenize!("{%@class}")
 
       assert [
-        {:tagged_expr, "%", {:expr, "@class", %{line: 1, column: 3, line_end: 1, column_end: 9}},
-          %{line: 1, column: 2, line_end: 1, column_end: 3}}
-      ] = tokens
+               {:tagged_expr, "%",
+                {:expr, "@class", %{line: 1, column: 3, line_end: 1, column_end: 9}},
+                %{line: 1, column: 2, line_end: 1, column_end: 3}}
+             ] = tokens
 
       tokens = tokenize!("{$@class}")
 
       assert [
-        {:tagged_expr, "$", {:expr, "@class", %{line: 1, column: 3, line_end: 1, column_end: 9}},
-          %{line: 1, column: 2, line_end: 1, column_end: 3}}
-      ] = tokens
+               {:tagged_expr, "$",
+                {:expr, "@class", %{line: 1, column: 3, line_end: 1, column_end: 9}},
+                %{line: 1, column: 2, line_end: 1, column_end: 3}}
+             ] = tokens
 
       tokens = tokenize!("{...@attrs}")
 
       assert [
-        {:tagged_expr, "...", {:expr, "@attrs", %{line: 1, column: 5, line_end: 1, column_end: 11}},
-          %{line: 1, column: 2, line_end: 1, column_end: 5}}
-      ] = tokens
+               {:tagged_expr, "...",
+                {:expr, "@attrs", %{line: 1, column: 5, line_end: 1, column_end: 11}},
+                %{line: 1, column: 2, line_end: 1, column_end: 5}}
+             ] = tokens
     end
 
     test "with spaces between the marker and the expression" do
-      tokens = tokenize!("""
-      {=
-        @class
-      }\
-      """)
+      tokens =
+        tokenize!("""
+        {=
+          @class
+        }\
+        """)
 
       assert [
-        {:tagged_expr, "=", {:expr, "@class\n", %{line: 2, column: 3, line_end: 3, column_end: 1}},
-          %{line: 1, column: 2, line_end: 1, column_end: 3}}
-      ] = tokens
+               {:tagged_expr, "=",
+                {:expr, "@class\n", %{line: 2, column: 3, line_end: 3, column_end: 1}},
+                %{line: 1, column: 2, line_end: 1, column_end: 3}}
+             ] = tokens
     end
   end
 

--- a/test/compiler/tokenizer_test.exs
+++ b/test/compiler/tokenizer_test.exs
@@ -128,7 +128,7 @@ defmodule Surface.Compiler.TokenizerTest do
              ]
     end
 
-    test "raise on incomplete expression (EOF)" do
+    test "raise on incomplete root expression (EOF)" do
       message = "nofile:5:7: expected closing `}` for expression begining at line: 2, column: 4"
 
       assert_raise ParseError, message, fn ->
@@ -185,6 +185,23 @@ defmodule Surface.Compiler.TokenizerTest do
         """)
       end
     end
+
+    test "raise on missing expected closing brace (EOF)" do
+      message = """
+      nofile:5:7: expected closing `}` for opening block expression `{#if` \
+      begining at line: 2, column: 4\
+      """
+
+      assert_raise ParseError, message, fn ->
+        tokenize!("""
+        <div>
+          {#if true
+            <br>
+          {/if}
+        </div>\
+        """)
+      end
+    end
   end
 
   describe "closing block" do
@@ -201,6 +218,18 @@ defmodule Surface.Compiler.TokenizerTest do
         tokenize!("""
         <div>
           {/}\
+        """)
+      end
+    end
+
+    test "raise on missing expected closing brace (EOF)" do
+      assert_raise ParseError, "nofile:4:7: expected closing `}`", fn ->
+        tokenize!("""
+        <div>
+          {#if true}
+            <br>
+          {/if
+        </div>\
         """)
       end
     end

--- a/test/compiler/tokenizer_test.exs
+++ b/test/compiler/tokenizer_test.exs
@@ -269,6 +269,58 @@ defmodule Surface.Compiler.TokenizerTest do
     end
   end
 
+  describe "tagged expressions with markers `=`, `...`, `~`, `%`, `$`)" do
+    test "represented as {:tagged_expr, marker, value, meta}" do
+      tokens = tokenize!("{=@class}")
+
+      assert [
+        {:tagged_expr, "=", {:expr, "@class", %{line: 1, column: 3, line_end: 1, column_end: 9}},
+          %{line: 1, column: 2, line_end: 1, column_end: 3}}
+      ] = tokens
+
+      tokens = tokenize!("{~@class}")
+
+      assert [
+        {:tagged_expr, "~", {:expr, "@class", %{line: 1, column: 3, line_end: 1, column_end: 9}},
+          %{line: 1, column: 2, line_end: 1, column_end: 3}}
+      ] = tokens
+
+      tokens = tokenize!("{%@class}")
+
+      assert [
+        {:tagged_expr, "%", {:expr, "@class", %{line: 1, column: 3, line_end: 1, column_end: 9}},
+          %{line: 1, column: 2, line_end: 1, column_end: 3}}
+      ] = tokens
+
+      tokens = tokenize!("{$@class}")
+
+      assert [
+        {:tagged_expr, "$", {:expr, "@class", %{line: 1, column: 3, line_end: 1, column_end: 9}},
+          %{line: 1, column: 2, line_end: 1, column_end: 3}}
+      ] = tokens
+
+      tokens = tokenize!("{...@attrs}")
+
+      assert [
+        {:tagged_expr, "...", {:expr, "@attrs", %{line: 1, column: 5, line_end: 1, column_end: 11}},
+          %{line: 1, column: 2, line_end: 1, column_end: 5}}
+      ] = tokens
+    end
+
+    test "with spaces between the marker and the expression" do
+      tokens = tokenize!("""
+      {=
+        @class
+      }\
+      """)
+
+      assert [
+        {:tagged_expr, "=", {:expr, "@class\n", %{line: 2, column: 3, line_end: 3, column_end: 1}},
+          %{line: 1, column: 2, line_end: 1, column_end: 3}}
+      ] = tokens
+    end
+  end
+
   describe "attributes" do
     test "represented as a list of {name, tuple | nil}, where tuple is the {type, value}" do
       attrs = tokenize_attrs(~S(<div class="panel" style={@style} hidden selected=true>))

--- a/test/compiler_test.exs
+++ b/test/compiler_test.exs
@@ -88,10 +88,29 @@ defmodule Surface.CompilerTest do
     end
   end
 
-  test "ignore comments" do
+  test "show public comments" do
     code = """
     <br>
     <!-- comment -->
+    <hr>
+    """
+
+    nodes = Surface.Compiler.compile(code, 1, __ENV__)
+
+    assert [
+             %Surface.AST.VoidTag{element: "br"},
+             %Surface.AST.Literal{value: "\n"},
+             %Surface.AST.Literal{value: "<!-- comment -->"},
+             %Surface.AST.Literal{value: "\n"},
+             %Surface.AST.VoidTag{element: "hr"},
+             %Surface.AST.Literal{value: "\n"}
+           ] = nodes
+  end
+
+  test "hide private comments" do
+    code = """
+    <br>
+    {!-- comment --}
     <hr>
     """
 

--- a/test/compiler_test.exs
+++ b/test/compiler_test.exs
@@ -524,23 +524,23 @@ defmodule Surface.CompilerTest do
     test "#if/#elseif/#else" do
       code = """
       <div>
-        <#if condition={false}>
+        {#if false}
           IF
-        <#elseif condition={false}>
+        {#elseif false}
           ELSEIF FALSE
-        <#elseif condition={true}>
+        {#elseif true}
           BEFORE
-          <#if condition={false}>
+          {#if false}
             NESTED IF
-          <#elseif condition={true}>
+          {#elseif true}
             NESTED ELSEIF TRUE
-          <#else>
+          {#else}
             NESTED ELSE
-          </#if>
+          {/if}
           AFTER
-        <#else>
+        {#else}
           ELSE
-        </#if>
+        {/if}
       </div>
       """
 
@@ -606,9 +606,9 @@ defmodule Surface.CompilerTest do
   test "#unless" do
     code = """
     <div>
-      <#unless condition={false}>
+      {#unless false}
         UNLESS
-      </#unless>
+      {/unless}
     </div>
     """
 

--- a/test/constructs/for_test.exs
+++ b/test/constructs/for_test.exs
@@ -46,7 +46,7 @@ defmodule Surface.Constructs.ForTest do
            using <For> to wrap elements in a for expression has been deprecated and will be removed in \
            future versions.
 
-           Hint: replace `<For>` with `<#for>`
+           Hint: replace `<For>` with `{#for}`
 
              code:1:\
            """
@@ -62,7 +62,7 @@ defmodule Surface.Constructs.ForTest do
         """
       end
 
-    message = ~S(code:2:12: expected closing tag for <span> defined on line 2, got </For>)
+    message = ~S(code:2:12: expected closing node for <span> defined on line 2, got </For>)
 
     assert_raise(Surface.Compiler.ParseError, message, fn ->
       compile_surface(code)
@@ -92,20 +92,20 @@ defmodule Surface.Constructs.ForTest do
       html =
         render_surface do
           ~H"""
-          <#for each={fruit <- ["apples", "bananas", "oranges"]}>
-          <span>The inner content {fruit}</span>
-          <span>with multiple tags</span>
-          </#for>
+          {#for fruit <- ["apples", "bananas", "oranges"]}
+            <span>The inner content {fruit}</span>
+            <span>with multiple tags</span>
+          {/for}
           """
         end
 
       assert html =~ """
-             <span>The inner content apples</span>
-             <span>with multiple tags</span>
-             <span>The inner content bananas</span>
-             <span>with multiple tags</span>
-             <span>The inner content oranges</span>
-             <span>with multiple tags</span>
+               <span>The inner content apples</span>
+               <span>with multiple tags</span>
+               <span>The inner content bananas</span>
+               <span>with multiple tags</span>
+               <span>The inner content oranges</span>
+               <span>with multiple tags</span>
              """
     end
 
@@ -115,15 +115,15 @@ defmodule Surface.Constructs.ForTest do
       html =
         render_surface do
           ~H"""
-          <#for each={x <- @list1, y <- @list2, x in @range, y in @range}>
-          <span>x: {x}, y: {y}</span>
-          </#for>
+          {#for x <- @list1, y <- @list2, x in @range, y in @range}
+            <span>x: {x}, y: {y}</span>
+          {/for}
           """
         end
 
       assert html =~ """
-             <span>x: 1, y: 2</span>
-             <span>x: 1, y: 3</span>
+               <span>x: 1, y: 2</span>
+               <span>x: 1, y: 3</span>
              """
     end
 
@@ -131,16 +131,16 @@ defmodule Surface.Constructs.ForTest do
       html =
         render_surface do
           ~H"""
-          <#for each={fruit <- ["apples", "bananas", "oranges"]}>
-          <SomeComponent content={fruit} />
-          </#for>
+          {#for fruit <- ["apples", "bananas", "oranges"]}
+            <SomeComponent content={fruit} />
+          {/for}
           """
         end
 
       assert html =~ """
-             <span>apples</span>
-             <span>bananas</span>
-             <span>oranges</span>
+               <span>apples</span>
+               <span>bananas</span>
+               <span>oranges</span>
              """
     end
 
@@ -148,13 +148,13 @@ defmodule Surface.Constructs.ForTest do
       code =
         quote do
           ~H"""
-          <#for each={fruit <- ["apples", "bananas", "oranges"]}>
+          {#for fruit <- ["apples", "bananas", "oranges"]}
             <span>The inner content
-          </#for>
+          {/for}
           """
         end
 
-      message = ~S(code:2:14: expected closing tag for <span> defined on line 2, got </#for>)
+      message = ~S(code:2:14: expected closing node for <span> defined on line 2, got {/for})
 
       assert_raise(Surface.Compiler.ParseError, message, fn ->
         compile_surface(code)
@@ -165,10 +165,10 @@ defmodule Surface.Constructs.ForTest do
       code =
         quote do
           ~H"""
-          <#for each={fruit <- ["apples", "bananas", "oranges"]}>
+          {#for fruit <- ["apples", "bananas", "oranges"]}
             <ListProp
               prop="some string" />
-          </#for>
+          {/for}
           """
         end
 
@@ -186,23 +186,23 @@ defmodule Surface.Constructs.ForTest do
       html =
         render_surface do
           ~H"""
-          <#for each={fruit <- ["apples", "bananas", "oranges"]}>
-          <span>The inner content {fruit}</span>
-          <span>with multiple tags</span>
-          <#else>
-          <span>The else content</span>
-          <span>with multiple tags</span>
-          </#for>
+          {#for fruit <- ["apples", "bananas", "oranges"]}
+            <span>The inner content {fruit}</span>
+            <span>with multiple tags</span>
+          {#else}
+            <span>The else content</span>
+            <span>with multiple tags</span>
+          {/for}
           """
         end
 
       assert html =~ """
-             <span>The inner content apples</span>
-             <span>with multiple tags</span>
-             <span>The inner content bananas</span>
-             <span>with multiple tags</span>
-             <span>The inner content oranges</span>
-             <span>with multiple tags</span>
+               <span>The inner content apples</span>
+               <span>with multiple tags</span>
+               <span>The inner content bananas</span>
+               <span>with multiple tags</span>
+               <span>The inner content oranges</span>
+               <span>with multiple tags</span>
              """
     end
 
@@ -210,19 +210,19 @@ defmodule Surface.Constructs.ForTest do
       html =
         render_surface do
           ~H"""
-          <#for each={fruit <- ["apples", "bananas", "oranges"]}>
-          <SomeComponent content={fruit} />
-          <#else>
-          <span>The else content</span>
-          <span>with multiple tags</span>
-          </#for>
+          {#for fruit <- ["apples", "bananas", "oranges"]}
+            <SomeComponent content={fruit} />
+          {#else}
+            <span>The else content</span>
+            <span>with multiple tags</span>
+          {/for}
           """
         end
 
       assert html =~ """
-             <span>apples</span>
-             <span>bananas</span>
-             <span>oranges</span>
+               <span>apples</span>
+               <span>bananas</span>
+               <span>oranges</span>
              """
     end
 
@@ -233,23 +233,23 @@ defmodule Surface.Constructs.ForTest do
       html =
         render_surface do
           ~H"""
-          <#for each={fruit <- @fruits}>
-          <span>The inner content {fruit}</span>
-          <span>with multiple tags</span>
-          <#else>
-          <span>The else content</span>
-          <span>with multiple tags</span>
-          </#for>
+          {#for fruit <- @fruits}
+            <span>The inner content {fruit}</span>
+            <span>with multiple tags</span>
+          {#else}
+            <span>The else content</span>
+            <span>with multiple tags</span>
+          {/for}
           """
         end
 
       assert html =~ """
-             <span>The inner content apples</span>
-             <span>with multiple tags</span>
-             <span>The inner content bananas</span>
-             <span>with multiple tags</span>
-             <span>The inner content oranges</span>
-             <span>with multiple tags</span>
+               <span>The inner content apples</span>
+               <span>with multiple tags</span>
+               <span>The inner content bananas</span>
+               <span>with multiple tags</span>
+               <span>The inner content oranges</span>
+               <span>with multiple tags</span>
              """
     end
 
@@ -259,17 +259,17 @@ defmodule Surface.Constructs.ForTest do
       code =
         quote do
           ~H"""
-          <#for each={x <- @list1, y <- @list2, x in @range, y in @range}>
-          <span>x: {x}, y: {y}</span>
-          <#else>
-          <span>The else content</span>
-          <span>with multiple tags</span>
-          </#for>
+          {#for x <- @list1, y <- @list2, x in @range, y in @range}
+            <span>x: {x}, y: {y}</span>
+          {#else}
+            <span>The else content</span>
+            <span>with multiple tags</span>
+          {/for}
           """
         end
 
       message =
-        ~r/code:3: using `<#else>` is only supported when the expression in `<#for>` has a single generator and no filters./
+        ~r/code:3: using `{#else}` is only supported when the expression in `{#for}` has a single generator and no filters./
 
       assert_raise(CompileError, message, fn ->
         compile_surface(code, assigns)
@@ -280,19 +280,19 @@ defmodule Surface.Constructs.ForTest do
       html =
         render_surface do
           ~H"""
-          <#for each={fruit <- []}>
-          <span>The inner content {fruit}</span>
-          <span>with multiple tags</span>
-          <#else>
-          <span>The else content</span>
-          <span>with multiple tags</span>
-          </#for>
+          {#for fruit <- []}
+            <span>The inner content {fruit}</span>
+            <span>with multiple tags</span>
+          {#else}
+            <span>The else content</span>
+            <span>with multiple tags</span>
+          {/for}
           """
         end
 
       assert html =~ """
-             <span>The else content</span>
-             <span>with multiple tags</span>
+               <span>The else content</span>
+               <span>with multiple tags</span>
              """
     end
 
@@ -300,12 +300,12 @@ defmodule Surface.Constructs.ForTest do
       html =
         render_surface do
           ~H"""
-          <#for each={fruit <- []}>
-          <span>The inner content {fruit}</span>
-          <span>with multiple tags</span>
-          <#else>
-          <SomeComponent content="The else content" />
-          </#for>
+          {#for fruit <- []}
+            <span>The inner content {fruit}</span>
+            <span>with multiple tags</span>
+          {#else}
+            <SomeComponent content="The else content" />
+          {/for}
           """
         end
 

--- a/test/constructs/if_test.exs
+++ b/test/constructs/if_test.exs
@@ -46,7 +46,7 @@ defmodule Surface.Constructs.IfTest do
            using <If> to wrap elements in an if expression has been deprecated and will be removed in \
            future versions.
 
-           Hint: replace `<If>` with `<#if>`
+           Hint: replace `<If>` with `{#if}`
 
              code:1:\
            """
@@ -62,7 +62,7 @@ defmodule Surface.Constructs.IfTest do
         """
       end
 
-    message = ~S(code:2:12: expected closing tag for <span> defined on line 2, got </If>)
+    message = ~S(code:2:12: expected closing node for <span> defined on line 2, got </If>)
 
     assert_raise(Surface.Compiler.ParseError, message, fn ->
       capture_io(:standard_error, fn ->
@@ -93,10 +93,10 @@ defmodule Surface.Constructs.IfTest do
       html =
         render_surface do
           ~H"""
-          <#if condition={true}>
+          {#if true}
           <span>The inner content</span>
           <span>with multiple tags</span>
-          </#if>
+          {/if}
           """
         end
 
@@ -110,9 +110,9 @@ defmodule Surface.Constructs.IfTest do
       html =
         render_surface do
           ~H"""
-          <#if condition={true}>
+          {#if true}
             <SomeComponent content="The inner content" />
-          </#if>
+          {/if}
           """
         end
 
@@ -125,13 +125,13 @@ defmodule Surface.Constructs.IfTest do
       code =
         quote do
           ~H"""
-          <#if condition={true}>
+          {#if true}
             <span>The inner content
-          </#if>
+          {/if}
           """
         end
 
-      message = ~S(code:2:14: expected closing tag for <span> defined on line 2, got </#if>)
+      message = ~S(code:2:14: expected closing node for <span> defined on line 2, got {/if})
 
       assert_raise(Surface.Compiler.ParseError, message, fn ->
         compile_surface(code)
@@ -142,9 +142,9 @@ defmodule Surface.Constructs.IfTest do
       code =
         quote do
           ~H"""
-          <#if condition={false}>
+          {#if false}
             <ListProp prop="some string" />
-          </#if>
+          {/if}
           """
         end
 
@@ -162,19 +162,19 @@ defmodule Surface.Constructs.IfTest do
       html =
         render_surface do
           ~H"""
-          <#if condition={true}>
-          <span>The inner content</span>
-          <span>with multiple tags</span>
-          <#else>
-          <span>The else content</span>
-          <span>with multiple tags</span>
-          </#if>
+          {#if true}
+            <span>The inner content</span>
+            <span>with multiple tags</span>
+          {#else}
+            <span>The else content</span>
+            <span>with multiple tags</span>
+          {/if}
           """
         end
 
       assert html =~ """
-             <span>The inner content</span>
-             <span>with multiple tags</span>
+               <span>The inner content</span>
+               <span>with multiple tags</span>
              """
     end
 
@@ -182,19 +182,19 @@ defmodule Surface.Constructs.IfTest do
       html =
         render_surface do
           ~H"""
-          <#if condition={false}>
-          <span>The inner content</span>
-          <span>with multiple tags</span>
-          <#else>
-          <span>The else content</span>
-          <span>with multiple tags</span>
-          </#if>
+          {#if false}
+            <span>The inner content</span>
+            <span>with multiple tags</span>
+          {#else}
+            <span>The else content</span>
+            <span>with multiple tags</span>
+          {/if}
           """
         end
 
       assert html =~ """
-             <span>The else content</span>
-             <span>with multiple tags</span>
+               <span>The else content</span>
+               <span>with multiple tags</span>
              """
     end
 
@@ -202,17 +202,17 @@ defmodule Surface.Constructs.IfTest do
       html =
         render_surface do
           ~H"""
-          <#if condition={false}>
-          <span>The inner content</span>
-          <span>with multiple tags</span>
-          <#else>
+          {#if false}
+            <span>The inner content</span>
+            <span>with multiple tags</span>
+          {#else}
             <SomeComponent content="The else content" />
-          </#if>
+          {/if}
           """
         end
 
       assert html =~ """
-             <span>The else content</span>
+               <span>The else content</span>
              """
     end
   end
@@ -222,13 +222,13 @@ defmodule Surface.Constructs.IfTest do
       html =
         render_surface do
           ~H"""
-          <#if condition={false}>
+          {#if false}
             IF
-          <#elseif condition={true}>
+          {#elseif true}
             ELSEIF TRUE
-          <#else>
+          {#else}
             ELSE
-          </#if>
+          {/if}
           """
         end
 
@@ -241,11 +241,11 @@ defmodule Surface.Constructs.IfTest do
       html =
         render_surface do
           ~H"""
-          <#if condition={false}>
+          {#if false}
             IF
-          <#elseif condition={true}>
+          {#elseif true}
             ELSEIF TRUE
-          </#if>
+          {/if}
           """
         end
 
@@ -258,13 +258,13 @@ defmodule Surface.Constructs.IfTest do
       html =
         render_surface do
           ~H"""
-          <#if condition={false}>
+          {#if false}
             IF
-          <#elseif condition={false}>
+          {#elseif false}
             ELSEIF FALSE
-          <#elseif condition={false}>
+          {#elseif false}
             ELSEIF TRUE
-          </#if>
+          {/if}
           """
         end
 
@@ -275,22 +275,22 @@ defmodule Surface.Constructs.IfTest do
       html =
         render_surface do
           ~H"""
-          <#if condition={false}>
-          <span>The inner content</span>
-          <span>with multiple tags</span>
-          <#elseif condition={false}>
-          <span>The elseif content</span>
-          <span>with multiple tags</span>
-          <#else>
-          <span>The else content</span>
-          <span>with multiple tags</span>
-          </#if>
+          {#if false}
+            <span>The inner content</span>
+            <span>with multiple tags</span>
+          {#elseif false}
+            <span>The elseif content</span>
+            <span>with multiple tags</span>
+          {#else}
+            <span>The else content</span>
+            <span>with multiple tags</span>
+          {/if}
           """
         end
 
       assert html =~ """
-             <span>The else content</span>
-             <span>with multiple tags</span>
+               <span>The else content</span>
+               <span>with multiple tags</span>
              """
     end
 
@@ -298,22 +298,22 @@ defmodule Surface.Constructs.IfTest do
       html =
         render_surface do
           ~H"""
-          <#if condition={true}>
-          <span>The inner content</span>
-          <span>with multiple tags</span>
-          <#elseif condition={true}>
-          <span>The elseif content</span>
-          <span>with multiple tags</span>
-          <#else>
-          <span>The else content</span>
-          <span>with multiple tags</span>
-          </#if>
+          {#if true}
+            <span>The inner content</span>
+            <span>with multiple tags</span>
+          {#elseif true}
+            <span>The elseif content</span>
+            <span>with multiple tags</span>
+          {#else}
+            <span>The else content</span>
+            <span>with multiple tags</span>
+          {/if}
           """
         end
 
       assert html =~ """
-             <span>The inner content</span>
-             <span>with multiple tags</span>
+               <span>The inner content</span>
+               <span>with multiple tags</span>
              """
     end
   end
@@ -323,23 +323,23 @@ defmodule Surface.Constructs.IfTest do
       html =
         render_surface do
           ~H"""
-          <#if condition={false}>
+          {#if false}
             IF
-          <#elseif condition={false}>
+          {#elseif false}
             ELSEIF FALSE
-          <#elseif condition={true}>
+          {#elseif true}
             BEFORE
-            <#if condition={false}>
+            {#if false}
               NESTED IF
-            <#elseif condition={true}>
+            {#elseif true}
               NESTED ELSEIF TRUE
-            <#else>
+            {#else}
               NESTED FALSE
-            </#if>
+            {/if}
             AFTER
-          <#else>
+          {#else}
             ELSE
-          </#if>
+          {/if}
           """
         end
 
@@ -354,23 +354,23 @@ defmodule Surface.Constructs.IfTest do
       code =
         quote do
           ~H"""
-          <#if condition={false}>
+          {#if false}
             IF
-          <#elseif condition={false}>
+          {#elseif false}
             ELSEIF FALSE
-          <#elseif condition={true}>
+          {#elseif true}
             BEFORE
-            <#if condition={false}>
+            {#if false}
               NESTED IF
-            <#elseif condition={true}>
+            {#elseif true}
               NESTED ELSEIF TRUE
-            <#else>
+            {#else}
               <ListProp prop="some string" />
-            </#if>
+            {/if}
             AFTER
-          <#else>
+          {#else}
             ELSE
-          </#if>
+          {/if}
           """
         end
 
@@ -386,28 +386,28 @@ defmodule Surface.Constructs.IfTest do
       code =
         quote do
           ~H"""
-          <#if condition={false}>
+          {#if false}
             IF
-          <#elseif condition={false}>
+          {#elseif false}
             ELSEIF FALSE
-          <#elseif condition={true}>
+          {#elseif true}
             BEFORE
-            <#if condition={false}>
+            {#if false}
               NESTED IF
-            <#elseif condition={true}>
+            {#elseif true}
               NESTED ELSEIF TRUE
-            <#else>
+            {#else}
               ELSE
               <span>Some text
-            </#if>
+            {/if}
             AFTER
-          <#else>
+          {#else}
             ELSE
-          </#if>
+          {/if}
           """
         end
 
-      message = ~S(code:13:16: expected closing tag for <span> defined on line 13, got </#if>)
+      message = ~S(code:13:16: expected closing node for <span> defined on line 13, got {/if})
 
       assert_raise(Surface.Compiler.ParseError, message, fn ->
         compile_surface(code)
@@ -420,16 +420,16 @@ defmodule Surface.Constructs.IfTest do
       html =
         render_surface do
           ~H"""
-          <#unless condition={false}>
-          <span>The inner content</span>
-          <span>with multiple tags</span>
-          </#unless>
+          {#unless false}
+            <span>The inner content</span>
+            <span>with multiple tags</span>
+          {/unless}
           """
         end
 
       assert html =~ """
-             <span>The inner content</span>
-             <span>with multiple tags</span>
+               <span>The inner content</span>
+               <span>with multiple tags</span>
              """
     end
 
@@ -437,13 +437,13 @@ defmodule Surface.Constructs.IfTest do
       code =
         quote do
           ~H"""
-          <#unless condition={false}>
+          {#unless false}
             <span>The inner content
-          </#unless>
+          {/unless}
           """
         end
 
-      message = ~S(code:2:14: expected closing tag for <span> defined on line 2, got </#unless>)
+      message = ~S(code:2:14: expected closing node for <span> defined on line 2, got {/unless})
 
       assert_raise(Surface.Compiler.ParseError, message, fn ->
         compile_surface(code)
@@ -454,9 +454,9 @@ defmodule Surface.Constructs.IfTest do
       code =
         quote do
           ~H"""
-          <#unless condition={false}>
+          {#unless false}
             <ListProp prop="some string" />
-          </#unless>
+          {/unless}
           """
         end
 

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -103,7 +103,7 @@ defmodule Surface.Compiler.ParserTest do
            ]
   end
 
-  test "comments" do
+  test "public comments" do
     code = """
     <div>
     <!--
@@ -114,13 +114,36 @@ defmodule Surface.Compiler.ParserTest do
     </div>
     """
 
-    [{"div", _, [_, {:comment, comment}, _, {"span", _, _, _}, _], _}, _] = parse!(code)
+    [{"div", _, [_, {:comment, comment, %{visibility: :public}}, _, {"span", _, _, _}, _], _}, _] =
+      parse!(code)
 
     assert comment == """
            <!--
            This is
            a comment
            -->\
+           """
+  end
+
+  test "private comments" do
+    code = """
+    <div>
+    {!--
+    This is
+    a comment
+    --}
+      <span/>
+    </div>
+    """
+
+    [{"div", _, [_, {:comment, comment, %{visibility: :private}}, _, {"span", _, _, _}, _], _}, _] =
+      parse!(code)
+
+    assert comment == """
+           {!--
+           This is
+           a comment
+           --}\
            """
   end
 

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -506,24 +506,6 @@ defmodule Surface.Compiler.ParserTest do
       message = "expected closing node for <#foo> defined on line 1, got </#bar>"
       assert %ParseError{message: ^message, line: 1} = exception
     end
-
-    test "non-closing interpolation" do
-      code = "<foo>{bar</foo>"
-
-      exception = assert_raise ParseError, fn -> parse!(code) end
-
-      message = "expected closing `}` for expression"
-      assert %ParseError{message: ^message, line: 1} = exception
-    end
-
-    test "non-matched curlies inside interpolation" do
-      code = "<foo>{bar { }</foo>"
-
-      exception = assert_raise ParseError, fn -> parse!(code) end
-
-      message = "expected closing `}` for expression"
-      assert %ParseError{message: ^message, line: 1} = exception
-    end
   end
 
   describe "attributes" do

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -374,7 +374,7 @@ defmodule Surface.Compiler.ParserTest do
 
       exception = assert_raise ParseError, fn -> parse!(code) end
 
-      message = "expected closing tag for <foo> defined on line 1, got </a>"
+      message = "expected closing node for <foo> defined on line 1, got </a>"
 
       assert %ParseError{message: ^message, line: 1} = exception
     end
@@ -384,7 +384,7 @@ defmodule Surface.Compiler.ParserTest do
 
       exception = assert_raise ParseError, fn -> parse!(code) end
 
-      message = "expected closing tag for <bar> defined on line 1, got </foo>"
+      message = "expected closing node for <bar> defined on line 1, got </foo>"
       assert %ParseError{message: ^message, line: 1} = exception
     end
 
@@ -393,7 +393,7 @@ defmodule Surface.Compiler.ParserTest do
 
       exception = assert_raise ParseError, fn -> parse!(code) end
 
-      message = "expected closing tag for <Bar> defined on line 1, got </foo>"
+      message = "expected closing node for <Bar> defined on line 1, got </foo>"
       assert %ParseError{message: ^message, line: 1} = exception
     end
 
@@ -402,7 +402,7 @@ defmodule Surface.Compiler.ParserTest do
 
       exception = assert_raise ParseError, fn -> parse!(code) end
 
-      message = "expected closing tag for <Bar.Baz> defined on line 1, got </foo>"
+      message = "expected closing node for <Bar.Baz> defined on line 1, got </foo>"
       assert %ParseError{message: ^message, line: 1} = exception
     end
 
@@ -411,7 +411,7 @@ defmodule Surface.Compiler.ParserTest do
 
       exception = assert_raise ParseError, fn -> parse!(code) end
 
-      message = "expected closing tag for <Bar1> defined on line 1, got </foo>"
+      message = "expected closing node for <Bar1> defined on line 1, got </foo>"
       assert %ParseError{message: ^message, line: 1} = exception
     end
 
@@ -420,7 +420,7 @@ defmodule Surface.Compiler.ParserTest do
 
       exception = assert_raise ParseError, fn -> parse!(code) end
 
-      message = "expected closing tag for <Bar_1> defined on line 1, got </foo>"
+      message = "expected closing node for <Bar_1> defined on line 1, got </foo>"
       assert %ParseError{message: ^message, line: 1} = exception
     end
 
@@ -429,7 +429,7 @@ defmodule Surface.Compiler.ParserTest do
 
       exception = assert_raise ParseError, fn -> parse!(code) end
 
-      message = "expected closing tag for <bar-baz> defined on line 1, got </foo>"
+      message = "expected closing node for <bar-baz> defined on line 1, got </foo>"
       assert %ParseError{message: ^message, line: 1} = exception
     end
 
@@ -438,7 +438,7 @@ defmodule Surface.Compiler.ParserTest do
 
       exception = assert_raise ParseError, fn -> parse!(code) end
 
-      message = "expected closing tag for <#Bar> defined on line 1, got EOF"
+      message = "expected closing node for <#Bar> defined on line 1, got EOF"
       assert %ParseError{message: ^message, line: 1} = exception
     end
 
@@ -453,7 +453,7 @@ defmodule Surface.Compiler.ParserTest do
 
       exception = assert_raise ParseError, fn -> parse!(code) end
 
-      message = "expected closing tag for <div> defined on line 3, got </foo>"
+      message = "expected closing node for <div> defined on line 3, got </foo>"
       assert %ParseError{message: ^message, line: 3} = exception
     end
 
@@ -462,7 +462,7 @@ defmodule Surface.Compiler.ParserTest do
 
       exception = assert_raise ParseError, fn -> parse!(code) end
 
-      message = "expected closing tag for <foo> defined on line 1, got </baz>"
+      message = "expected closing node for <foo> defined on line 1, got </baz>"
       assert %ParseError{message: ^message, line: 1} = exception
     end
 
@@ -471,7 +471,7 @@ defmodule Surface.Compiler.ParserTest do
 
       exception = assert_raise ParseError, fn -> parse!(code) end
 
-      message = "expected closing tag for <foo> defined on line 1, got EOF"
+      message = "expected closing node for <foo> defined on line 1, got EOF"
       assert %ParseError{message: ^message, line: 1} = exception
     end
 
@@ -480,7 +480,7 @@ defmodule Surface.Compiler.ParserTest do
 
       exception = assert_raise ParseError, fn -> parse!(code) end
 
-      message = "expected closing tag for <#foo> defined on line 1, got </#bar>"
+      message = "expected closing node for <#foo> defined on line 1, got </#bar>"
       assert %ParseError{message: ^message, line: 1} = exception
     end
 
@@ -777,19 +777,19 @@ defmodule Surface.Compiler.ParserTest do
   describe "sub-blocks" do
     test "no sub-block with nested child" do
       code = """
-      <#if {true}>
+      {#if true}
         1
         <span>2</span>
         <span>3</span>
-      </#if>\
+      {/if}\
       """
 
       assert parse!(code) ==
                [
-                 {"#if",
+                 {:block, "if",
                   [
-                    {:root, {:attribute_expr, "true", %{line: 1, column: 7, file: "nofile"}},
-                     %{line: 1, column: 7, file: "nofile"}}
+                    {:root, {:attribute_expr, "true", %{line: 1, column: 6, file: "nofile"}},
+                     %{line: 1, column: 6, file: "nofile"}}
                   ],
                   [
                     "\n  1\n  ",
@@ -803,100 +803,100 @@ defmodule Surface.Compiler.ParserTest do
 
     test "single sub-block" do
       code = """
-      <#if {true}>
+      {#if true}
         1
-      <#else>
+      {#else}
         2
-      </#if>\
+      {/if}\
       """
 
       assert parse!(code) ==
                [
-                 {"#if",
+                 {:block, "if",
                   [
-                    {:root, {:attribute_expr, "true", %{line: 1, file: "nofile", column: 7}},
-                     %{line: 1, file: "nofile", column: 7}}
+                    {:root, {:attribute_expr, "true", %{line: 1, file: "nofile", column: 6}},
+                     %{line: 1, file: "nofile", column: 6}}
                   ],
                   [
-                    {:default, [], ["\n  1\n"], %{}},
-                    {"#else", [], ["\n  2\n"], %{line: 3, file: "nofile", column: 2}}
+                    {:block, :default, [], ["\n  1\n"], %{}},
+                    {:block, "else", [], ["\n  2\n"], %{line: 3, file: "nofile", column: 2}}
                   ], %{line: 1, file: "nofile", column: 2, has_sub_blocks?: true}}
                ]
     end
 
     test "multiple sub-blocks" do
       code = """
-      <#if {true}>
+      {#if true}
         1
-      <#elseif>
+      {#elseif}
         2
-      <#elseif>
+      {#elseif}
         3
-      <#else>
+      {#else}
         4
-      </#if>\
+      {/if}\
       """
 
       assert parse!(code) ==
                [
-                 {"#if",
+                 {:block, "if",
                   [
-                    {:root, {:attribute_expr, "true", %{line: 1, file: "nofile", column: 7}},
-                     %{line: 1, file: "nofile", column: 7}}
+                    {:root, {:attribute_expr, "true", %{line: 1, file: "nofile", column: 6}},
+                     %{line: 1, file: "nofile", column: 6}}
                   ],
                   [
-                    {:default, [], ["\n  1\n"], %{}},
-                    {"#elseif", [], ["\n  2\n"], %{line: 3, file: "nofile", column: 2}},
-                    {"#elseif", [], ["\n  3\n"], %{line: 5, file: "nofile", column: 2}},
-                    {"#else", [], ["\n  4\n"], %{line: 7, file: "nofile", column: 2}}
+                    {:block, :default, [], ["\n  1\n"], %{}},
+                    {:block, "elseif", [], ["\n  2\n"], %{line: 3, file: "nofile", column: 2}},
+                    {:block, "elseif", [], ["\n  3\n"], %{line: 5, file: "nofile", column: 2}},
+                    {:block, "else", [], ["\n  4\n"], %{line: 7, file: "nofile", column: 2}}
                   ], %{line: 1, file: "nofile", column: 2, has_sub_blocks?: true}}
                ]
     end
 
     test "nested sub-blocks" do
       code = """
-      <#if {1}>
+      {#if 1}
         111
-      <#elseif {2}>
+      {#elseif 2}
         222
-        <#if {3}>
+        {#if 3}
           333
-        <#else>
+        {#else}
           444
-        </#if>
-      <#else>
+        {/if}
+      {#else}
         555
-      </#if>\
+      {/if}\
       """
 
       assert parse!(code) ==
                [
-                 {"#if",
+                 {:block, "if",
                   [
-                    {:root, {:attribute_expr, "1", %{line: 1, file: "nofile", column: 7}},
-                     %{line: 1, file: "nofile", column: 7}}
+                    {:root, {:attribute_expr, "1", %{line: 1, file: "nofile", column: 6}},
+                     %{line: 1, file: "nofile", column: 6}}
                   ],
                   [
-                    {:default, [], ["\n  111\n"], %{}},
-                    {"#elseif",
+                    {:block, :default, [], ["\n  111\n"], %{}},
+                    {:block, "elseif",
                      [
-                       {:root, {:attribute_expr, "2", %{line: 3, file: "nofile", column: 11}},
-                        %{line: 3, file: "nofile", column: 11}}
+                       {:root, {:attribute_expr, "2", %{line: 3, file: "nofile", column: 10}},
+                        %{line: 3, file: "nofile", column: 10}}
                      ],
                      [
                        "\n  222\n  ",
-                       {"#if",
+                       {:block, "if",
                         [
-                          {:root, {:attribute_expr, "3", %{line: 5, file: "nofile", column: 9}},
-                           %{line: 5, file: "nofile", column: 9}}
+                          {:root, {:attribute_expr, "3", %{line: 5, file: "nofile", column: 8}},
+                           %{line: 5, file: "nofile", column: 8}}
                         ],
                         [
-                          {:default, [], ["\n    333\n  "], %{}},
-                          {"#else", [], ["\n    444\n  "], %{line: 7, file: "nofile", column: 4}}
+                          {:block, :default, [], ["\n    333\n  "], %{}},
+                          {:block, "else", [], ["\n    444\n  "], %{line: 7, file: "nofile", column: 4}}
                         ], %{has_sub_blocks?: true, line: 5, file: "nofile", column: 4}},
                        "\n"
                      ], %{line: 3, file: "nofile", column: 2}},
-                    {"#else", [], ["\n  555\n"], %{line: 10, file: "nofile", column: 2}}
+                    {:block, "else", [], ["\n  555\n"], %{line: 10, file: "nofile", column: 2}}
                   ], %{has_sub_blocks?: true, line: 1, file: "nofile", column: 2}}
                ]
     end
@@ -904,27 +904,27 @@ defmodule Surface.Compiler.ParserTest do
     test "handle invalid parents for #else" do
       code = """
       <div>
-      <#else>
+      {#else}
       </div>
       """
 
       exception = assert_raise ParseError, fn -> parse!(code) end
 
-      message = "cannot use <#else> inside <div>. Possible parents are \"<#if>\" and \"<#for>\""
+      message = "no valid parent node defined for {#else}. Possible parents are \"{#if}\" and \"{#for}\""
       assert %ParseError{message: ^message, line: 2} = exception
     end
 
     test "handle invalid parents for #elseif" do
       code = """
       <div>
-      <#elseif>
+      {#elseif}
       </div>
       """
 
       exception = assert_raise ParseError, fn -> parse!(code) end
 
       message =
-        "cannot use <#elseif> inside <div>. The <#elseif> construct can only be used inside a \"<#if>\""
+        "no valid parent node defined for {#elseif}. The {#elseif} construct can only be used inside a \"{#if}\""
 
       assert %ParseError{message: ^message, line: 2} = exception
     end
@@ -932,14 +932,14 @@ defmodule Surface.Compiler.ParserTest do
     test "handle invalid parents for #match" do
       code = """
       <div>
-      <#match>
+      {#match}
       </div>
       """
 
       exception = assert_raise ParseError, fn -> parse!(code) end
 
       message =
-        "cannot use <#match> inside <div>. The <#match> construct can only be used inside a \"<#case>\""
+        "no valid parent node defined for {#match}. The {#match} construct can only be used inside a \"{#case}\""
 
       assert %ParseError{message: ^message, line: 2} = exception
     end
@@ -947,14 +947,14 @@ defmodule Surface.Compiler.ParserTest do
     test "raise error on sub-blocks without parent node" do
       code = """
         1
-      <#else>
+      {#else}
         2
       """
 
       exception = assert_raise ParseError, fn -> parse!(code) end
 
       message =
-        "no valid parent node defined for <#else>. Possible parents are \"<#if>\" and \"<#for>\""
+        "no valid parent node defined for {#else}. Possible parents are \"{#if}\" and \"{#for}\""
 
       assert %ParseError{message: ^message, line: 2} = exception
     end

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -967,7 +967,7 @@ defmodule Surface.Compiler.ParserTest do
 
       message = """
       unknown `{/iff}` block. Available blocks are \
-      "if", "unless", "for", "case", "else", "elseif" and "match"\
+      "if", "unless", "for" and "case"\
       """
 
       assert %ParseError{message: ^message, line: 3} = exception

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -892,7 +892,8 @@ defmodule Surface.Compiler.ParserTest do
                         ],
                         [
                           {:block, :default, [], ["\n    333\n  "], %{}},
-                          {:block, "else", [], ["\n    444\n  "], %{line: 7, file: "nofile", column: 4}}
+                          {:block, "else", [], ["\n    444\n  "],
+                           %{line: 7, file: "nofile", column: 4}}
                         ], %{has_sub_blocks?: true, line: 5, file: "nofile", column: 4}},
                        "\n"
                      ], %{line: 3, file: "nofile", column: 2}},
@@ -910,7 +911,9 @@ defmodule Surface.Compiler.ParserTest do
 
       exception = assert_raise ParseError, fn -> parse!(code) end
 
-      message = "no valid parent node defined for {#else}. Possible parents are \"{#if}\" and \"{#for}\""
+      message =
+        "no valid parent node defined for {#else}. Possible parents are \"{#if}\" and \"{#for}\""
+
       assert %ParseError{message: ^message, line: 2} = exception
     end
 

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -214,41 +214,41 @@ defmodule Surface.Compiler.ParserTest do
     end
   end
 
-  describe "interpolation" do
+  describe "expressions" do
     test "as root" do
       assert parse!("{baz}") ==
-               [{:interpolation, "baz", %{line: 1, file: "nofile", column: 2}}]
+               [{:expr, "baz", %{line: 1, file: "nofile", column: 2}}]
     end
 
     test "with curlies embedded" do
       assert parse!("{ {1, 3} }") ==
-               [{:interpolation, " {1, 3} ", %{line: 1, file: "nofile", column: 2}}]
+               [{:expr, " {1, 3} ", %{line: 1, file: "nofile", column: 2}}]
     end
 
     test "with deeply nested curlies" do
       assert parse!("{{{{{{{{{{{}}}}}}}}}}}") ==
-               [{:interpolation, "{{{{{{{{{{}}}}}}}}}}", %{line: 1, file: "nofile", column: 2}}]
+               [{:expr, "{{{{{{{{{{}}}}}}}}}}", %{line: 1, file: "nofile", column: 2}}]
     end
 
     test "matched curlies for a map expression" do
       assert parse!("{ %{a: %{b: 1}} }") ==
-               [{:interpolation, " %{a: %{b: 1}} ", %{line: 1, file: "nofile", column: 2}}]
+               [{:expr, " %{a: %{b: 1}} ", %{line: 1, file: "nofile", column: 2}}]
     end
 
     test "tuple without spaces between enclosing curlies" do
       assert parse!("{{:a, :b}}") ==
-               [{:interpolation, "{:a, :b}", %{line: 1, file: "nofile", column: 2}}]
+               [{:expr, "{:a, :b}", %{line: 1, file: "nofile", column: 2}}]
     end
 
     test "without root node but with text" do
       assert parse!("foo {baz} bar") ==
-               ["foo ", {:interpolation, "baz", %{line: 1, file: "nofile", column: 6}}, " bar"]
+               ["foo ", {:expr, "baz", %{line: 1, file: "nofile", column: 6}}, " bar"]
     end
 
     test "with root node" do
       assert parse!("<foo>{baz}</foo>") ==
                [
-                 {"foo", '', [{:interpolation, "baz", %{line: 1, file: "nofile", column: 7}}],
+                 {"foo", '', [{:expr, "baz", %{line: 1, file: "nofile", column: 7}}],
                   %{line: 1, file: "nofile", column: 2}}
                ]
     end
@@ -259,7 +259,7 @@ defmodule Surface.Compiler.ParserTest do
                  {"foo", '',
                   [
                     "bar",
-                    {:interpolation, "baz", %{line: 1, file: "nofile", column: 10}},
+                    {:expr, "baz", %{line: 1, file: "nofile", column: 10}},
                     "bat"
                   ], %{line: 1, file: "nofile", column: 2}}
                ]
@@ -306,12 +306,12 @@ defmodule Surface.Compiler.ParserTest do
 
     test "containing a charlist with escaped single quote" do
       assert parse!("{ 'a\\'b' }") ==
-               [{:interpolation, " 'a\\'b' ", %{line: 1, file: "nofile", column: 2}}]
+               [{:expr, " 'a\\'b' ", %{line: 1, file: "nofile", column: 2}}]
     end
 
     test "containing a binary with escaped double quote" do
       assert parse!("{ \"a\\\"b\" }") ==
-               [{:interpolation, " \"a\\\"b\" ", %{line: 1, file: "nofile", column: 2}}]
+               [{:expr, " \"a\\\"b\" ", %{line: 1, file: "nofile", column: 2}}]
     end
 
     test "nested multi-element tuples" do
@@ -319,7 +319,7 @@ defmodule Surface.Compiler.ParserTest do
              { {a, {b, c}} <- [{"a", {"b", "c"}}]}
              """) ==
                [
-                 {:interpolation, " {a, {b, c}} <- [{\"a\", {\"b\", \"c\"}}]",
+                 {:expr, " {a, {b, c}} <- [{\"a\", {\"b\", \"c\"}}]",
                   %{line: 1, file: "nofile", column: 2}},
                  "\n"
                ]
@@ -558,7 +558,7 @@ defmodule Surface.Compiler.ParserTest do
 
       children = [
         "\n  bar\n  ",
-        {"div", [], [{:interpolation, " var ", %{line: 6, file: "nofile", column: 9}}],
+        {"div", [], [{:expr, " var ", %{line: 6, file: "nofile", column: 9}}],
          %{line: 6, file: "nofile", column: 4}},
         "\n"
       ]

--- a/test/support/catalogue/fake_playground.ex
+++ b/test/support/catalogue/fake_playground.ex
@@ -10,9 +10,9 @@ defmodule Surface.Catalogue.FakePlayground do
 
   def render(assigns) do
     ~H"""
-    <#for each={{prop, value} <- @props}>
+    {#for {prop, value} <- @props}
       {prop}: {value}
-    </#for>
+    {/for}
     """
   end
 end

--- a/test/transform_test.exs
+++ b/test/transform_test.exs
@@ -169,7 +169,7 @@ defmodule Surface.TransformTest do
 
     assert_raise(
       Surface.Compiler.ParseError,
-      "nofile:1:2: expected closing tag for <DivToSpan> defined on line 1, got EOF",
+      "nofile:1:2: expected closing node for <DivToSpan> defined on line 1, got EOF",
       fn ->
         Surface.Compiler.compile(code, 1, __ENV__)
       end


### PR DESCRIPTION
These are the minimum changes necessary to apply the new syntax without updating the tokenizer and keeping the same structure of the nodes, except for the addition of the `:block` atom to differentiate blocks from tags. It even keeps the representation of the construct expression as a `:root` prop. However, we should change this to a more appropriate format after #378 gets merged.

@lnr0626, @Malian and @miguel-s there are still a couple of things to decide:

1. Are we keeping `<#slot>`, `<#template>` and `<#raw>` or should we go back to `<Slot>`, `<Template>` and `<#Raw>`?
2. Should we use `{/...}` or `{#end}`. The current version is using `{/...}` but it's extremely easy to change. 

Here are some examples using both notations:

### Using `{/...}`

![image](https://user-images.githubusercontent.com/457237/118825840-69d0ea80-b891-11eb-96f0-6a70624385cb.png)

### Using `{#end}`

![image](https://user-images.githubusercontent.com/457237/118826097-908f2100-b891-11eb-8af4-0afdddafc590.png)

Using `{#end}` somehow looks better to me. I'm not sure why :)