### PR TITLE
Support Descriptive EEx Delimiter Errors

### DIFF
--- a/lib/surface/compiler/tokenizer.ex
+++ b/lib/surface/compiler/tokenizer.ex
@@ -22,7 +22,7 @@ defmodule Surface.Compiler.Tokenizer do
 
   defp handle_text("<%=" <> _rest, line, column, _buffer, _acc, state) do
     raise parse_error(
-            "EEx syntax `<%=` not allowed. Please use the Surface interpolation syntax `{{ foo = :bar }}`",
+            "EEx syntax `<%= foo = :bar %>` not allowed. Please use the Surface interpolation syntax `{{ foo = :bar }}`",
             line,
             column + 4,
             state

--- a/lib/surface/compiler/tokenizer.ex
+++ b/lib/surface/compiler/tokenizer.ex
@@ -20,6 +20,15 @@ defmodule Surface.Compiler.Tokenizer do
 
   ## handle_text
 
+  defp handle_text("<%=" <> _rest, line, column, _buffer, _acc, state) do
+    raise parse_error(
+            "EEx syntax `<%=` not allowed. Please use the Surface interpolation syntax `{{ foo = :bar }}`",
+            line,
+            column + 4,
+            state
+          )
+  end
+
   defp handle_text("\r\n" <> rest, line, _column, buffer, acc, state) do
     handle_text(rest, line + 1, state.column_offset, ["\r\n" | buffer], acc, state)
   end

--- a/lib/surface/compiler/tokenizer.ex
+++ b/lib/surface/compiler/tokenizer.ex
@@ -22,7 +22,7 @@ defmodule Surface.Compiler.Tokenizer do
 
   defp handle_text("<%=" <> _rest, line, column, _buffer, _acc, state) do
     raise parse_error(
-            "EEx syntax `<%= foo = :bar %>` not allowed. Please use the Surface interpolation syntax `{{ foo = :bar }}`",
+            "EEx syntax `<%= foo = :bar %>` not allowed. Please use the Surface interpolation syntax `{ foo = :bar }`",
             line,
             column + 4,
             state

--- a/test/compiler/tokenizer_test.exs
+++ b/test/compiler/tokenizer_test.exs
@@ -64,7 +64,7 @@ defmodule Surface.Compiler.TokenizerTest do
   describe "EEx interpolation" do
     test "raises when present" do
       assert_raise ParseError,
-                   "nofile:2:5: EEx syntax `<%=` not allowed. Please use the Surface interpolation syntax `{{ foo = :bar }}`",
+                   "nofile:2:5: EEx syntax `<%= foo = :bar %>` not allowed. Please use the Surface interpolation syntax `{{ foo = :bar }}`",
                    fn ->
                      tokenize!("""
                      <div>

--- a/test/compiler/tokenizer_test.exs
+++ b/test/compiler/tokenizer_test.exs
@@ -61,6 +61,20 @@ defmodule Surface.Compiler.TokenizerTest do
     end
   end
 
+  describe "EEx interpolation" do
+    test "raises when present" do
+      assert_raise ParseError,
+                   "nofile:2:5: EEx syntax `<%=` not allowed. Please use the Surface interpolation syntax `{{ foo = :bar }}`",
+                   fn ->
+                     tokenize!("""
+                     <div>
+                     <%= foo = :bar %>
+                     </div>
+                     """)
+                   end
+    end
+  end
+
   describe "interpolation in body" do
     test "represented as {:interpolation, value, meta}" do
       assert tokenize!("""


### PR DESCRIPTION
In the process of converting LiveView components and views into Surface, developers can run into somewhat confusing parsing errors if they fail to convert their Embedded Elixir `<%= foo = :bar %>` into the Surface Elixir interpolation syntax `{{ foo = :bar }}`.

I bumped into this a couple of times and the "missing closing tag foo" errors had me initially scratching my head until I realized that the parser died due to some embedded Elixir that I had not converted to `{{ }}`. 

This commit raises a more descriptive error alerting developers to the need to change their syntax. I didn't bother capturing the interstitial code between the EEx delimiters or ensure a closing EEx delimiter since most of the time we just want to tip off developers that they have some EEx code in their Surface template. 