### PR TITLE
Move typespecs into appropriate modules

### DIFF
--- a/lib/surface/compiler/node_translator.ex
+++ b/lib/surface/compiler/node_translator.ex
@@ -1,93 +1,84 @@
 defmodule Surface.Compiler.NodeTranslator do
-  @type parse_metadata :: %{line: non_neg_integer(), column: non_neg_integer(), file: binary()}
-
-  @typedoc """
-  The token representing the open node for a block.
-
-  The second element is nil if the block does not have an expression (i.e. `{#else}`), or
-
-  {:block_open, expression, children, parse metadata}
+  @moduledoc """
+  Surface.Compiler.Parser uses a node translator to convert
   """
-  @type block_info :: {:block_open, binary(), nil | binary(), parse_metadata()}
-  @type tag_info :: {:tag_open, binary(), list(), parse_metadata()}
-  @type context :: term()
+  alias Surface.Compiler.Tokenizer
 
-  @type state :: %{
-          caller: Macro.Env.t(),
-          tags: list({tag_info() | block_info(), context()}),
-          checks: keyword(boolean()),
-          warnings: keyword(boolean())
-        }
+  @type context :: term()
 
   @typedoc """
   A node translator can return anything to represent the node, or use `:ignore` to
-  indicate that this node should be removed entirely from the result
+  indicate that this node should be removed entirely from the result.
   """
   @type result :: term() | :ignore
 
-  @callback context_for_node(name :: binary(), meta :: parse_metadata(), state :: state()) ::
+  @callback context_for_node(name :: binary(), Tokenizer.tag_metadata(), Parser.state()) ::
               context()
-  @callback context_for_block(name :: binary(), meta :: parse_metadata(), state :: state()) ::
+  @callback context_for_block(name :: binary(), Tokenizer.block_metadata(), Parser.state()) ::
               context()
   @callback context_for_subblock(
-              block_name :: :default | binary(),
-              meta :: parse_metadata(),
-              state :: state(),
+              Tokenizer.block_name(),
+              Tokenizer.block_metadata(),
+              Parser.state(),
               parent_context :: context()
             ) ::
               context()
 
   @callback handle_attribute(
-              name :: binary() | atom(),
-              value :: binary() | {:expr, binary(), parse_metadata()},
-              attr_meta :: parse_metadata(),
-              state :: state(),
+              Tokenizer.attribute_name(),
+              value :: binary() | Tokenizer.expression(),
+              Tokenizer.attribute_metadata(),
+              Parser.state(),
               context :: context()
-            ) :: any()
+            ) :: result()
 
   @callback handle_block_expression(
-              block_name :: :default | binary(),
-              nil | {:expr, binary(), parse_metadata()},
-              state :: state(),
+              Tokenizer.block_name(),
+              nil | Tokenizer.expression(),
+              Parser.state(),
               context :: context()
-            ) :: any()
+            ) :: result()
 
-  @callback handle_init(state :: state()) :: state()
+  @callback handle_init(Parser.state()) :: Parser.state()
 
-  @callback handle_text(value :: binary(), state :: state()) :: {result(), state()}
-  @callback handle_comment(comment :: binary(), meta :: parse_metadata(), state :: state()) ::
-              {result(), state()}
+  @callback handle_text(value :: binary(), Parser.state()) :: {result(), Parser.state()}
+  @callback handle_comment(
+              comment :: binary(),
+              meta :: Tokenizer.comment_metadata(),
+              Parser.state()
+            ) ::
+              {result(), Parser.state()}
 
   @callback handle_node(
-              name :: binary(),
-              attrs :: list(),
-              children :: list(),
-              meta :: parse_metadata(),
-              state :: state(),
+              name :: Tokenizer.tag_name(),
+              attrs :: list(result()),
+              children :: list(result()),
+              meta :: Tokenizer.tag_metadata(),
+              Parser.state(),
               context :: context()
-            ) :: {result(), state()}
+            ) :: {result(), Parser.state()}
 
   @callback handle_block(
-              name :: binary(),
-              expr :: any(),
-              children :: list(),
-              meta :: parse_metadata(),
-              state :: state(),
+              Tokenizer.block_name(),
+              nil | result(),
+              children :: list(result()),
+              Tokenizer.block_metadata(),
+              Parser.state(),
               context :: context()
-            ) :: {result(), state()}
+            ) :: {result(), Parser.state()}
 
   @callback handle_subblock(
-              name :: binary(),
-              expr :: any(),
-              children :: list(),
-              meta :: parse_metadata(),
-              state :: state(),
+              Tokenizer.block_name(),
+              nil | result(),
+              children :: list(result()),
+              Tokenizer.block_metadata(),
+              Parser.state(),
               context :: context()
-            ) :: {result(), state()}
+            ) :: {result(), Parser.state()}
 
   @callback handle_expression(
               expression :: binary(),
-              meta :: parse_metadata(),
-              state :: state()
-            ) :: {result(), state()}
+              meta :: Tokenizer.metadata(),
+              Parser.state()
+            ) :: {result(), Parser.state()}
 end

--- a/lib/surface/compiler/node_translator.ex
+++ b/lib/surface/compiler/node_translator.ex
@@ -1,7 +1,14 @@
 defmodule Surface.Compiler.NodeTranslator do
   @type parse_metadata :: %{line: non_neg_integer(), column: non_neg_integer(), file: binary()}
 
-  @type block_info :: {:block_open, nil | Macro.t(), list(), parse_metadata()}
+  @typedoc """
+  The token representing the open node for a block.
+
+  The second element is nil if the block does not have an expression (i.e. `{#else}`), or
+
+  {:block_open, expression, children, parse metadata}
+  """
+  @type block_info :: {:block_open, binary(), nil | binary(), parse_metadata()}
   @type tag_info :: {:tag_open, binary(), list(), parse_metadata()}
   @type context :: term()
 
@@ -11,6 +18,12 @@ defmodule Surface.Compiler.NodeTranslator do
           checks: keyword(boolean()),
           warnings: keyword(boolean())
         }
+
+  @typedoc """
+  A node translator can return anything to represent the node, or use `:ignore` to
+  indicate that this node should be removed entirely from the result
+  """
+  @type result :: term() | :ignore
 
   @callback context_for_node(name :: binary(), meta :: parse_metadata(), state :: state()) ::
               context()
@@ -41,9 +54,9 @@ defmodule Surface.Compiler.NodeTranslator do
 
   @callback handle_init(state :: state()) :: state()
 
-  @callback handle_text(value :: binary(), state :: state()) :: {any(), state()}
+  @callback handle_text(value :: binary(), state :: state()) :: {result(), state()}
   @callback handle_comment(comment :: binary(), meta :: parse_metadata(), state :: state()) ::
-              {any(), state()}
+              {result(), state()}
 
   @callback handle_node(
               name :: binary(),
@@ -52,7 +65,7 @@ defmodule Surface.Compiler.NodeTranslator do
               meta :: parse_metadata(),
               state :: state(),
               context :: context()
-            ) :: {any(), state()}
+            ) :: {result(), state()}
 
   @callback handle_block(
               name :: binary(),
@@ -61,7 +74,7 @@ defmodule Surface.Compiler.NodeTranslator do
               meta :: parse_metadata(),
               state :: state(),
               context :: context()
-            ) :: {any(), state()}
+            ) :: {result(), state()}
 
   @callback handle_subblock(
               name :: binary(),
@@ -70,11 +83,11 @@ defmodule Surface.Compiler.NodeTranslator do
               meta :: parse_metadata(),
               state :: state(),
               context :: context()
-            ) :: {any(), state()}
+            ) :: {result(), state()}
 
   @callback handle_expression(
               expression :: binary(),
               meta :: parse_metadata(),
               state :: state()
-            ) :: {any(), state()}
+            ) :: {result(), state()}
 end

--- a/lib/surface/compiler/node_translator.ex
+++ b/lib/surface/compiler/node_translator.ex
@@ -1,7 +1,5 @@
 defmodule Surface.Compiler.NodeTranslator do
-  @moduledoc """
-  Surface.Compiler.Parser uses a node translator to convert
-  """
+  @moduledoc false
   alias Surface.Compiler.Tokenizer
 
   @type context :: term()

--- a/lib/surface/compiler/parse_tree_translator.ex
+++ b/lib/surface/compiler/parse_tree_translator.ex
@@ -99,6 +99,13 @@ defmodule Surface.Compiler.ParseTreeTranslator do
   end
 
   defp drop_common_keys(meta) do
-    Map.drop(meta, [:self_close, :line_end, :column_end, :node_line_end, :node_column_end, :macro?])
+    Map.drop(meta, [
+      :self_close,
+      :line_end,
+      :column_end,
+      :node_line_end,
+      :node_column_end,
+      :macro?
+    ])
   end
 end

--- a/lib/surface/compiler/parse_tree_translator.ex
+++ b/lib/surface/compiler/parse_tree_translator.ex
@@ -89,10 +89,16 @@ defmodule Surface.Compiler.ParseTreeTranslator do
   end
 
   def to_meta(%{void_tag?: true} = meta) do
-    Map.drop(meta, [:self_close, :line_end, :column_end])
+    drop_common_keys(meta)
   end
 
   def to_meta(meta) do
-    Map.drop(meta, [:self_close, :line_end, :column_end, :void_tag?])
+    meta
+    |> Map.drop([:void_tag?])
+    |> drop_common_keys()
+  end
+
+  defp drop_common_keys(meta) do
+    Map.drop(meta, [:self_close, :line_end, :column_end, :node_line_end, :node_column_end, :macro?])
   end
 end

--- a/lib/surface/compiler/parser.ex
+++ b/lib/surface/compiler/parser.ex
@@ -6,12 +6,16 @@ defmodule Surface.Compiler.Parser do
   alias Surface.Compiler.Helpers
 
   @type state :: %{
-    token_stack: list({Tokenizer.block_open() | Tokenizer.tag_open(), Surface.Compiler.NodeTranslator.context()}),
-    translator: module(),
-    caller: Macro.Env.t(),
-    checks: keyword(boolean()),
-    warnings: keyword(boolean())
-  }
+          token_stack:
+            list(
+              {Tokenizer.block_open() | Tokenizer.tag_open(),
+               Surface.Compiler.NodeTranslator.context()}
+            ),
+          translator: module(),
+          caller: Macro.Env.t(),
+          checks: keyword(boolean()),
+          warnings: keyword(boolean())
+        }
 
   @blocks [
     "if",

--- a/lib/surface/compiler/parser.ex
+++ b/lib/surface/compiler/parser.ex
@@ -5,6 +5,14 @@ defmodule Surface.Compiler.Parser do
   alias Surface.Compiler.ParseError
   alias Surface.Compiler.Helpers
 
+  @type state :: %{
+    token_stack: list({Tokenizer.block_open() | Tokenizer.tag_open(), Surface.Compiler.NodeTranslator.context()}),
+    translator: module(),
+    caller: Macro.Env.t(),
+    checks: keyword(boolean()),
+    warnings: keyword(boolean())
+  }
+
   @blocks [
     "if",
     "unless",

--- a/lib/surface/compiler/tokenizer.ex
+++ b/lib/surface/compiler/tokenizer.ex
@@ -31,7 +31,25 @@ defmodule Surface.Compiler.Tokenizer do
           file: binary()
         }
 
+  @type text :: {:text, value :: binary()}
+
   @type comment_metadata :: metadata() | %{visibility: :public | :private}
+  @type comment :: {:comment, value :: binary(), comment_metadata()}
+
+  @type block_metadata :: metadata()
+  @type block_name :: binary() | :default
+  @type block_open ::
+          {:block_open, block_name, expression :: nil | binary(), block_metadata()}
+  @type block_close :: {:block_close, block_name, metadata()}
+
+  @type expression_metadata :: {:expr, value :: binary(), metadata()}
+  @type expression :: {:expr, value :: binary(), metadata()}
+
+  @type attribute_value :: {:string, value :: binary() | nil, metadata()} | expression()
+  @type attribute_name :: binary() | :root
+  @type attribute_metadata :: metadata()
+  @type attribute :: {attribute_name(), attribute_value(), metadata()}
+
   @type tag_metadata ::
           metadata()
           | %{
@@ -41,19 +59,7 @@ defmodule Surface.Compiler.Tokenizer do
               node_line_end: integer(),
               node_column_end: integer()
             }
-
-  @type expression :: {:expr, value :: binary(), metadata()}
-  @type attribute_value :: {:string, value :: binary() | nil, metadata()} | expression()
-
-  @type attribute :: {name :: binary() | :root, attribute_value(), metadata()}
-
-  @type text :: {:text, value :: binary()}
-  @type comment :: {:comment, value :: binary(), comment_metadata()}
-
-  @type block_open ::
-          {:block_open, name :: binary(), expression :: nil | binary(), metadata()}
-  @type block_close :: {:block_close, name :: binary(), metadata()}
-
+  @type tag_name :: binary()
   @type tag_open :: {:tag_open, name :: binary(), list(attribute()), tag_metadata()}
   @type tag_close :: {:tag_close, name :: binary(), metadata()}
 

--- a/lib/surface/compiler/tokenizer.ex
+++ b/lib/surface/compiler/tokenizer.ex
@@ -836,7 +836,6 @@ defmodule Surface.Compiler.Tokenizer do
     {pos, %{state | braces: braces}}
   end
 
-  defp macro_tag?("#raw"), do: true
   defp macro_tag?(<<"#", first, _rest::binary>>) when first in ?A..?Z, do: true
   defp macro_tag?(_name), do: false
 

--- a/test/compiler/tokenizer_test.exs
+++ b/test/compiler/tokenizer_test.exs
@@ -259,11 +259,6 @@ defmodule Surface.Compiler.TokenizerTest do
       assert [{:tag_open, "#Macro", [], %{self_close: true, macro?: true}}] = tokens
     end
 
-    test "self close #raw" do
-      tokens = tokenize!("<#raw/>")
-      assert [{:tag_open, "#raw", [], %{self_close: true, macro?: true}}] = tokens
-    end
-
     test "compute line and column" do
       tokens =
         tokenize!("""

--- a/test/compiler/tokenizer_test.exs
+++ b/test/compiler/tokenizer_test.exs
@@ -27,12 +27,11 @@ defmodule Surface.Compiler.TokenizerTest do
 
   describe "public comment" do
     test "represented as {:comment, comment, meta}" do
-      assert tokenize!("Begin<!-- comment -->End") ==
-               [
-                 {:text, "Begin"},
-                 {:comment, "<!-- comment -->", %{visibility: :public}},
-                 {:text, "End"}
-               ]
+      assert [
+               {:text, "Begin"},
+               {:comment, "<!-- comment -->", %{visibility: :public}},
+               {:text, "End"}
+             ] = tokenize!("Begin<!-- comment -->End")
     end
 
     test "multiple lines and wrapped by tags" do
@@ -67,12 +66,11 @@ defmodule Surface.Compiler.TokenizerTest do
 
   describe "private comment" do
     test "represented as {:comment, comment, meta}" do
-      assert tokenize!("Begin{!-- comment --}End") ==
-               [
-                 {:text, "Begin"},
-                 {:comment, "{!-- comment --}", %{visibility: :private}},
-                 {:text, "End"}
-               ]
+      assert [
+               {:text, "Begin"},
+               {:comment, "{!-- comment --}", %{visibility: :private}},
+               {:text, "End"}
+             ] = tokenize!("Begin{!-- comment --}End")
     end
 
     test "multiple lines and wrapped by tags" do
@@ -238,22 +236,32 @@ defmodule Surface.Compiler.TokenizerTest do
   describe "opening tag" do
     test "represented as {:tag_open, name, attrs, meta}" do
       tokens = tokenize!("<div>")
-      assert [{:tag_open, "div", [], %{}}] = tokens
+      assert [{:tag_open, "div", [], %{self_close: false, macro?: false}}] = tokens
     end
 
     test "with space after name" do
       tokens = tokenize!("<div >")
-      assert [{:tag_open, "div", [], %{}}] = tokens
+      assert [{:tag_open, "div", [], %{self_close: false, macro?: false}}] = tokens
     end
 
     test "with line break after name" do
       tokens = tokenize!("<div\n>")
-      assert [{:tag_open, "div", [], %{}}] = tokens
+      assert [{:tag_open, "div", [], %{self_close: false, macro?: false}}] = tokens
     end
 
     test "self close" do
       tokens = tokenize!("<div/>")
-      assert [{:tag_open, "div", [], %{self_close: true}}] = tokens
+      assert [{:tag_open, "div", [], %{self_close: true, macro?: false}}] = tokens
+    end
+
+    test "self close macro" do
+      tokens = tokenize!("<#Macro/>")
+      assert [{:tag_open, "#Macro", [], %{self_close: true, macro?: true}}] = tokens
+    end
+
+    test "self close #raw" do
+      tokens = tokenize!("<#raw/>")
+      assert [{:tag_open, "#raw", [], %{self_close: true, macro?: true}}] = tokens
     end
 
     test "compute line and column" do


### PR DESCRIPTION
I added typespecs for the tokenizer, and updated some of the metadata that we generate. Most of the metadata changes were to be consistent (e.g. adding `self_close: false`, updating the comment metadata to include line and column info, always adding the node line/column end values).

The only addition is `macro?: boolean()` to the tag metadata - this allows us to centralize our definition of macro so we don't have to have `when first in ?A..Z? or name == "#raw"` in a few different places. I have another change (https://github.com/lnr0626/surface/compare/lr-translator-types...lnr0626:lr-macro-body-end) that removes the `</#raw>` and `</# <> ...` signatures