### PR TITLE
Handle tagged expressions `{... }` and `{= }`

### DIFF
--- a/lib/surface/compiler/parse_tree_translator.ex
+++ b/lib/surface/compiler/parse_tree_translator.ex
@@ -101,7 +101,7 @@ defmodule Surface.Compiler.ParseTreeTranslator do
 
     message = """
     cannot assign `{...#{value}}` to attribute `#{name}`. \
-    Tagged expression `{... }` can only be defined as root attribute/property.
+    The tagged expression `{... }` can only be used on a root attribute/property.
 
     Example: <div {...@attrs}>
     """
@@ -144,7 +144,7 @@ defmodule Surface.Compiler.ParseTreeTranslator do
 
     message = """
     cannot assign `{=#{value}}` to attribute `#{name}`. \
-    Tagged expression `{= }` can only be defined as root attribute/property.
+    The tagged expression `{= }` can only be used on a root attribute/property.
 
     Example: <div {=@class}>
     """

--- a/lib/surface/compiler/parser.ex
+++ b/lib/surface/compiler/parser.ex
@@ -349,8 +349,24 @@ defmodule Surface.Compiler.Parser do
     state.translator.handle_attribute(:root, expr, expr_meta, state, context)
   end
 
+  defp translate_attr(
+         state,
+         context,
+         {:root, {:tagged_expr, _marker, _expr, marker_meta} = expr, _attr_meta}
+       ) do
+    state.translator.handle_attribute(:root, expr, marker_meta, state, context)
+  end
+
   defp translate_attr(state, context, {name, {:expr, _value, _expr_meta} = expr, attr_meta}) do
     state.translator.handle_attribute(name, expr, attr_meta, state, context)
+  end
+
+  defp translate_attr(
+         state,
+         context,
+         {name, {:tagged_expr, _marker, _expr, marker_meta} = expr, _attr_meta}
+       ) do
+    state.translator.handle_attribute(name, expr, marker_meta, state, context)
   end
 
   defp translate_attr(state, context, {name, nil, meta}) do

--- a/test/directives_test.exs
+++ b/test/directives_test.exs
@@ -137,6 +137,47 @@ defmodule Surface.DirectivesTest do
              </div>
              """
     end
+
+    test "shorthand notation `{...@props}`" do
+      assigns = %{props: %{class: "text-xs", hidden: false, content: "dynamic props content"}}
+
+      html =
+        render_surface do
+          ~F"""
+          <DivWithProps {...@props} />
+          """
+        end
+
+      assert html =~ """
+             <div class="text-xs block">
+               dynamic props content
+             </div>
+             """
+    end
+
+    test "raise if trying to assisn `{... }` to a property" do
+      assigns = %{props: %{}}
+
+      code =
+        quote do
+          ~F"""
+          <DivWithProps
+            class=
+              {...@props} />
+          """
+        end
+
+      message = """
+      code:3: cannot assign `{...@props}` to attribute `class`. \
+      Tagged expression `{... }` can only be defined as root attribute/property.
+
+      Example: <div {...@attrs}>
+      """
+
+      assert_raise(CompileError, message, fn ->
+        compile_surface(code, assigns)
+      end)
+    end
   end
 
   describe ":attrs in html tags" do
@@ -225,6 +266,43 @@ defmodule Surface.DirectivesTest do
                Some Text
              </div>
              """
+    end
+
+    test "shorthand notation `{...@attrs}`" do
+      assigns = %{attrs: [class: "text-xs", style: "color: black;"]}
+
+      html =
+        render_surface do
+          ~F"""
+          <div {...@attrs}/>
+          """
+        end
+
+      assert html =~ ~s(<div class="text-xs" style="color: black;"></div>)
+    end
+
+    test "raise if trying to assisn `{... }` to an attribute" do
+      assigns = %{attrs: %{}}
+
+      code =
+        quote do
+          ~F"""
+          <div
+            class=
+              {...@attrs} />
+          """
+        end
+
+      message = """
+      code:3: cannot assign `{...@attrs}` to attribute `class`. \
+      Tagged expression `{... }` can only be defined as root attribute/property.
+
+      Example: <div {...@attrs}>
+      """
+
+      assert_raise(CompileError, message, fn ->
+        compile_surface(code, assigns)
+      end)
     end
   end
 

--- a/test/directives_test.exs
+++ b/test/directives_test.exs
@@ -169,7 +169,7 @@ defmodule Surface.DirectivesTest do
 
       message = """
       code:3: cannot assign `{...@props}` to attribute `class`. \
-      Tagged expression `{... }` can only be defined as root attribute/property.
+      The tagged expression `{... }` can only be used on a root attribute/property.
 
       Example: <div {...@attrs}>
       """
@@ -295,7 +295,7 @@ defmodule Surface.DirectivesTest do
 
       message = """
       code:3: cannot assign `{...@attrs}` to attribute `class`. \
-      Tagged expression `{... }` can only be defined as root attribute/property.
+      The tagged expression `{... }` can only be used on a root attribute/property.
 
       Example: <div {...@attrs}>
       """

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -808,7 +808,7 @@ defmodule Surface.Compiler.ParserTest do
 
       message = """
       nofile:2: cannot assign `{=@class}` to attribute `class`. \
-      Tagged expression `{= }` can only be defined as root attribute/property.
+      The tagged expression `{= }` can only be used on a root attribute/property.
 
       Example: <div {=@class}>
       """


### PR DESCRIPTION
* Add shorthand notation for dynamic attrs/props with `{... }`

* Add shorthand notation for self-assign attrs/prop with `{= }`