### PR TITLE
Add case/match block

### DIFF
--- a/lib/surface/ast.ex
+++ b/lib/surface/ast.ex
@@ -38,6 +38,50 @@ defmodule Surface.AST.Container do
         }
 end
 
+defmodule Surface.AST.Block do
+  @moduledoc """
+  An AST node representing a generic block.
+
+  ## Properties
+      * `:name` - name of the block
+      * `:expression` - the expression passed to block
+      * `:sub_blocks` - a list containing each sub-block's {name, children_ast}
+      * `:meta` - compile meta
+      * `:debug` - keyword list indicating when debug information should be printed during compilation
+  """
+  defstruct [:name, :expression, :sub_blocks, :meta, debug: []]
+
+  @type t :: %__MODULE__{
+          name: binary(),
+          expression: Surface.AST.AttributeExpr.t(),
+          sub_blocks: [{:default | binary(), Surface.AST.t()}],
+          debug: list(atom()),
+          meta: Surface.AST.Meta.t()
+        }
+end
+
+defmodule Surface.AST.SubBlock do
+  @moduledoc """
+  An AST node representing a generic sub-block.
+
+  ## Properties
+      * `:name` - name of the block
+      * `:expression` - the expression passed to block
+      * `:children` - children AST nodes
+      * `:meta` - compile meta
+      * `:debug` - keyword list indicating when debug information should be printed during compilation
+  """
+  defstruct [:name, :expression, :children, :meta, debug: []]
+
+  @type t :: %__MODULE__{
+          name: binary(),
+          expression: Surface.AST.AttributeExpr.t(),
+          children: list(Surface.AST.t()),
+          debug: list(atom()),
+          meta: Surface.AST.Meta.t()
+        }
+end
+
 defmodule Surface.AST.Expr do
   @moduledoc """
   An AST node representing an expression which does not resolve to a value printed out to the final DOM.

--- a/lib/surface/ast.ex
+++ b/lib/surface/ast.ex
@@ -54,7 +54,7 @@ defmodule Surface.AST.Block do
   @type t :: %__MODULE__{
           name: binary(),
           expression: Surface.AST.AttributeExpr.t(),
-          sub_blocks: [{:default | binary(), Surface.AST.t()}],
+          sub_blocks: list(Surface.AST.SubBlock.t()),
           debug: list(atom()),
           meta: Surface.AST.Meta.t()
         }
@@ -74,7 +74,7 @@ defmodule Surface.AST.SubBlock do
   defstruct [:name, :expression, :children, :meta, debug: []]
 
   @type t :: %__MODULE__{
-          name: binary(),
+          name: :default | binary(),
           expression: Surface.AST.AttributeExpr.t(),
           children: list(Surface.AST.t()),
           debug: list(atom()),

--- a/lib/surface/compiler/helpers.ex
+++ b/lib/surface/compiler/helpers.ex
@@ -26,8 +26,8 @@ defmodule Surface.Compiler.Helpers do
     @builtin_assigns_by_type[type]
   end
 
-  def interpolation_to_quoted!(text, meta) do
-    case Code.string_to_quoted(text, file: meta.file, line: meta.line) do
+  def expression_to_quoted!(text, meta) do
+    case Code.string_to_quoted(text, file: meta.file, line: meta.line, column: meta.column) do
       {:ok, expr} ->
         expr
 
@@ -102,11 +102,11 @@ defmodule Surface.Compiler.Helpers do
     assigns
   end
 
-  def to_meta(tree_meta, %CompileMeta{caller: caller, checks: checks}) do
+  def to_meta(tree_meta, %CompileMeta{caller: caller, checks: checks} = compile_meta) do
     %AST.Meta{
-      line: tree_meta.line,
-      column: tree_meta.column,
-      file: tree_meta.file,
+      line: tree_meta[:line] || compile_meta.line,
+      column: tree_meta[:column],
+      file: tree_meta[:file] || compile_meta.file,
       caller: caller,
       checks: checks
     }

--- a/lib/surface/compiler/helpers.ex
+++ b/lib/surface/compiler/helpers.ex
@@ -102,11 +102,11 @@ defmodule Surface.Compiler.Helpers do
     assigns
   end
 
-  def to_meta(tree_meta, %CompileMeta{caller: caller, checks: checks} = compile_meta) do
+  def to_meta(tree_meta, %CompileMeta{caller: caller, checks: checks}) do
     %AST.Meta{
-      line: tree_meta[:line] || compile_meta.line,
-      column: tree_meta[:column],
-      file: tree_meta[:file] || compile_meta.file,
+      line: tree_meta.line,
+      column: tree_meta.column,
+      file: tree_meta.file,
       caller: caller,
       checks: checks
     }

--- a/lib/surface/compiler/parse_tree_translator.ex
+++ b/lib/surface/compiler/parse_tree_translator.ex
@@ -53,11 +53,11 @@ defmodule Surface.Compiler.ParseTreeTranslator do
       IOHelper.compile_error(message, meta.file, meta.line)
     end
 
-    {{:block, :default, expr, [], %{}}, state}
+    {{:block, :default, expr, [], to_meta(meta)}, state}
   end
 
-  def handle_subblock(:default, expr, children, _meta, state, _context) do
-    {{:block, :default, expr, children, %{}}, state}
+  def handle_subblock(:default, expr, children, meta, state, _context) do
+    {{:block, :default, expr, children, to_meta(meta)}, state}
   end
 
   def handle_subblock(name, expr, children, meta, state, _context) do
@@ -174,12 +174,12 @@ defmodule Surface.Compiler.ParseTreeTranslator do
     %{tag_name: name}
   end
 
-  def context_for_subblock(_name, _meta, _state, parent_context) do
-    parent_context
+  def context_for_subblock(name, _meta, _state, parent_context) do
+    %{sub_block: name, parent_block: Map.get(parent_context, :block_name)}
   end
 
   def context_for_block(name, _meta, _state) do
-    %{parent_block: name}
+    %{block_name: name}
   end
 
   def to_meta(%{void_tag?: true} = meta) do

--- a/test/constructs/case_test.exs
+++ b/test/constructs/case_test.exs
@@ -41,6 +41,31 @@ defmodule Surface.Constructs.CaseTest do
            """
   end
 
+  test "nested case/match" do
+    assigns = %{value: [{1, 2}]}
+
+    html =
+      render_surface do
+        ~F"""
+        {#case @value}
+          {#match [tuple | _]}
+            {#case tuple}
+              {#match {_, var}}
+                <span>Nested. Var: {var}</span>
+              {#match _}
+                <span>Last nested match</span>
+            {/case}
+          {#match _}
+            <span>Last match</span>
+        {/case}
+        """
+      end
+
+    assert html =~ """
+           <span>Nested. Var: 2</span>
+           """
+  end
+
   test "raise error if default sub-block has content" do
     code =
       quote do

--- a/test/constructs/case_test.exs
+++ b/test/constructs/case_test.exs
@@ -1,0 +1,103 @@
+defmodule Surface.Constructs.CaseTest do
+  use Surface.ConnCase, async: true
+
+  test "renders matching first sub-block" do
+    assigns = %{value: [1, 2]}
+
+    html =
+      render_surface do
+        ~F"""
+        {#case @value}
+          {#match [var | _]}
+            <span>First match. Var: {var}</span>
+          {#match _}
+            <span>Last match</span>
+        {/case}
+        """
+      end
+
+    assert html =~ """
+           <span>First match. Var: 1</span>
+           """
+  end
+
+  test "renders matching last sub-block" do
+    assigns = %{value: []}
+
+    html =
+      render_surface do
+        ~F"""
+        {#case @value}
+          {#match [var | _]}
+            <span>First match. Var: {var}</span>
+          {#match _}
+            <span>Last match</span>
+        {/case}
+        """
+      end
+
+    assert html =~ """
+           <span>Last match</span>
+           """
+  end
+
+  test "raise error if default sub-block has content" do
+    code =
+      quote do
+        ~F"""
+        <br>
+        {#case @value}
+          <span>First match</span>
+        {#match _}
+          <span>Last match</span>
+        {/case}
+        """
+      end
+
+    message = ~S(code:2: cannot have content between {#case ...} and {#match ...})
+
+    assert_raise(CompileError, message, fn ->
+      compile_surface(code)
+    end)
+  end
+
+  test "raise syntax error message at the correct line" do
+    code =
+      quote do
+        ~F"""
+        {#case @value}
+          {#match [_]}
+            <span>First</span>
+          {#match {,}}
+            <span>Last</span>
+        {/case}
+        """
+      end
+
+    message = ~S(code:4: syntax error before: ',')
+
+    assert_raise(SyntaxError, message, fn ->
+      compile_surface(code)
+    end)
+  end
+
+  test "raise parser error message at the correct line" do
+    code =
+      quote do
+        ~F"""
+        {#case @value}
+          {#match [_]}
+            <span>First</span>
+          {#match _}
+            <span>The inner content
+        {/case}
+        """
+      end
+
+    message = ~S(code:5:14: expected closing node for <span> defined on line 5, got {/case})
+
+    assert_raise(Surface.Compiler.ParseError, message, fn ->
+      compile_surface(code)
+    end)
+  end
+end

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -860,7 +860,7 @@ defmodule Surface.Compiler.ParserTest do
                      %{line: 1, file: "nofile", column: 6}}
                   ],
                   [
-                    {:block, :default, [], ["\n  1\n"], %{}},
+                    {:block, :default, [], ["\n  1\n"], %{column: 3, file: "nofile", line: 1}},
                     {:block, "else", [], ["\n  2\n"], %{line: 3, file: "nofile", column: 3}}
                   ], %{line: 1, file: "nofile", column: 3, has_sub_blocks?: true}}
                ]
@@ -887,7 +887,7 @@ defmodule Surface.Compiler.ParserTest do
                      %{line: 1, file: "nofile", column: 6}}
                   ],
                   [
-                    {:block, :default, [], ["\n  1\n"], %{}},
+                    {:block, :default, [], ["\n  1\n"], %{column: 3, file: "nofile", line: 1}},
                     {:block, "elseif", [], ["\n  2\n"], %{line: 3, file: "nofile", column: 3}},
                     {:block, "elseif", [], ["\n  3\n"], %{line: 5, file: "nofile", column: 3}},
                     {:block, "else", [], ["\n  4\n"], %{line: 7, file: "nofile", column: 3}}
@@ -919,7 +919,7 @@ defmodule Surface.Compiler.ParserTest do
                      %{line: 1, file: "nofile", column: 6}}
                   ],
                   [
-                    {:block, :default, [], ["\n  111\n"], %{}},
+                    {:block, :default, [], ["\n  111\n"], %{column: 3, file: "nofile", line: 1}},
                     {:block, "elseif",
                      [
                        {:root, {:attribute_expr, "2", %{line: 3, file: "nofile", column: 10}},
@@ -933,7 +933,8 @@ defmodule Surface.Compiler.ParserTest do
                            %{line: 5, file: "nofile", column: 8}}
                         ],
                         [
-                          {:block, :default, [], ["\n    333\n  "], %{}},
+                          {:block, :default, [], ["\n    333\n  "],
+                           %{column: 5, file: "nofile", line: 5}},
                           {:block, "else", [], ["\n    444\n  "],
                            %{line: 7, file: "nofile", column: 5}}
                         ], %{has_sub_blocks?: true, line: 5, file: "nofile", column: 5}},


### PR DESCRIPTION
I decided to create generic `AST.Block` and `AST.SubBlock` nodes to represent `case/match`. I think it simplifies the code a lot. And now that we have all constructs standardized with the same shape, I don't think it's necessary to have a specific node for each one of them.

I believe all other blocks (if/elseif/else, for/else, ...) could be much easier to implement using this approach as they would share the implementation in `Surface.Compiler`. The code in `Surface.Compiler.EExEngine` also gets much simpler, IMO. Here's the `to_expression/3` implementation for `case`:

```elixir
  defp to_expression(%AST.Block{name: "case"} = block, buffer, state) do
    %AST.Block{expression: case_expr, sub_blocks: sub_blocks} = block

    state = %{state | depth: state.depth + 1, context: [:case | state.context]}

    match_blocks =
      Enum.flat_map(sub_blocks, fn %AST.SubBlock{children: children, expression: expr} ->
        match_body = handle_nested_block(children, buffer, state)

        quote do
          unquote(expr) -> unquote(match_body)
        end
      end)

    quote do
      case unquote(case_expr) do
        unquote(match_blocks)
      end
    end
    |> maybe_print_expression(block)
  end
 ```

I also implemented some of the validation in `Surface.Compiler.ParseTreeTranslator` as it contains information about the parent block. All validations should be unified later when we start generating the AST directly in the node translator.

**Quick general note:** as you can see, I'm starting to avoid pattern matching everything I can in the head of the functions. If something is not required to match in order to distinguish the different function clauses, I prefer to have an extra line right below the head just to extract the other information. This makes it much easier to read the function head as well as preventing it from be broken by the formatter. However, if the function head is small enough, I don't see a problem extracting everything there.