### PR TITLE
evaluate literal expressions at compile time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   * Introduce `s-` prefix as an alternative to `:` for directives (i.e. `s-if` and `:if` are now equivalent)
   * Introduce `:values` directive for generating multiple `phx-value-` attributes
   * Added a convert task to aid migrating to the new syntax
+  * Evaluate literal attribute values at compile time instead of runtime
 
 ### Deprecations
 

--- a/lib/surface/ast.ex
+++ b/lib/surface/ast.ex
@@ -88,14 +88,16 @@ defmodule Surface.AST.Expr do
 
   ## Properties
       * `:value` - a quoted expression
+      * `:constant?` - true if the expression can be evaluated at compile time
       * `:meta` - compile meta
       * `:directives` - directives associated with this expression node
   """
-  defstruct [:value, :meta, directives: []]
+  defstruct [:value, :meta, constant?: false, directives: []]
 
   @type t :: %__MODULE__{
           # quoted expression
           value: any(),
+          constant?: boolean(),
           directives: list(Surface.AST.Directive.t()),
           meta: Surface.AST.Meta.t()
         }
@@ -215,14 +217,16 @@ defmodule Surface.AST.Attribute do
       * `:type_opts` - a keyword list of options for the type
       * `:name` - the name of the attribute (e.g. `:class`)
       * `:value` - a list of nodes that can be concatenated to form the value for this attribute. Potentially contains dynamic data
+      * `:constant?` - true if the attribute can be evaluated at compile time
       * `:meta` - compilation meta data
   """
-  defstruct [:name, :type, :type_opts, :value, :meta]
+  defstruct [:name, :type, :type_opts, :value, :meta, constant?: false]
 
   @type t :: %__MODULE__{
           type: atom(),
           type_opts: keyword(),
           name: atom(),
+          constant?: boolean(),
           value: Surface.AST.Literal.t() | Surface.AST.AttributeExpr.t(),
           meta: Surface.AST.Meta.t()
         }
@@ -251,14 +255,16 @@ defmodule Surface.AST.AttributeExpr do
   ## Properties
       * `:original` - the original text, useful for debugging and error messages
       * `:value` - a quoted expression
+      * `:constant?` - true if the expression can be evaluated at compile time
       * `:meta` - compilation meta data
   """
-  defstruct [:original, :value, :meta]
+  defstruct [:original, :value, :meta, constant?: false]
 
   @type t :: %__MODULE__{
           # quoted
           value: any(),
           original: binary(),
+          constant?: boolean(),
           meta: Surface.AST.Meta.t()
         }
 end
@@ -270,15 +276,17 @@ defmodule Surface.AST.Interpolation do
   ## Properties
       * `:original` - the original text, useful for debugging and error messages
       * `:value` - a quoted expression
+      * `:constant?` - true if the expression can be evaluated at compile time
       * `:meta` - compilation meta data
       * `:directives` - directives associated with this interpolation
   """
-  defstruct [:original, :value, :meta, directives: []]
+  defstruct [:original, :value, :meta, constant?: false, directives: []]
 
   @type t :: %__MODULE__{
           original: binary(),
           # quoted
           value: any(),
+          constant?: boolean(),
           directives: list(Surface.AST.Directive.t()),
           meta: Surface.AST.Meta.t()
         }

--- a/lib/surface/directive/component_props.ex
+++ b/lib/surface/directive/component_props.ex
@@ -31,10 +31,10 @@ defmodule Surface.Directive.ComponentProps do
   end
 
   defp directive_value(value, meta) do
-    %AST.AttributeExpr{
-      original: value,
-      value: Surface.TypeHandler.expr_to_quoted!(value, ":props", :map, meta),
-      meta: meta
-    }
+    AST.AttributeExpr.new(
+      Surface.TypeHandler.expr_to_quoted!(value, ":props", :map, meta),
+      value,
+      meta
+    )
   end
 end

--- a/lib/surface/directive/debug.ex
+++ b/lib/surface/directive/debug.ex
@@ -16,11 +16,7 @@ defmodule Surface.Directive.Debug do
     %AST.Directive{
       module: __MODULE__,
       name: :debug,
-      value: %AST.AttributeExpr{
-        original: "",
-        value: [:code],
-        meta: attr_meta
-      },
+      value: AST.AttributeExpr.new([:code], "", attr_meta),
       meta: attr_meta
     }
   end
@@ -38,11 +34,7 @@ defmodule Surface.Directive.Debug do
 
     if type in [AST.VoidTag, AST.Tag, AST.Container] and Enum.member?(node.debug, :code) do
       %AST.If{
-        condition: %AST.AttributeExpr{
-          original: "generated from :debug",
-          value: true,
-          meta: node.meta
-        },
+        condition: AST.AttributeExpr.new(true, "generated from :debug", node.meta),
         debug: node.debug,
         meta: node.meta,
         children: [node]
@@ -61,11 +53,7 @@ defmodule Surface.Directive.Debug do
       end
     end
 
-    %AST.AttributeExpr{
-      value: expr,
-      original: value,
-      meta: meta
-    }
+    AST.AttributeExpr.new(expr, value, meta)
   end
 
   @spec invalid_debug_value!(any(), Surface.AST.Meta.t()) :: no_return()

--- a/lib/surface/directive/events.ex
+++ b/lib/surface/directive/events.ex
@@ -64,11 +64,7 @@ defmodule Surface.Directive.Events do
   end
 
   defp to_quoted_expr(_name, [], meta) do
-    %AST.AttributeExpr{
-      original: "",
-      value: nil,
-      meta: meta
-    }
+    AST.AttributeExpr.new(nil, "", meta)
   end
 
   defp to_quoted_expr(name, value, meta) when is_list(value) do
@@ -76,11 +72,11 @@ defmodule Surface.Directive.Events do
   end
 
   defp to_quoted_expr(name, event, meta) when is_binary(event) or is_bitstring(event) do
-    %AST.AttributeExpr{
-      original: event,
-      value: Surface.TypeHandler.expr_to_quoted!(Macro.to_string(event), name, :event, meta),
-      meta: meta
-    }
+    AST.AttributeExpr.new(
+      Surface.TypeHandler.expr_to_quoted!(Macro.to_string(event), name, :event, meta),
+      event,
+      meta
+    )
   end
 
   defp to_quoted_expr(name, {:attribute_expr, original, expr_meta}, meta) do
@@ -95,11 +91,7 @@ defmodule Surface.Directive.Events do
         value -> value
       end
 
-    %AST.AttributeExpr{
-      original: original,
-      value: value,
-      meta: expr_meta
-    }
+    AST.AttributeExpr.new(value, original, expr_meta)
   end
 
   def event_name(%{name: name}) do

--- a/lib/surface/directive/for.ex
+++ b/lib/surface/directive/for.ex
@@ -21,11 +21,7 @@ defmodule Surface.Directive.For do
       |> Surface.TypeHandler.expr_to_quoted!(":for", :generator, meta)
       |> handle_modifiers(attr_meta.modifiers, %{line: attr_meta.line, file: meta.file})
 
-    %AST.AttributeExpr{
-      original: value,
-      value: quoted_value,
-      meta: meta
-    }
+    AST.AttributeExpr.new(quoted_value, value, meta)
   end
 
   defp handle_modifiers([{:<-, clause_meta, [var, list]}], ["with_index" | modifiers], meta) do

--- a/lib/surface/directive/hook.ex
+++ b/lib/surface/directive/hook.ex
@@ -43,11 +43,11 @@ defmodule Surface.Directive.Hook do
   defp directive_value({:attribute_expr, value, expr_meta}, _attr_meta, meta) do
     new_meta = Helpers.to_meta(expr_meta, meta)
 
-    %AST.AttributeExpr{
-      original: value,
-      value: Surface.TypeHandler.expr_to_quoted!(value, ":hook", :hook, new_meta),
-      meta: meta
-    }
+    AST.AttributeExpr.new(
+      Surface.TypeHandler.expr_to_quoted!(value, ":hook", :hook, new_meta),
+      value,
+      meta
+    )
   end
 
   defp directive_value(value, attr_meta, meta) do

--- a/lib/surface/directive/if.ex
+++ b/lib/surface/directive/if.ex
@@ -16,10 +16,10 @@ defmodule Surface.Directive.If do
     do: %AST.If{condition: expr, children: [node], meta: meta}
 
   defp directive_value(value, meta) do
-    %AST.AttributeExpr{
-      original: value,
-      value: Surface.TypeHandler.expr_to_quoted!(value, ":if", :boolean, meta),
-      meta: meta
-    }
+    AST.AttributeExpr.new(
+      Surface.TypeHandler.expr_to_quoted!(value, ":if", :boolean, meta),
+      value,
+      meta
+    )
   end
 end

--- a/lib/surface/directive/let.ex
+++ b/lib/surface/directive/let.ex
@@ -30,10 +30,10 @@ defmodule Surface.Directive.Let do
   def process(_, node), do: node
 
   defp directive_value(value, meta) do
-    %AST.AttributeExpr{
-      value: Surface.TypeHandler.expr_to_quoted!(value, ":let", :bindings, meta),
-      original: value,
-      meta: meta
-    }
+    AST.AttributeExpr.new(
+      Surface.TypeHandler.expr_to_quoted!(value, ":let", :bindings, meta),
+      value,
+      meta
+    )
   end
 end

--- a/lib/surface/directive/show.ex
+++ b/lib/surface/directive/show.ex
@@ -64,7 +64,8 @@ defmodule Surface.Directive.Show do
           | value:
               quote generated: true do
                 not unquote(value)
-              end
+              end,
+            constant?: false
         },
         meta: show_meta
       }
@@ -95,22 +96,19 @@ defmodule Surface.Directive.Show do
   end
 
   defp directive_value(value, meta) do
-    expr = Surface.TypeHandler.expr_to_quoted!(value, ":show", :boolean, meta)
-
-    %AST.AttributeExpr{
-      original: value,
-      value: expr,
-      meta: meta
-    }
+    AST.AttributeExpr.new(
+      Surface.TypeHandler.expr_to_quoted!(value, ":show", :boolean, meta),
+      value,
+      meta
+    )
   end
 
   defp style_value_to_expr(%AST.Literal{value: value}, attr_meta) do
-    %AST.AttributeExpr{
-      original: value,
-      value:
-        Surface.TypeHandler.expr_to_quoted!(Macro.to_string(value), ":style", :style, attr_meta),
-      meta: attr_meta
-    }
+    AST.AttributeExpr.new(
+      Surface.TypeHandler.expr_to_quoted!(Macro.to_string(value), ":style", :style, attr_meta),
+      value,
+      attr_meta
+    )
   end
 
   defp style_value_to_expr(attr_value, _attr_meta) do

--- a/lib/surface/directive/slot_props.ex
+++ b/lib/surface/directive/slot_props.ex
@@ -19,11 +19,11 @@ defmodule Surface.Directive.SlotProps do
   end
 
   defp directive_value(value, meta) do
-    %AST.AttributeExpr{
-      value: Surface.TypeHandler.expr_to_quoted!(value, ":props", :explict_keyword, meta),
-      original: value,
-      meta: meta
-    }
+    AST.AttributeExpr.new(
+      Surface.TypeHandler.expr_to_quoted!(value, ":props", :explict_keyword, meta),
+      value,
+      meta
+    )
   end
 
   defp validate_keys!(slot, value, meta) do

--- a/lib/surface/directive/tag_attrs.ex
+++ b/lib/surface/directive/tag_attrs.ex
@@ -46,10 +46,10 @@ defmodule Surface.Directive.TagAttrs do
   end
 
   defp directive_value(value, meta) do
-    %AST.AttributeExpr{
-      original: value,
-      value: Surface.TypeHandler.expr_to_quoted!(value, ":attrs", :map, meta),
-      meta: meta
-    }
+    AST.AttributeExpr.new(
+      Surface.TypeHandler.expr_to_quoted!(value, ":attrs", :map, meta),
+      value,
+      meta
+    )
   end
 end

--- a/lib/surface/directive/values.ex
+++ b/lib/surface/directive/values.ex
@@ -49,11 +49,11 @@ defmodule Surface.Directive.Values do
   end
 
   defp directive_value(value, meta) do
-    %AST.AttributeExpr{
-      original: value,
-      value: Surface.TypeHandler.expr_to_quoted!(value, ":values", :map, meta),
-      meta: meta
-    }
+    AST.AttributeExpr.new(
+      Surface.TypeHandler.expr_to_quoted!(value, ":values", :map, meta),
+      value,
+      meta
+    )
   end
 
   def validate_value!(name, value) do

--- a/lib/surface/type_handler.ex
+++ b/lib/surface/type_handler.ex
@@ -165,18 +165,25 @@ defmodule Surface.TypeHandler do
   end
 
   def attr_to_html!(type, name, value) do
+    case attr_to_html(type, name, value) do
+      {:ok, value} -> value
+      {:error, message} -> IOHelper.runtime_error(message)
+    end
+  end
+
+  def attr_to_html(type, name, value) do
     case handler(type).value_to_html(name, value) do
       {:ok, val} when val in ["", nil, false] ->
-        ""
+        {:ok, ""}
 
       {:ok, true} ->
-        [~S( ), to_string(name)]
+        {:ok, [~S( ), to_string(name)]}
 
       {:ok, val} ->
-        [" ", to_string(name), "=", ~S("), Phoenix.HTML.Safe.to_iodata(val), ~S(")]
+        {:ok, [" ", to_string(name), "=", ~S("), Phoenix.HTML.Safe.to_iodata(val), ~S(")]}
 
       {:error, message} ->
-        IOHelper.runtime_error(message)
+        {:error, message}
     end
   end
 

--- a/lib/surface/type_handler/css_class.ex
+++ b/lib/surface/type_handler/css_class.ex
@@ -10,11 +10,11 @@ defmodule Surface.TypeHandler.CssClass do
 
   def literal_to_ast_node(type, name, value, meta) do
     {:ok,
-     %Surface.AST.AttributeExpr{
-       original: value,
-       value: Surface.TypeHandler.expr_to_quoted!(Macro.to_string(value), name, type, meta),
-       meta: meta
-     }}
+     Surface.AST.AttributeExpr.new(
+       Surface.TypeHandler.expr_to_quoted!(Macro.to_string(value), name, type, meta),
+       value,
+       meta
+     )}
   end
 
   @impl true

--- a/lib/surface/type_handler/event.ex
+++ b/lib/surface/type_handler/event.ex
@@ -6,11 +6,11 @@ defmodule Surface.TypeHandler.Event do
   @impl true
   def literal_to_ast_node(type, name, value, meta) when is_binary(value) do
     {:ok,
-     %Surface.AST.AttributeExpr{
-       original: value,
-       value: Surface.TypeHandler.expr_to_quoted!(Macro.to_string(value), name, type, meta),
-       meta: meta
-     }}
+     Surface.AST.AttributeExpr.new(
+       Surface.TypeHandler.expr_to_quoted!(Macro.to_string(value), name, type, meta),
+       value,
+       meta
+     )}
   end
 
   def literal_to_ast_node(_type, _name, _value, _meta) do

--- a/lib/surface/type_handler/hook.ex
+++ b/lib/surface/type_handler/hook.ex
@@ -6,11 +6,11 @@ defmodule Surface.TypeHandler.Hook do
   @impl true
   def literal_to_ast_node(type, name, value, meta) when is_binary(value) do
     {:ok,
-     %Surface.AST.AttributeExpr{
-       original: value,
-       value: Surface.TypeHandler.expr_to_quoted!(Macro.to_string(value), name, type, meta),
-       meta: meta
-     }}
+     Surface.AST.AttributeExpr.new(
+       Surface.TypeHandler.expr_to_quoted!(Macro.to_string(value), name, type, meta),
+       value,
+       meta
+     )}
   end
 
   def literal_to_ast_node(_type, _name, _value, _meta) do

--- a/test/compiler_test.exs
+++ b/test/compiler_test.exs
@@ -436,6 +436,31 @@ defmodule Surface.CompilerTest do
            } = node
   end
 
+  test "attribute values that are runtime constants" do
+    code = """
+    <div number={1} string={"string"} bool={true} class={"c1", "c2", "c3", "c4"}></div>
+    """
+
+    [node | _] = Surface.Compiler.compile(code, 1, __ENV__)
+
+    assert %Surface.AST.Tag{
+             attributes: [
+               %Surface.AST.Attribute{
+                 value: %Surface.AST.AttributeExpr{constant?: true}
+               },
+               %Surface.AST.Attribute{
+                 value: %Surface.AST.AttributeExpr{constant?: true}
+               },
+               %Surface.AST.Attribute{
+                 value: %Surface.AST.AttributeExpr{constant?: true}
+               },
+               %Surface.AST.Attribute{
+                 value: %Surface.AST.AttributeExpr{constant?: true}
+               }
+             ]
+           } = node
+  end
+
   describe "macro components" do
     test "inject a __compile_dep__/0 macro call to force compile-time dependency" do
       code = """

--- a/test/directives_test.exs
+++ b/test/directives_test.exs
@@ -949,14 +949,14 @@ defmodule Surface.DirectivesTest do
     end
 
     test "passing unsupported types" do
-      assert_raise(RuntimeError, ~r(invalid value for key ":map" in attribute ":values".), fn ->
-        render_surface do
-          ~F"""
-          <div :values={map: %{}, tuple: {}}>
-            Some Text
-          </div>
-          """
-        end
+      assert_raise(CompileError, ~r(invalid value for key ":map" in attribute ":values".), fn ->
+        """
+        <div :values={map: %{}, tuple: {}}>
+          Some Text
+        </div>
+        """
+        |> Surface.Compiler.compile(1, __ENV__)
+        |> Surface.Compiler.to_live_struct()
       end)
     end
 

--- a/test/html_tag_test.exs
+++ b/test/html_tag_test.exs
@@ -4,12 +4,10 @@ defmodule HtmlTagTest do
   @encoded_json "[{\"x\":10,\"y\":20}]"
 
   test "raise runtime error for invalid attributes values" do
-    assert_raise(RuntimeError, ~r/invalid value for attribute "title"/, fn ->
-      render_surface do
-        ~F"""
-        <div title={{1, 2}}/>
-        """
-      end
+    assert_raise(CompileError, ~r/invalid value for attribute "title"/, fn ->
+      "<div title={{1, 2}}/>"
+      |> Surface.Compiler.compile(1, __ENV__)
+      |> Surface.Compiler.to_live_struct()
     end)
   end
 
@@ -404,12 +402,10 @@ defmodule HtmlTagTest do
     end
 
     test "raise compile error for invalid style value that can be evaluated at compile time" do
-      assert_raise(RuntimeError, ~r/invalid value for attribute "style"/, fn ->
-        render_surface do
-          ~F"""
-          <div style={{1, 2}}/>
-          """
-        end
+      assert_raise(CompileError, ~r/invalid value for attribute "style"/, fn ->
+        "<div style={{1, 2}}/>"
+        |> Surface.Compiler.compile(1, __ENV__)
+        |> Surface.Compiler.to_live_struct()
       end)
     end
 

--- a/test/html_tag_test.exs
+++ b/test/html_tag_test.exs
@@ -403,11 +403,23 @@ defmodule HtmlTagTest do
              """
     end
 
-    test "raise runtime error for invalid style value" do
+    test "raise compile error for invalid style value that can be evaluated at compile time" do
       assert_raise(RuntimeError, ~r/invalid value for attribute "style"/, fn ->
         render_surface do
           ~F"""
           <div style={{1, 2}}/>
+          """
+        end
+      end)
+    end
+
+    test "raise runtime error for invalid style value" do
+      assert_raise(RuntimeError, ~r/invalid value for attribute "style"/, fn ->
+        assigns = %{style: {1, 2}}
+
+        render_surface do
+          ~F"""
+          <div style={@style}/>
           """
         end
       end)


### PR DESCRIPTION
This came about because I was noticing a lot of `class="..."` and similar in the websocket diff payloads for literal values, and I was curious how much bandwidth we could save if we evaluated these literal expressions at compile time instead of runtime (which would be more in line with what would happen using pure live view).

This should only effect expressions which are essentially quoted literals, and should not effect any expression that calls a function or uses a variable/assign.

I tested it out on a project of mine locally that uses tailwind extensively, and it resulted in ~10% less data over the wire for diff payloads. I didn't do extensive testing on the savings though, so that number should be taken with a grain of salt.