### PR TITLE
Add static option for prop

### DIFF
--- a/lib/surface/api.ex
+++ b/lib/surface/api.ex
@@ -404,7 +404,7 @@ defmodule Surface.API do
   end
 
   defp get_valid_opts(:prop, _type, _opts) do
-    [:required, :default, :values, :values!, :accumulate, :root]
+    [:required, :default, :values, :values!, :accumulate, :root, :static]
   end
 
   defp get_valid_opts(:data, _type, _opts) do
@@ -439,6 +439,11 @@ defmodule Surface.API do
   defp validate_opt(:prop, _name, _type, _opts, :root, value, _line, _env)
        when not is_boolean(value) do
     {:error, "invalid value for option :root. Expected a boolean, got: #{inspect(value)}"}
+  end
+
+  defp validate_opt(:prop, _name, _type, _opts, :static, value, _line, _env)
+       when not is_boolean(value) do
+    {:error, "invalid value for option :static. Expected a boolean, got: #{inspect(value)}"}
   end
 
   defp validate_opt(_func, _name, _type, _opts, :required, value, _line, _env)

--- a/test/surface/api_test.exs
+++ b/test/surface/api_test.exs
@@ -83,6 +83,13 @@ defmodule Surface.APITest do
     assert_raise(CompileError, message, fn -> eval(code) end)
   end
 
+  test "validate :static in prop" do
+    code = "prop label, :string, static: 1"
+    message = ~r/invalid value for option :static. Expected a boolean, got: 1/
+
+    assert_raise(CompileError, message, fn -> eval(code) end)
+  end
+
   test "validate duplicate assigns" do
     code = """
     prop label, :string
@@ -321,7 +328,7 @@ defmodule Surface.APITest do
       code = "prop label, :string, a: 1"
 
       message =
-        ~r/unknown option :a. Available options: \[:required, :default, :values, :values!, :accumulate, :root\]/
+        ~r/unknown option :a. Available options: \[:required, :default, :values, :values!, :accumulate, :root, :static\]/
 
       assert_raise(CompileError, message, fn ->
         eval(code)


### PR DESCRIPTION
As we can now use dynamic expressions's in macro components, we need a way to differentiate props that are meant to be used at compile-time and props that will be forwarded to the generated AST and evaluated at runtime. 

This PR adds a `:static` option to `prop` to achieve that goal. This option is used by `MacroComponent.eval_static_props!/3` so it bypass the runtime props while evaluating/validating the values.

### Usage

```
@doc "The value of this prop will be used at compile-time"
prop unwrap, boolean, static: true
```