### PR TITLE
Replace slot option :props with :args

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -11,6 +11,9 @@ translate Surface `v0.4` code into the new `v0.5` syntax.
   * The replacement of `~H` with `~F` happens globally in a `.ex` (or `.exs`) file, i.e., the converter will
   replace any occurrence of `~H` followed by `"""`, `"`, `[`, `(` or `{`, including occurrences found in comments.
 
+  * The replacement of `slot name, props: [...]` with `slot name, args: [...]` happens globally in a `.ex` (or `.exs`) file,
+  i.e., the converter will replace any occurrence of it, even if found in comments.
+
   * Running the converter on a project that has already been converted may generate invalid code. If anything goes
   wrong with the conversion, make sure you revert the changes before running it again.
 
@@ -76,16 +79,16 @@ mix compile
 
 ## Expected changes
 
-| Subject                      | Examples (Old syntax -> New syntax)                                      |
-| ---------------------------- | ------------------------------------------------------------------------ |
-| Sigil                        | `~H"""` -> `~F"""`                                                       |
-| Interpolation                | `{{@value}}` -> `{@value}`                                               |
-| Templates                    | `<template>` -> `<#template>`                                            |
-| Slots                        | `<slot :props={{ item: item }}>` -> `<#slot :args={item: item}>`         |
-| If                           | `<If condition={{ expr }}>` -> `{#if expr}`                              |
-| For                          | `<For each={{ expr }}>` -> `{#for expr}`                                 |
-| Interpolation in attr values | `id="id_{{@id}}"` -> `id={"id_#{@id}"}`                                  |
-| Non-string attr values       | `selected=true` -> `selected={true}` <br> `tabindex=1` -> `tabindex={1}` |
+| Subject                      | Examples (Old syntax -> New syntax)                                                                                                      |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| Sigil                        | `~H"""` -> `~F"""`                                                                                                                       |
+| Interpolation                | `{{@value}}` -> `{@value}`                                                                                                               |
+| Templates                    | `<template>` -> `<#template>`                                                                                                            |
+| If                           | `<If condition={{ expr }}>` -> `{#if expr}`                                                                                              |
+| For                          | `<For each={{ expr }}>` -> `{#for expr}`                                                                                                 |
+| Interpolation in attr values | `id="id_{{@id}}"` -> `id={"id_#{@id}"}`                                                                                                  |
+| Non-string attr values       | &bull; `selected=true` -> `selected={true}` <br> &bull; `tabindex=1` -> `tabindex={1}`                                                   |
+| Slots                        | &bull; `<slot :props={{ item: item }}>` -> `<#slot :args={item: item}>` <br> &bull; `slot name, props: [...]` -> `slot name, args: [...]`|
 
 ## Reporting issues
 

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -971,7 +971,7 @@ defmodule Surface.Compiler do
             Available arguments: #{inspect(non_generator_args)}.
 
             Hint: You can define a new slot argument using the `args` option: \
-            `slot #{slot_name}, args: [..., #{inspect(arg)}]`\
+            `slot #{slot_name}, args: [..., #{inspect(arg)}]`
             """
 
             IOHelper.compile_error(message, arg_meta.file, arg_meta.line)

--- a/lib/surface/compiler/converter_0_5.ex
+++ b/lib/surface/compiler/converter_0_5.ex
@@ -10,7 +10,8 @@ defmodule Surface.Compiler.Converter_0_5 do
 
   @impl true
   def after_convert_file(ext, content) when ext in [".ex", ".exs"] do
-    Regex.replace(~r/~H("""|\"|\[|\(|\{)/s, content, "~F\\1")
+    content = Regex.replace(~r/~H("""|\"|\[|\(|\{)/s, content, "~F\\1")
+    Regex.replace(~r/^(\s*slot[\s|\(].+?,\s*)props:(.+)/m, content, "\\1args:\\2")
   end
 
   def after_convert_file(_ext, content) do

--- a/lib/surface/directive/slot_props.ex
+++ b/lib/surface/directive/slot_props.ex
@@ -34,15 +34,13 @@ defmodule Surface.Directive.SlotProps do
 
     if undefined_keys != [] do
       undefined_text = Helpers.list_to_string("argument", "arguments", undefined_keys)
-      defined_text = Helpers.list_to_string("argument:", "arguments:", defined_keys)
+      defined_text = Helpers.list_to_string("\n\nDefined argument:", "\n\nDefined arguments:", defined_keys)
 
       message = """
-      undefined #{undefined_text} for slot `#{slot.name}`.
-
-      Defined #{defined_text}.
+      undefined #{undefined_text} for slot `#{slot.name}`.#{defined_text}
 
       Hint: You can define a new slot argument using the `args` option: \
-      `slot default, args: [..., :some_arg]`\
+      `slot default, args: [..., :some_arg]`
       """
 
       IOHelper.compile_error(message, meta.file, meta.line)

--- a/test/surface/compiler/converter_0_5_test.exs
+++ b/test/surface/compiler/converter_0_5_test.exs
@@ -413,7 +413,7 @@ defmodule Surface.Compiler.Converter_0_5Test do
            """
   end
 
-  test "convert slot's :props into :args" do
+  test "replace slot directive :props with :args" do
     code =
       convert("""
       <div :props=""/>
@@ -425,6 +425,28 @@ defmodule Surface.Compiler.Converter_0_5Test do
            <div :props=""/>
            <#slot :args=""/>
            <div :props=""/>
+           """
+  end
+
+  test "replace slot option :props with :args" do
+    code = """
+    # slot commented, props: [:item]
+
+    slot default, required: true, props: [:item]
+    slot cols, props: [:item]
+      slot cols, props: [item: ^items]
+
+      slot(cols, props: [item: ^items])
+    """
+
+    assert Convert.convert_file_contents!("nofile.ex", code) === """
+           # slot commented, props: [:item]
+
+           slot default, required: true, args: [:item]
+           slot cols, args: [:item]
+             slot cols, args: [item: ^items]
+
+             slot(cols, args: [item: ^items])
            """
   end
 

--- a/test/surface/integrations/slot_test.exs
+++ b/test/surface/integrations/slot_test.exs
@@ -643,7 +643,7 @@ defmodule Surface.SlotTest do
     Available arguments: [:info, :item].
 
     Hint: You can define a new slot argument using the `args` option: \
-    `slot cols, args: [..., :non_existing]`\
+    `slot cols, args: [..., :non_existing]`
     """
 
     assert_raise(CompileError, message, fn ->
@@ -712,7 +712,7 @@ defmodule Surface.SlotTest do
     Available arguments: [:info].
 
     Hint: You can define a new slot argument using the `args` option: \
-    `slot default, args: [..., :non_existing]`\
+    `slot default, args: [..., :non_existing]`
     """
 
     assert_raise(CompileError, message, fn ->
@@ -739,7 +739,7 @@ defmodule Surface.SlotTest do
     Available arguments: [:info].
 
     Hint: You can define a new slot argument using the `args` option: \
-    `slot body, args: [..., :non_existing]`\
+    `slot body, args: [..., :non_existing]`
     """
 
     assert_raise(CompileError, message, fn ->
@@ -791,10 +791,42 @@ defmodule Surface.SlotTest do
     message = """
     code.exs:10: undefined arguments :id and :name for slot `default`.
 
-    Defined argument: :item.
+    Defined argument: :item
 
     Hint: You can define a new slot argument using the `args` option: \
-    `slot default, args: [..., :some_arg]`\
+    `slot default, args: [..., :some_arg]`
+    """
+
+    assert_raise(CompileError, message, fn ->
+      {{:module, _, _, _}, _} = Code.eval_string(code, [], %{__ENV__ | file: "code.exs", line: 1})
+    end)
+  end
+
+  test "raise compile error when passing :args but no arg is defined in `slot`" do
+    id = :erlang.unique_integer([:positive]) |> to_string()
+
+    code = """
+    defmodule TestSlotPassingUndefinedArg_#{id} do
+      use Surface.Component
+
+      slot default
+
+      def render(assigns) do
+        ~F"\""
+          <span>
+            <#slot
+              :args={id: 1}/>
+            </span>
+        "\""
+      end
+    end
+    """
+
+    message = """
+    code.exs:10: undefined argument :id for slot `default`.
+
+    Hint: You can define a new slot argument using the `args` option: \
+    `slot default, args: [..., :some_arg]`
     """
 
     assert_raise(CompileError, message, fn ->


### PR DESCRIPTION
  * [converter] Rename :props to :args 
  * Fix error message when no argument is defined for the slot
  * Update migration guide
