### PR TITLE
Fix ErrorTag.translate_error/1 crash

### DIFF
--- a/lib/surface/components/form/error_tag.ex
+++ b/lib/surface/components/form/error_tag.ex
@@ -124,7 +124,14 @@ defmodule Surface.Components.Form.ErrorTag do
     # Because the error messages we show in our forms and APIs
     # are defined inside Ecto, we need to translate them dynamically.
     Enum.reduce(opts, msg, fn {key, value}, acc ->
-      String.replace(acc, "%{#{key}}", to_string(value))
+      # Since this just interpolates opts into the error message,
+      # we can just skip doing so in cases where this doesn't make
+      # sense (the opt value is not convertable to a string).
+      try do
+        String.replace(acc, "%{#{key}}", to_string(value))
+      rescue
+        _e -> acc
+      end
     end)
   end
 


### PR DESCRIPTION
Fixes #436 

Not sure if a try-rescue is the best solution. I used it instead of an `is_atom` because I figured there might be cases where it's a string or some other type that is convertible to a string but not an atom.