### PR TITLE
allow form inputs to accept values

### DIFF
--- a/lib/surface/components/form/checkbox.ex
+++ b/lib/surface/components/form/checkbox.ex
@@ -18,7 +18,7 @@ defmodule Surface.Components.Form.Checkbox do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [checkbox: 3]
-  import Surface.Components.Utils, only: [events_to_opts: 1]
+  import Surface.Components.Utils, only: [events_to_opts: 1, opts_to_attrs: 1]
   import Surface.Components.Form.Utils
 
   @doc "The value to be sent when the checkbox is checked. Defaults to \"true\""
@@ -40,7 +40,7 @@ defmodule Surface.Components.Form.Checkbox do
       ])
 
     attr_opts = props_to_attr_opts(assigns, class: get_config(:default_class))
-    event_opts = events_to_opts(assigns)
+    event_opts = assigns |> events_to_opts() |> opts_to_attrs()
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>

--- a/lib/surface/components/form/checkbox.ex
+++ b/lib/surface/components/form/checkbox.ex
@@ -18,7 +18,7 @@ defmodule Surface.Components.Form.Checkbox do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [checkbox: 3]
-  import Surface.Components.Utils, only: [events_to_opts: 1, opts_to_attrs: 1]
+  import Surface.Components.Utils, only: [events_to_attrs: 1]
   import Surface.Components.Form.Utils
 
   @doc "The value to be sent when the checkbox is checked. Defaults to \"true\""
@@ -40,11 +40,11 @@ defmodule Surface.Components.Form.Checkbox do
       ])
 
     attr_opts = props_to_attr_opts(assigns, class: get_config(:default_class))
-    event_opts = assigns |> events_to_opts() |> opts_to_attrs()
+    event_attrs = events_to_attrs(assigns)
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>
-    {checkbox(form, field, helper_opts ++ attr_opts ++ @opts ++ event_opts)}
+    {checkbox(form, field, helper_opts ++ attr_opts ++ @opts ++ event_attrs)}
     </InputContext>
     """
   end

--- a/lib/surface/components/form/color_input.ex
+++ b/lib/surface/components/form/color_input.ex
@@ -19,17 +19,17 @@ defmodule Surface.Components.Form.ColorInput do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [color_input: 3]
-  import Surface.Components.Utils, only: [events_to_opts: 1, opts_to_attrs: 1]
+  import Surface.Components.Utils, only: [events_to_attrs: 1]
   import Surface.Components.Form.Utils
 
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, [:value, class: get_config(:default_class)])
-    event_opts = assigns |> events_to_opts() |> opts_to_attrs()
+    event_attrs = events_to_attrs(assigns)
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>
-      {color_input(form, field, helper_opts ++ attr_opts ++ @opts ++ event_opts)}
+      {color_input(form, field, helper_opts ++ attr_opts ++ @opts ++ event_attrs)}
     </InputContext>
     """
   end

--- a/lib/surface/components/form/color_input.ex
+++ b/lib/surface/components/form/color_input.ex
@@ -19,13 +19,13 @@ defmodule Surface.Components.Form.ColorInput do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [color_input: 3]
-  import Surface.Components.Utils, only: [events_to_opts: 1]
+  import Surface.Components.Utils, only: [events_to_opts: 1, opts_to_attrs: 1]
   import Surface.Components.Form.Utils
 
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, [:value, class: get_config(:default_class)])
-    event_opts = events_to_opts(assigns)
+    event_opts = assigns |> events_to_opts() |> opts_to_attrs()
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>

--- a/lib/surface/components/form/date_input.ex
+++ b/lib/surface/components/form/date_input.ex
@@ -19,17 +19,17 @@ defmodule Surface.Components.Form.DateInput do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [date_input: 3]
-  import Surface.Components.Utils, only: [events_to_opts: 1, opts_to_attrs: 1]
+  import Surface.Components.Utils, only: [events_to_attrs: 1]
   import Surface.Components.Form.Utils
 
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, [:value, class: get_config(:default_class)])
-    event_opts = assigns |> events_to_opts() |> opts_to_attrs()
+    event_attrs = events_to_attrs(assigns)
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>
-      {date_input(form, field, helper_opts ++ attr_opts ++ @opts ++ event_opts)}
+      {date_input(form, field, helper_opts ++ attr_opts ++ @opts ++ event_attrs)}
     </InputContext>
     """
   end

--- a/lib/surface/components/form/date_input.ex
+++ b/lib/surface/components/form/date_input.ex
@@ -19,13 +19,13 @@ defmodule Surface.Components.Form.DateInput do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [date_input: 3]
-  import Surface.Components.Utils, only: [events_to_opts: 1]
+  import Surface.Components.Utils, only: [events_to_opts: 1, opts_to_attrs: 1]
   import Surface.Components.Form.Utils
 
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, [:value, class: get_config(:default_class)])
-    event_opts = events_to_opts(assigns)
+    event_opts = assigns |> events_to_opts() |> opts_to_attrs()
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>

--- a/lib/surface/components/form/datetime_local_input.ex
+++ b/lib/surface/components/form/datetime_local_input.ex
@@ -19,13 +19,13 @@ defmodule Surface.Components.Form.DateTimeLocalInput do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [datetime_local_input: 3]
-  import Surface.Components.Utils, only: [events_to_opts: 1]
+  import Surface.Components.Utils, only: [events_to_opts: 1, opts_to_attrs: 1]
   import Surface.Components.Form.Utils
 
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, [:value, class: get_config(:default_class)])
-    event_opts = events_to_opts(assigns)
+    event_opts = assigns |> events_to_opts() |> opts_to_attrs()
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>

--- a/lib/surface/components/form/datetime_local_input.ex
+++ b/lib/surface/components/form/datetime_local_input.ex
@@ -19,17 +19,17 @@ defmodule Surface.Components.Form.DateTimeLocalInput do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [datetime_local_input: 3]
-  import Surface.Components.Utils, only: [events_to_opts: 1, opts_to_attrs: 1]
+  import Surface.Components.Utils, only: [events_to_attrs: 1]
   import Surface.Components.Form.Utils
 
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, [:value, class: get_config(:default_class)])
-    event_opts = assigns |> events_to_opts() |> opts_to_attrs()
+    event_attrs = events_to_attrs(assigns)
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>
-      {datetime_local_input(form, field, helper_opts ++ attr_opts ++ @opts ++ event_opts)}
+      {datetime_local_input(form, field, helper_opts ++ attr_opts ++ @opts ++ event_attrs)}
     </InputContext>
     """
   end

--- a/lib/surface/components/form/email_input.ex
+++ b/lib/surface/components/form/email_input.ex
@@ -18,17 +18,17 @@ defmodule Surface.Components.Form.EmailInput do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [email_input: 3]
-  import Surface.Components.Utils, only: [events_to_opts: 1, opts_to_attrs: 1]
+  import Surface.Components.Utils, only: [events_to_attrs: 1]
   import Surface.Components.Form.Utils
 
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, [:value, class: get_config(:default_class)])
-    event_opts = assigns |> events_to_opts() |> opts_to_attrs()
+    event_attrs = events_to_attrs(assigns)
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>
-      {email_input(form, field, helper_opts ++ attr_opts ++ @opts ++ event_opts)}
+      {email_input(form, field, helper_opts ++ attr_opts ++ @opts ++ event_attrs)}
     </InputContext>
     """
   end

--- a/lib/surface/components/form/email_input.ex
+++ b/lib/surface/components/form/email_input.ex
@@ -18,13 +18,13 @@ defmodule Surface.Components.Form.EmailInput do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [email_input: 3]
-  import Surface.Components.Utils, only: [events_to_opts: 1]
+  import Surface.Components.Utils, only: [events_to_opts: 1, opts_to_attrs: 1]
   import Surface.Components.Form.Utils
 
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, [:value, class: get_config(:default_class)])
-    event_opts = events_to_opts(assigns)
+    event_opts = assigns |> events_to_opts() |> opts_to_attrs()
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>

--- a/lib/surface/components/form/file_input.ex
+++ b/lib/surface/components/form/file_input.ex
@@ -22,17 +22,17 @@ defmodule Surface.Components.Form.FileInput do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [file_input: 3]
-  import Surface.Components.Utils, only: [events_to_opts: 1, opts_to_attrs: 1]
+  import Surface.Components.Utils, only: [events_to_attrs: 1]
   import Surface.Components.Form.Utils
 
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, [:value, class: get_config(:default_class)])
-    event_opts = assigns |> events_to_opts() |> opts_to_attrs()
+    event_attrs = events_to_attrs(assigns)
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>
-      {file_input(form, field, helper_opts ++ attr_opts ++ @opts ++ event_opts)}
+      {file_input(form, field, helper_opts ++ attr_opts ++ @opts ++ event_attrs)}
     </InputContext>
     """
   end

--- a/lib/surface/components/form/file_input.ex
+++ b/lib/surface/components/form/file_input.ex
@@ -22,13 +22,13 @@ defmodule Surface.Components.Form.FileInput do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [file_input: 3]
-  import Surface.Components.Utils, only: [events_to_opts: 1]
+  import Surface.Components.Utils, only: [events_to_opts: 1, opts_to_attrs: 1]
   import Surface.Components.Form.Utils
 
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, [:value, class: get_config(:default_class)])
-    event_opts = events_to_opts(assigns)
+    event_opts = assigns |> events_to_opts() |> opts_to_attrs()
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>

--- a/lib/surface/components/form/hidden_input.ex
+++ b/lib/surface/components/form/hidden_input.ex
@@ -18,17 +18,17 @@ defmodule Surface.Components.Form.HiddenInput do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [hidden_input: 3]
-  import Surface.Components.Utils, only: [events_to_opts: 1]
+  import Surface.Components.Utils, only: [events_to_attrs: 1]
   import Surface.Components.Form.Utils
 
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, [:value, :class])
-    event_opts = events_to_opts(assigns)
+    event_attrs = events_to_attrs(assigns)
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>
-      {hidden_input(form, field, helper_opts ++ attr_opts ++ @opts ++ event_opts)}
+      {hidden_input(form, field, helper_opts ++ attr_opts ++ @opts ++ event_attrs)}
     </InputContext>
     """
   end

--- a/lib/surface/components/form/label.ex
+++ b/lib/surface/components/form/label.ex
@@ -15,7 +15,7 @@ defmodule Surface.Components.Form.Label do
   use Surface.Component
   use Surface.Components.Events
 
-  import Surface.Components.Utils, only: [events_to_opts: 1, opts_to_attrs: 1]
+  import Surface.Components.Utils, only: [events_to_attrs: 1]
   import Surface.Components.Form.Utils
   alias Surface.Components.Form.Input.InputContext
 
@@ -44,11 +44,11 @@ defmodule Surface.Components.Form.Label do
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, class: get_config(:default_class))
-    event_opts = assigns |> events_to_opts() |> opts_to_attrs()
+    event_attrs = events_to_attrs(assigns)
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>
-      <label :attrs={helper_opts ++ attr_opts ++ input_id(form, field) ++ @opts ++ event_opts}>
+      <label :attrs={helper_opts ++ attr_opts ++ input_id(form, field) ++ @opts ++ event_attrs}>
         <#slot>{@text || Phoenix.Naming.humanize(field)}</#slot>
       </label>
     </InputContext>

--- a/lib/surface/components/form/number_input.ex
+++ b/lib/surface/components/form/number_input.ex
@@ -18,13 +18,13 @@ defmodule Surface.Components.Form.NumberInput do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [number_input: 3]
-  import Surface.Components.Utils, only: [events_to_opts: 1]
+  import Surface.Components.Utils, only: [events_to_opts: 1, opts_to_attrs: 1]
   import Surface.Components.Form.Utils
 
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, [:value, class: get_config(:default_class)])
-    event_opts = events_to_opts(assigns)
+    event_opts = assigns |> events_to_opts() |> opts_to_attrs()
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>

--- a/lib/surface/components/form/number_input.ex
+++ b/lib/surface/components/form/number_input.ex
@@ -18,17 +18,17 @@ defmodule Surface.Components.Form.NumberInput do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [number_input: 3]
-  import Surface.Components.Utils, only: [events_to_opts: 1, opts_to_attrs: 1]
+  import Surface.Components.Utils, only: [events_to_attrs: 1]
   import Surface.Components.Form.Utils
 
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, [:value, class: get_config(:default_class)])
-    event_opts = assigns |> events_to_opts() |> opts_to_attrs()
+    event_attrs = events_to_attrs(assigns)
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>
-      {number_input(form, field, helper_opts ++ attr_opts ++ @opts ++ event_opts)}
+      {number_input(form, field, helper_opts ++ attr_opts ++ @opts ++ event_attrs)}
     </InputContext>
     """
   end

--- a/lib/surface/components/form/password_input.ex
+++ b/lib/surface/components/form/password_input.ex
@@ -18,17 +18,17 @@ defmodule Surface.Components.Form.PasswordInput do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [password_input: 3]
-  import Surface.Components.Utils, only: [events_to_opts: 1]
+  import Surface.Components.Utils, only: [events_to_attrs: 1]
   import Surface.Components.Form.Utils
 
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, [:value, class: get_config(:default_class)])
-    event_opts = events_to_opts(assigns)
+    event_attrs = events_to_attrs(assigns)
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>
-      {password_input(form, field, helper_opts ++ attr_opts ++ @opts ++ event_opts)}
+      {password_input(form, field, helper_opts ++ attr_opts ++ @opts ++ event_attrs)}
     </InputContext>
     """
   end

--- a/lib/surface/components/form/radio_button.ex
+++ b/lib/surface/components/form/radio_button.ex
@@ -18,7 +18,7 @@ defmodule Surface.Components.Form.RadioButton do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [radio_button: 4]
-  import Surface.Components.Utils, only: [events_to_opts: 1, opts_to_attrs: 1]
+  import Surface.Components.Utils, only: [events_to_attrs: 1]
   import Surface.Components.Form.Utils
 
   @doc "Indicates whether or not the radio button is the selected item in the group"
@@ -27,11 +27,11 @@ defmodule Surface.Components.Form.RadioButton do
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, [:checked, class: get_config(:default_class)])
-    event_opts = assigns |> events_to_opts() |> opts_to_attrs()
+    event_attrs = events_to_attrs(assigns)
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>
-      {radio_button(form, field, assigns[:value], helper_opts ++ attr_opts ++ @opts ++ event_opts)}
+      {radio_button(form, field, assigns[:value], helper_opts ++ attr_opts ++ @opts ++ event_attrs)}
     </InputContext>
     """
   end

--- a/lib/surface/components/form/radio_button.ex
+++ b/lib/surface/components/form/radio_button.ex
@@ -18,7 +18,7 @@ defmodule Surface.Components.Form.RadioButton do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [radio_button: 4]
-  import Surface.Components.Utils, only: [events_to_opts: 1]
+  import Surface.Components.Utils, only: [events_to_opts: 1, opts_to_attrs: 1]
   import Surface.Components.Form.Utils
 
   @doc "Indicates whether or not the radio button is the selected item in the group"
@@ -27,7 +27,7 @@ defmodule Surface.Components.Form.RadioButton do
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, [:checked, class: get_config(:default_class)])
-    event_opts = events_to_opts(assigns)
+    event_opts = assigns |> events_to_opts() |> opts_to_attrs()
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>

--- a/lib/surface/components/form/range_input.ex
+++ b/lib/surface/components/form/range_input.ex
@@ -19,7 +19,7 @@ defmodule Surface.Components.Form.RangeInput do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [range_input: 3]
-  import Surface.Components.Utils, only: [events_to_opts: 1]
+  import Surface.Components.Utils, only: [events_to_attrs: 1]
   import Surface.Components.Form.Utils
 
   @doc "Minimum value for the input"
@@ -36,11 +36,11 @@ defmodule Surface.Components.Form.RangeInput do
 
     attr_opts = props_to_attr_opts(assigns, [:value, :min, :max, :step, class: get_config(:default_class)])
 
-    event_opts = events_to_opts(assigns)
+    event_attrs = events_to_attrs(assigns)
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>
-      {range_input(form, field, helper_opts ++ attr_opts ++ @opts ++ event_opts)}
+      {range_input(form, field, helper_opts ++ attr_opts ++ @opts ++ event_attrs)}
     </InputContext>
     """
   end

--- a/lib/surface/components/form/reset.ex
+++ b/lib/surface/components/form/reset.ex
@@ -19,7 +19,7 @@ defmodule Surface.Components.Form.Reset do
   use Surface.Components.Events
 
   import Phoenix.HTML.Form, only: [reset: 2]
-  import Surface.Components.Utils, only: [events_to_opts: 1]
+  import Surface.Components.Utils, only: [events_to_attrs: 1]
   import Surface.Components.Form.Utils
 
   @doc "The id of the corresponding input field"
@@ -40,10 +40,10 @@ defmodule Surface.Components.Form.Reset do
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, [:class])
-    event_opts = events_to_opts(assigns)
+    event_attrs = events_to_attrs(assigns)
 
     ~F"""
-    {reset(assigns[:value], helper_opts ++ attr_opts ++ @opts ++ event_opts)}
+    {reset(assigns[:value], helper_opts ++ attr_opts ++ @opts ++ event_attrs)}
     """
   end
 end

--- a/lib/surface/components/form/search_input.ex
+++ b/lib/surface/components/form/search_input.ex
@@ -18,17 +18,17 @@ defmodule Surface.Components.Form.SearchInput do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [search_input: 3]
-  import Surface.Components.Utils, only: [events_to_opts: 1, opts_to_attrs: 1]
+  import Surface.Components.Utils, only: [events_to_attrs: 1]
   import Surface.Components.Form.Utils
 
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, [:value, class: get_default_class()])
-    event_opts = assigns |> events_to_opts() |> opts_to_attrs()
+    event_attrs = events_to_attrs(assigns)
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>
-      {search_input(form, field, helper_opts ++ attr_opts ++ @opts ++ event_opts)}
+      {search_input(form, field, helper_opts ++ attr_opts ++ @opts ++ event_attrs)}
     </InputContext>
     """
   end

--- a/lib/surface/components/form/search_input.ex
+++ b/lib/surface/components/form/search_input.ex
@@ -18,13 +18,13 @@ defmodule Surface.Components.Form.SearchInput do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [search_input: 3]
-  import Surface.Components.Utils, only: [events_to_opts: 1]
+  import Surface.Components.Utils, only: [events_to_opts: 1, opts_to_attrs: 1]
   import Surface.Components.Form.Utils
 
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, [:value, class: get_default_class()])
-    event_opts = events_to_opts(assigns)
+    event_opts = assigns |> events_to_opts() |> opts_to_attrs()
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>

--- a/lib/surface/components/form/telephone_input.ex
+++ b/lib/surface/components/form/telephone_input.ex
@@ -18,7 +18,7 @@ defmodule Surface.Components.Form.TelephoneInput do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [telephone_input: 3]
-  import Surface.Components.Utils, only: [events_to_opts: 1, opts_to_attrs: 1]
+  import Surface.Components.Utils, only: [events_to_attrs: 1]
   import Surface.Components.Form.Utils
 
   @doc "A regular expression to validate the entered value"
@@ -27,11 +27,11 @@ defmodule Surface.Components.Form.TelephoneInput do
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, [:value, :pattern, class: get_default_class()])
-    event_opts = assigns |> events_to_opts() |> opts_to_attrs()
+    event_attrs = events_to_attrs(assigns)
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>
-      {telephone_input(form, field, helper_opts ++ attr_opts ++ @opts ++ event_opts)}
+      {telephone_input(form, field, helper_opts ++ attr_opts ++ @opts ++ event_attrs)}
     </InputContext>
     """
   end

--- a/lib/surface/components/form/telephone_input.ex
+++ b/lib/surface/components/form/telephone_input.ex
@@ -18,7 +18,7 @@ defmodule Surface.Components.Form.TelephoneInput do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [telephone_input: 3]
-  import Surface.Components.Utils, only: [events_to_opts: 1]
+  import Surface.Components.Utils, only: [events_to_opts: 1, opts_to_attrs: 1]
   import Surface.Components.Form.Utils
 
   @doc "A regular expression to validate the entered value"
@@ -27,7 +27,7 @@ defmodule Surface.Components.Form.TelephoneInput do
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, [:value, :pattern, class: get_default_class()])
-    event_opts = events_to_opts(assigns)
+    event_opts = assigns |> events_to_opts() |> opts_to_attrs()
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>

--- a/lib/surface/components/form/text_input.ex
+++ b/lib/surface/components/form/text_input.ex
@@ -18,17 +18,17 @@ defmodule Surface.Components.Form.TextInput do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [text_input: 3]
-  import Surface.Components.Utils, only: [events_to_opts: 1, opts_to_attrs: 1]
+  import Surface.Components.Utils, only: [events_to_attrs: 1]
   import Surface.Components.Form.Utils
 
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, [:value, class: get_default_class()])
-    event_opts = assigns |> events_to_opts() |> opts_to_attrs()
+    event_attrs = events_to_attrs(assigns)
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>
-      {text_input(form, field, helper_opts ++ attr_opts ++ @opts ++ event_opts)}
+      {text_input(form, field, helper_opts ++ attr_opts ++ @opts ++ event_attrs)}
     </InputContext>
     """
   end

--- a/lib/surface/components/form/text_input.ex
+++ b/lib/surface/components/form/text_input.ex
@@ -21,7 +21,6 @@ defmodule Surface.Components.Form.TextInput do
   import Surface.Components.Utils, only: [events_to_opts: 1, opts_to_attrs: 1]
   import Surface.Components.Form.Utils
 
-
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, [:value, class: get_default_class()])

--- a/lib/surface/components/form/text_input.ex
+++ b/lib/surface/components/form/text_input.ex
@@ -18,13 +18,14 @@ defmodule Surface.Components.Form.TextInput do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [text_input: 3]
-  import Surface.Components.Utils, only: [events_to_opts: 1]
+  import Surface.Components.Utils, only: [events_to_opts: 1, opts_to_attrs: 1]
   import Surface.Components.Form.Utils
+
 
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, [:value, class: get_default_class()])
-    event_opts = events_to_opts(assigns)
+    event_opts = assigns |> events_to_opts() |> opts_to_attrs()
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>

--- a/lib/surface/components/form/textarea.ex
+++ b/lib/surface/components/form/textarea.ex
@@ -18,7 +18,7 @@ defmodule Surface.Components.Form.TextArea do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [textarea: 3]
-  import Surface.Components.Utils, only: [events_to_opts: 1]
+  import Surface.Components.Utils, only: [events_to_attrs: 1]
   import Surface.Components.Form.Utils
 
   @doc "Specifies the visible number of lines in a text area"
@@ -30,11 +30,11 @@ defmodule Surface.Components.Form.TextArea do
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, [:value, :rows, :cols, class: get_default_class()])
-    event_opts = events_to_opts(assigns)
+    event_attrs = events_to_attrs(assigns)
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>
-      {textarea(form, field, helper_opts ++ attr_opts ++ @opts ++ event_opts)}
+      {textarea(form, field, helper_opts ++ attr_opts ++ @opts ++ event_attrs)}
     </InputContext>
     """
   end

--- a/lib/surface/components/form/time_input.ex
+++ b/lib/surface/components/form/time_input.ex
@@ -19,17 +19,17 @@ defmodule Surface.Components.Form.TimeInput do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [time_input: 3]
-  import Surface.Components.Utils, only: [events_to_opts: 1, opts_to_attrs: 1]
+  import Surface.Components.Utils, only: [events_to_attrs: 1]
   import Surface.Components.Form.Utils
 
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, [:value, class: get_default_class()])
-    event_opts = assigns |> events_to_opts() |> opts_to_attrs()
+    event_attrs = events_to_attrs(assigns)
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>
-      {time_input(form, field, helper_opts ++ attr_opts ++ @opts ++ event_opts)}
+      {time_input(form, field, helper_opts ++ attr_opts ++ @opts ++ event_attrs)}
     </InputContext>
     """
   end

--- a/lib/surface/components/form/time_input.ex
+++ b/lib/surface/components/form/time_input.ex
@@ -19,13 +19,13 @@ defmodule Surface.Components.Form.TimeInput do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [time_input: 3]
-  import Surface.Components.Utils, only: [events_to_opts: 1]
+  import Surface.Components.Utils, only: [events_to_opts: 1, opts_to_attrs: 1]
   import Surface.Components.Form.Utils
 
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, [:value, class: get_default_class()])
-    event_opts = events_to_opts(assigns)
+    event_opts = assigns |> events_to_opts() |> opts_to_attrs()
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>

--- a/lib/surface/components/form/url_input.ex
+++ b/lib/surface/components/form/url_input.ex
@@ -18,17 +18,17 @@ defmodule Surface.Components.Form.UrlInput do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [url_input: 3]
-  import Surface.Components.Utils, only: [events_to_opts: 1]
+  import Surface.Components.Utils, only: [events_to_attrs: 1]
   import Surface.Components.Form.Utils
 
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, [:value, class: get_default_class()])
-    event_opts = events_to_opts(assigns)
+    event_attrs = events_to_attrs(assigns)
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>
-      {url_input(form, field, helper_opts ++ attr_opts ++ @opts ++ event_opts)}
+      {url_input(form, field, helper_opts ++ attr_opts ++ @opts ++ event_attrs)}
     </InputContext>
     """
   end

--- a/lib/surface/components/live_file_input.ex
+++ b/lib/surface/components/live_file_input.ex
@@ -18,7 +18,7 @@ defmodule Surface.Components.LiveFileInput do
   use Surface.Component
   use Surface.Components.Events
 
-  import Surface.Components.Utils, only: [events_to_opts: 1]
+  import Surface.Components.Utils, only: [events_to_attrs: 1]
   import Surface.Components.Form.Utils, only: [props_to_attr_opts: 2]
 
   @doc "Upload specified via `allow_upload`"
@@ -32,8 +32,8 @@ defmodule Surface.Components.LiveFileInput do
 
   def render(assigns) do
     attr_opts = props_to_attr_opts(assigns, class: get_config(:default_class))
-    event_opts = events_to_opts(assigns)
+    event_attrs = events_to_attrs(assigns)
 
-    ~F"{live_file_input(@upload, attr_opts ++ @opts ++ event_opts)}"
+    ~F"{live_file_input(@upload, attr_opts ++ @opts ++ event_attrs)}"
   end
 end

--- a/lib/surface/components/utils.ex
+++ b/lib/surface/components/utils.ex
@@ -136,6 +136,12 @@ defmodule Surface.Components.Utils do
     |> List.flatten()
   end
 
+  def events_to_attrs(assigns) do
+    assigns
+    |> events_to_opts()
+    |> opts_to_attrs()
+  end
+
   defp values_to_opts([]) do
     []
   end

--- a/test/surface/components/events_test.exs
+++ b/test/surface/components/events_test.exs
@@ -5,13 +5,10 @@ defmodule Surface.Components.EventsTest do
     use Surface.Component
     use Surface.Components.Events
 
-    import Surface.Components.Utils, only: [events_to_opts: 1, opts_to_attrs: 1]
+    import Surface.Components.Utils, only: [events_to_attrs: 1]
 
     def render(assigns) do
-      attrs =
-        assigns
-        |> events_to_opts()
-        |> opts_to_attrs()
+      attrs = events_to_attrs(assigns)
 
       ~F"""
       <div :attrs={attrs} />

--- a/test/surface/components/form/checkbox_test.exs
+++ b/test/surface/components/form/checkbox_test.exs
@@ -160,6 +160,19 @@ defmodule Surface.Components.Form.CheckboxTest do
            <input id="is_admin" name="is_admin" type="checkbox" value="true">
            """
   end
+
+  test "setting the phx-value-* values" do
+    html =
+      render_surface do
+        ~F"""
+        <Checkbox form="user" field="admin" values={a: "one", b: :two, c: 3} />
+        """
+      end
+
+    assert html =~ """
+           <input id="user_admin" name="user[admin]" phx-value-a="one" phx-value-b="two" phx-value-c="3" type="checkbox" value="true">
+           """
+  end
 end
 
 defmodule Surface.Components.Form.CheckboxConfigTest do

--- a/test/surface/components/form/color_input_test.exs
+++ b/test/surface/components/form/color_input_test.exs
@@ -100,6 +100,19 @@ defmodule Surface.Components.Form.ColorInputTest do
            <input id="color" name="color" type="color">
            """
   end
+
+  test "setting the phx-value-* values" do
+    html =
+      render_surface do
+        ~F"""
+        <ColorInput form="user" field="color" values={a: "one", b: :two, c: 3} />
+        """
+      end
+
+    assert html =~ """
+           <input id="user_color" name="user[color]" phx-value-a="one" phx-value-b="two" phx-value-c="3" type="color">
+           """
+  end
 end
 
 defmodule Surface.Components.Form.ColorInputConfigTest do

--- a/test/surface/components/form/date_input_test.exs
+++ b/test/surface/components/form/date_input_test.exs
@@ -100,6 +100,19 @@ defmodule Surface.Components.Form.DateInputTest do
            <input id="birthday" name="birthday" type="date">
            """
   end
+
+  test "setting the phx-value-* values" do
+    html =
+      render_surface do
+        ~F"""
+        <DateInput form="user" field="birthday" values={a: "one", b: :two, c: 3} />
+        """
+      end
+
+    assert html =~ """
+           <input id="user_birthday" name="user[birthday]" phx-value-a="one" phx-value-b="two" phx-value-c="3" type="date">
+           """
+  end
 end
 
 defmodule Surface.Components.Form.DateInputConfigTest do

--- a/test/surface/components/form/datetime_local_input_test.exs
+++ b/test/surface/components/form/datetime_local_input_test.exs
@@ -87,6 +87,19 @@ defmodule Surface.Components.Form.DateTimeLocalInputTest do
            <input id="birthday" name="birthday" type="datetime-local">
            """
   end
+
+  test "setting the phx-value-* values" do
+    html =
+      render_surface do
+        ~F"""
+        <DateTimeLocalInput form="user" field="birth" values={a: "one", b: :two, c: 3} />
+        """
+      end
+
+    assert html =~ """
+           <input id="user_birth" name="user[birth]" phx-value-a="one" phx-value-b="two" phx-value-c="3" type="datetime-local">
+           """
+  end
 end
 
 defmodule Surface.Components.Form.DateTimeLocalInputConfigTest do

--- a/test/surface/components/form/email_input_test.exs
+++ b/test/surface/components/form/email_input_test.exs
@@ -100,6 +100,19 @@ defmodule Surface.Components.Form.EmailInputTest do
            <input id="myemail" name="myemail" type="email">
            """
   end
+
+  test "setting the phx-value-* values" do
+    html =
+      render_surface do
+        ~F"""
+        <EmailInput form="user" field="email" values={a: "one", b: :two, c: 3} />
+        """
+      end
+
+    assert html =~ """
+           <input id="user_email" name="user[email]" phx-value-a="one" phx-value-b="two" phx-value-c="3" type="email">
+           """
+  end
 end
 
 defmodule Surface.Components.Form.EmailInputConfigTest do

--- a/test/surface/components/form/file_input_test.exs
+++ b/test/surface/components/form/file_input_test.exs
@@ -119,6 +119,19 @@ defmodule Surface.Components.Form.FileInputTest do
            <input id="image" name="image" type="file">
            """
   end
+
+  test "setting the phx-value-* values" do
+    html =
+      render_surface do
+        ~F"""
+        <FileInput form="user" field="picture" values={a: "one", b: :two, c: 3} />
+        """
+      end
+
+    assert html =~ """
+           <input id="user_picture" name="user[picture]" phx-value-a="one" phx-value-b="two" phx-value-c="3" type="file">
+           """
+  end
 end
 
 defmodule Surface.Components.Form.FileInputConfigTest do

--- a/test/surface/components/form/number_input_test.exs
+++ b/test/surface/components/form/number_input_test.exs
@@ -100,6 +100,19 @@ defmodule Surface.Components.Form.NumberInputTest do
            <input id="old" name="old" type="number">
            """
   end
+
+  test "setting the phx-value-* values" do
+    html =
+      render_surface do
+        ~F"""
+        <NumberInput form="user" field="age" values={a: "one", b: :two, c: 3} />
+        """
+      end
+
+    assert html =~ """
+           <input id="user_age" name="user[age]" phx-value-a="one" phx-value-b="two" phx-value-c="3" type="number">
+           """
+  end
 end
 
 defmodule Surface.Components.Form.NumberInputConfigTest do

--- a/test/surface/components/form/password_input_test.exs
+++ b/test/surface/components/form/password_input_test.exs
@@ -100,6 +100,19 @@ defmodule Surface.Components.Form.PasswordInputTest do
            <input id="secret" name="secret" type="password">
            """
   end
+
+  test "setting the phx-value-* values" do
+    html =
+      render_surface do
+        ~F"""
+        <PasswordInput form="user" field="password" values={a: "one", b: :two, c: 3} />
+        """
+      end
+
+    assert html =~ """
+           <input id="user_password" name="user[password]" phx-value-a="one" phx-value-b="two" phx-value-c="3" type="password">
+           """
+  end
 end
 
 defmodule Surface.Components.Form.PasswordInputConfigTest do

--- a/test/surface/components/form/radio_button_test.exs
+++ b/test/surface/components/form/radio_button_test.exs
@@ -87,6 +87,19 @@ defmodule Surface.Components.Form.RadioButtonTest do
            <input id="role" name="role" type="radio" value="" checked>
            """
   end
+
+  test "setting the phx-value-* values" do
+    html =
+      render_surface do
+        ~F"""
+        <RadioButton form="user" field="role" value="admin" values={a: "one", b: :two, c: 3} />
+        """
+      end
+
+    assert html =~ """
+           <input id="user_role_admin" name="user[role]" phx-value-a="one" phx-value-b="two" phx-value-c="3" type="radio" value="admin">
+           """
+  end
 end
 
 defmodule Surface.Components.Form.RadioButtonConfigTest do

--- a/test/surface/components/form/range_input_test.exs
+++ b/test/surface/components/form/range_input_test.exs
@@ -113,6 +113,19 @@ defmodule Surface.Components.Form.RangeInputTest do
            <input id="rate" name="rate" type="range">
            """
   end
+
+  test "setting the phx-value-* values" do
+    html =
+      render_surface do
+        ~F"""
+        <RangeInput form="volume" field="percent" values={a: "one", b: :two, c: 3} />
+        """
+      end
+
+    assert html =~ """
+           <input id="volume_percent" name="volume[percent]" phx-value-a="one" phx-value-b="two" phx-value-c="3" type="range">
+           """
+  end
 end
 
 defmodule Surface.Components.Form.RangeInputConfigTest do

--- a/test/surface/components/form/reset_test.exs
+++ b/test/surface/components/form/reset_test.exs
@@ -87,4 +87,17 @@ defmodule Surface.Components.Form.ResetTest do
            <input id="countdown" name="countdown" type="reset" value="Reset">
            """
   end
+
+  test "setting the phx-value-* values" do
+    html =
+      render_surface do
+        ~F"""
+        <Reset values={a: "one", b: :two, c: 3} />
+        """
+      end
+
+    assert html =~ """
+           <input phx-value-a="one" phx-value-b="two" phx-value-c="3" type="reset" value="Reset">
+           """
+  end
 end

--- a/test/surface/components/form/search_input_test.exs
+++ b/test/surface/components/form/search_input_test.exs
@@ -100,6 +100,19 @@ defmodule Surface.Components.Form.SearchInputTest do
            <input id="mytitle" name="mytitle" type="search">
            """
   end
+
+  test "setting the phx-value-* values" do
+    html =
+      render_surface do
+        ~F"""
+        <SearchInput form="user" field="title" values={a: "one", b: :two, c: 3} />
+        """
+      end
+
+    assert html =~ """
+           <input id="user_title" name="user[title]" phx-value-a="one" phx-value-b="two" phx-value-c="3" type="search">
+           """
+  end
 end
 
 defmodule Surface.Components.Form.SearchInputConfigTest do

--- a/test/surface/components/form/telephone_input_test.exs
+++ b/test/surface/components/form/telephone_input_test.exs
@@ -100,6 +100,19 @@ defmodule Surface.Components.Form.TelephoneInputTest do
            <input id="telephone" name="telephone" type="tel">
            """
   end
+
+  test "setting the phx-value-* values" do
+    html =
+      render_surface do
+        ~F"""
+        <TelephoneInput form="user" field="phone" values={a: "one", b: :two, c: 3} />
+        """
+      end
+
+    assert html =~ """
+           <input id="user_phone" name="user[phone]" phx-value-a="one" phx-value-b="two" phx-value-c="3" type="tel">
+           """
+  end
 end
 
 defmodule Surface.Components.Form.TelephoneInputConfigTest do

--- a/test/surface/components/form/text_input_test.exs
+++ b/test/surface/components/form/text_input_test.exs
@@ -100,6 +100,19 @@ defmodule Surface.Components.Form.TextInputTest do
            <input id="username" name="username" type="text">
            """
   end
+
+  test "setting the phx-value-* values" do
+    html =
+      render_surface do
+        ~F"""
+        <TextInput form="user" field="name" values={a: "one", b: :two, c: 3} />
+        """
+      end
+
+    assert html =~ """
+           <input id="user_name" name="user[name]" phx-value-a="one" phx-value-b="two" phx-value-c="3" type="text">
+           """
+  end
 end
 
 defmodule Surface.Components.Form.TextInputConfigTest do

--- a/test/surface/components/form/textarea_test.exs
+++ b/test/surface/components/form/textarea_test.exs
@@ -105,6 +105,20 @@ defmodule Surface.Components.Form.TextAreaTest do
            </textarea>
            """
   end
+
+  test "setting the phx-value-* values" do
+    html =
+      render_surface do
+        ~F"""
+        <TextArea form="user" field="summary" values={a: "one", b: :two, c: 3} />
+        """
+      end
+
+    assert html =~ """
+           <textarea id="user_summary" name="user[summary]" phx-value-a="one" phx-value-b="two" phx-value-c="3">
+           </textarea>
+           """
+  end
 end
 
 defmodule Surface.Components.Form.TextAreaConfigTest do

--- a/test/surface/components/form/time_input_test.exs
+++ b/test/surface/components/form/time_input_test.exs
@@ -100,6 +100,19 @@ defmodule Surface.Components.Form.TimeInputTest do
            <input id="start_at" name="start_at" type="time">
            """
   end
+
+  test "setting the phx-value-* values" do
+    html =
+      render_surface do
+        ~F"""
+        <TimeInput form="user" field="time" values={a: "one", b: :two, c: 3} />
+        """
+      end
+
+    assert html =~ """
+           <input id="user_time" name="user[time]" phx-value-a="one" phx-value-b="two" phx-value-c="3" type="time">
+           """
+  end
 end
 
 defmodule Surface.Components.Form.TimeInputConfigTest do

--- a/test/surface/components/form/url_input_test.exs
+++ b/test/surface/components/form/url_input_test.exs
@@ -100,6 +100,19 @@ defmodule Surface.Components.Form.UrlInputTest do
            <input id="website" name="website" type="url">
            """
   end
+
+  test "setting the phx-value-* values" do
+    html =
+      render_surface do
+        ~F"""
+        <UrlInput form="user" field="website" values={a: "one", b: :two, c: 3} />
+        """
+      end
+
+    assert html =~ """
+           <input id="user_website" name="user[website]" phx-value-a="one" phx-value-b="two" phx-value-c="3" type="url">
+           """
+  end
 end
 
 defmodule Surface.Components.Form.UrlInputConfigTest do

--- a/test/surface/components/live_file_input_test.exs
+++ b/test/surface/components/live_file_input_test.exs
@@ -16,7 +16,7 @@ defmodule Surface.Components.LiveFileInputTest do
 
     def render(assigns) do
       ~F"""
-        <LiveFileInput upload={@uploads.avatar} class={"test_class", disabled_test: true} opts={"data-test": "test-data", name: "a name?"} />
+        <LiveFileInput upload={@uploads.avatar} class={"test_class", disabled_test: true} opts={"data-test": "test-data", name: "a name?"} values={a: "one", b: :two, c: 3} />
       """
     end
   end
@@ -54,6 +54,10 @@ defmodule Surface.Components.LiveFileInputTest do
     # expected passed through attrs
     assert html =~ "class=\"test_class disabled_test\""
     assert html =~ "data-test=\"test-data\""
+    # expected phx-value-*s
+    assert html =~ "phx-value-a=\"one\""
+    assert html =~ "phx-value-b=\"two\""
+    assert html =~ "phx-value-c=\"3\""
   end
 
   test "correctly renders live_file_input/2 with `:default_class` config" do


### PR DESCRIPTION
Fixes #447.

This PR allows developers to add the `values` prop to form input fields.  The docs for the components list the `values` prop but when attempting to use it, the compiliation will fail.