### PR TITLE
Improve error message when default_translator is not configured for ErrorTag

### DIFF
--- a/lib/surface/components/form/error_tag.ex
+++ b/lib/surface/components/form/error_tag.ex
@@ -144,7 +144,7 @@ defmodule Surface.Components.Form.ErrorTag do
               ]
 
             Given value: #{inspect(value)}
-            
+
             Exception: #{Exception.message(e)}
             """,
             __STACKTRACE__

--- a/lib/surface/components/form/error_tag.ex
+++ b/lib/surface/components/form/error_tag.ex
@@ -135,7 +135,7 @@ defmodule Surface.Components.Form.ErrorTag do
         e ->
           IO.warn(
             """
-            the fallback message translator for the `ErrorTag` component cannot handle the given message.
+            the fallback message translator for the `ErrorTag` component cannot handle the given value.
 
             Hint: you can set up the `default_translator` to route all errors to your application helpers:
 

--- a/lib/surface/components/form/error_tag.ex
+++ b/lib/surface/components/form/error_tag.ex
@@ -143,7 +143,9 @@ defmodule Surface.Components.Form.ErrorTag do
                 {Surface.Components.Form.ErrorTag, default_translator: {MyAppWeb.ErrorHelpers, :translate_error}}
               ]
 
-            Original error: #{Exception.message(e)}
+            Given value: #{inspect(value)}
+            
+            Exception: #{Exception.message(e)}
             """,
             __STACKTRACE__
           )

--- a/lib/surface/components/form/error_tag.ex
+++ b/lib/surface/components/form/error_tag.ex
@@ -21,9 +21,10 @@ defmodule Surface.Components.Form.ErrorTag do
   ]
   ```
 
-  Surface provides a fallback error message if the error cannot be converted to a string. If it
-  happens, Surface will raise a warning to invite you to configure a `default_translator` that
-  handles such a case.
+  > **Note:** If you don't configure a `default_translator`, Surface will try to translate errors using 
+  a built-in message translator which may not cover all types of errors. If the error cannot
+  be translated, a generic `"invalid value"` will be returned and a warning will be emitted,
+  reminding the user to set up a proper `default_translator` that can handle such cases.
 
   There is also a `translator` prop which can be used on a case-by-case basis.
   It overrides the configuration.

--- a/test/surface/components/form/error_tag_test.exs
+++ b/test/surface/components/form/error_tag_test.exs
@@ -11,13 +11,6 @@ defmodule Surface.Components.Form.ErrorTagTest.Common do
     # Simulate that form submission already occurred so that error message will display
     |> Map.put(:action, :insert)
   end
-
-  def unsafe_unique_changeset do
-    {%{}, %{name: :string}}
-    |> Ecto.Changeset.cast(%{name: "myname"}, [:name])
-    |> Ecto.Changeset.add_error(:name, "has already been taken", validation: :unsafe_unique, fields: [:name])
-    |> Map.put(:action, :insert)
-  end
 end
 
 defmodule Surface.Components.Form.ErrorTagTest do

--- a/test/surface/components/form/error_tag_test.exs
+++ b/test/surface/components/form/error_tag_test.exs
@@ -122,7 +122,7 @@ defmodule Surface.Components.Form.ErrorTagTest do
 
   test "warn if translate_error returns cannot convert the error message to a string" do
     message = """
-    the fallback message translator for the `ErrorTag` component cannot handle the given message.
+    the fallback message translator for the `ErrorTag` component cannot handle the given value.
 
     Hint: you can set up the `default_translator` to route all errors to your application helpers:
 
@@ -130,7 +130,9 @@ defmodule Surface.Components.Form.ErrorTagTest do
         {Surface.Components.Form.ErrorTag, default_translator: {MyAppWeb.ErrorHelpers, :translate_error}}
       ]
 
-    Original error:\
+    Given value: [:name]
+
+    Exception:\
     """
 
     output =


### PR DESCRIPTION
Related to #276, #436 and #450. 
Fixes #450

When users use `unsafe_unique` validation, it results in an ambiguous error message that confuses the user. Most of the time this issue raises because the user hasn't set the `default_translator` for the `ErrorTag` component.

The users believe it is a Surface issue and report it on Slack or here on github. I would like to avoid this overhead and help the users upfront.

Here is a proposition to improve the default `phoenix` error message with our own hint that suggests to set the `default_translator`

@miguel-s @msaraiva WDYT?