### PR TITLE
All Input components should inherit :default_class from Form.Input

### DIFF
--- a/lib/surface/components/form/checkbox.ex
+++ b/lib/surface/components/form/checkbox.ex
@@ -39,7 +39,7 @@ defmodule Surface.Components.Form.Checkbox do
         :value
       ])
 
-    attr_opts = props_to_attr_opts(assigns, class: get_config(:default_class))
+    attr_opts = props_to_attr_opts(assigns, class: get_default_class())
     event_attrs = events_to_attrs(assigns)
 
     ~F"""

--- a/lib/surface/components/form/color_input.ex
+++ b/lib/surface/components/form/color_input.ex
@@ -24,7 +24,7 @@ defmodule Surface.Components.Form.ColorInput do
 
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
-    attr_opts = props_to_attr_opts(assigns, [:value, class: get_config(:default_class)])
+    attr_opts = props_to_attr_opts(assigns, [:value, class: get_default_class()])
     event_attrs = events_to_attrs(assigns)
 
     ~F"""

--- a/lib/surface/components/form/date_input.ex
+++ b/lib/surface/components/form/date_input.ex
@@ -24,7 +24,7 @@ defmodule Surface.Components.Form.DateInput do
 
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
-    attr_opts = props_to_attr_opts(assigns, [:value, class: get_config(:default_class)])
+    attr_opts = props_to_attr_opts(assigns, [:value, class: get_default_class()])
     event_attrs = events_to_attrs(assigns)
 
     ~F"""

--- a/lib/surface/components/form/datetime_local_input.ex
+++ b/lib/surface/components/form/datetime_local_input.ex
@@ -24,7 +24,7 @@ defmodule Surface.Components.Form.DateTimeLocalInput do
 
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
-    attr_opts = props_to_attr_opts(assigns, [:value, class: get_config(:default_class)])
+    attr_opts = props_to_attr_opts(assigns, [:value, class: get_default_class()])
     event_attrs = events_to_attrs(assigns)
 
     ~F"""

--- a/lib/surface/components/form/email_input.ex
+++ b/lib/surface/components/form/email_input.ex
@@ -23,7 +23,7 @@ defmodule Surface.Components.Form.EmailInput do
 
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
-    attr_opts = props_to_attr_opts(assigns, [:value, class: get_config(:default_class)])
+    attr_opts = props_to_attr_opts(assigns, [:value, class: get_default_class()])
     event_attrs = events_to_attrs(assigns)
 
     ~F"""

--- a/lib/surface/components/form/file_input.ex
+++ b/lib/surface/components/form/file_input.ex
@@ -27,7 +27,7 @@ defmodule Surface.Components.Form.FileInput do
 
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
-    attr_opts = props_to_attr_opts(assigns, [:value, class: get_config(:default_class)])
+    attr_opts = props_to_attr_opts(assigns, [:value, class: get_default_class()])
     event_attrs = events_to_attrs(assigns)
 
     ~F"""

--- a/lib/surface/components/form/number_input.ex
+++ b/lib/surface/components/form/number_input.ex
@@ -23,7 +23,7 @@ defmodule Surface.Components.Form.NumberInput do
 
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
-    attr_opts = props_to_attr_opts(assigns, [:value, class: get_config(:default_class)])
+    attr_opts = props_to_attr_opts(assigns, [:value, class: get_default_class()])
     event_attrs = events_to_attrs(assigns)
 
     ~F"""

--- a/lib/surface/components/form/password_input.ex
+++ b/lib/surface/components/form/password_input.ex
@@ -23,7 +23,7 @@ defmodule Surface.Components.Form.PasswordInput do
 
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
-    attr_opts = props_to_attr_opts(assigns, [:value, class: get_config(:default_class)])
+    attr_opts = props_to_attr_opts(assigns, [:value, class: get_default_class()])
     event_attrs = events_to_attrs(assigns)
 
     ~F"""

--- a/lib/surface/components/form/radio_button.ex
+++ b/lib/surface/components/form/radio_button.ex
@@ -26,7 +26,7 @@ defmodule Surface.Components.Form.RadioButton do
 
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
-    attr_opts = props_to_attr_opts(assigns, [:checked, class: get_config(:default_class)])
+    attr_opts = props_to_attr_opts(assigns, [:checked, class: get_default_class()])
     event_attrs = events_to_attrs(assigns)
 
     ~F"""

--- a/lib/surface/components/form/range_input.ex
+++ b/lib/surface/components/form/range_input.ex
@@ -34,7 +34,7 @@ defmodule Surface.Components.Form.RangeInput do
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
 
-    attr_opts = props_to_attr_opts(assigns, [:value, :min, :max, :step, class: get_config(:default_class)])
+    attr_opts = props_to_attr_opts(assigns, [:value, :min, :max, :step, class: get_default_class()])
 
     event_attrs = events_to_attrs(assigns)
 

--- a/test/surface/components/form/checkbox_test.exs
+++ b/test/surface/components/form/checkbox_test.exs
@@ -178,6 +178,7 @@ end
 defmodule Surface.Components.Form.CheckboxConfigTest do
   use Surface.ConnCase
 
+  alias Surface.Components.Form.Input
   alias Surface.Components.Form.Checkbox
 
   test ":default_class config" do
@@ -190,6 +191,34 @@ defmodule Surface.Components.Form.CheckboxConfigTest do
         end
 
       assert html =~ ~r/class="default_class"/
+    end
+  end
+
+  test "component inherits :default_class from Form.Input" do
+    using_config Input, default_class: "inherited_default_class" do
+      html =
+        render_surface do
+          ~F"""
+          <Checkbox/>
+          """
+        end
+
+      assert html =~ ~r/class="inherited_default_class"/
+    end
+  end
+
+  test ":default_class config overrides inherited :default_class from Form.Input" do
+    using_config Input, default_class: "inherited_default_class" do
+      using_config Checkbox, default_class: "default_class" do
+        html =
+          render_surface do
+            ~F"""
+            <Checkbox/>
+            """
+          end
+
+        assert html =~ ~r/class="default_class"/
+      end
     end
   end
 end

--- a/test/surface/components/form/color_input_test.exs
+++ b/test/surface/components/form/color_input_test.exs
@@ -118,6 +118,7 @@ end
 defmodule Surface.Components.Form.ColorInputConfigTest do
   use Surface.ConnCase
 
+  alias Surface.Components.Form.Input
   alias Surface.Components.Form.ColorInput
 
   test ":default_class config" do
@@ -130,6 +131,34 @@ defmodule Surface.Components.Form.ColorInputConfigTest do
         end
 
       assert html =~ ~r/class="default_class"/
+    end
+  end
+
+  test "component inherits :default_class from Form.Input" do
+    using_config Input, default_class: "inherited_default_class" do
+      html =
+        render_surface do
+          ~F"""
+          <ColorInput/>
+          """
+        end
+
+      assert html =~ ~r/class="inherited_default_class"/
+    end
+  end
+
+  test ":default_class config overrides inherited :default_class from Form.Input" do
+    using_config Input, default_class: "inherited_default_class" do
+      using_config ColorInput, default_class: "default_class" do
+        html =
+          render_surface do
+            ~F"""
+            <ColorInput/>
+            """
+          end
+
+        assert html =~ ~r/class="default_class"/
+      end
     end
   end
 end

--- a/test/surface/components/form/date_input_test.exs
+++ b/test/surface/components/form/date_input_test.exs
@@ -118,6 +118,7 @@ end
 defmodule Surface.Components.Form.DateInputConfigTest do
   use Surface.ConnCase
 
+  alias Surface.Components.Form.Input
   alias Surface.Components.Form.DateInput
 
   test ":default_class config" do
@@ -130,6 +131,34 @@ defmodule Surface.Components.Form.DateInputConfigTest do
         end
 
       assert html =~ ~r/class="default_class"/
+    end
+  end
+
+  test "component inherits :default_class from Form.Input" do
+    using_config Input, default_class: "inherited_default_class" do
+      html =
+        render_surface do
+          ~F"""
+          <DateInput/>
+          """
+        end
+
+      assert html =~ ~r/class="inherited_default_class"/
+    end
+  end
+
+  test ":default_class config overrides inherited :default_class from Form.Input" do
+    using_config Input, default_class: "inherited_default_class" do
+      using_config DateInput, default_class: "default_class" do
+        html =
+          render_surface do
+            ~F"""
+            <DateInput/>
+            """
+          end
+
+        assert html =~ ~r/class="default_class"/
+      end
     end
   end
 end

--- a/test/surface/components/form/datetime_local_input_test.exs
+++ b/test/surface/components/form/datetime_local_input_test.exs
@@ -105,6 +105,7 @@ end
 defmodule Surface.Components.Form.DateTimeLocalInputConfigTest do
   use Surface.ConnCase
 
+  alias Surface.Components.Form.Input
   alias Surface.Components.Form.DateTimeLocalInput
 
   test ":default_class config" do
@@ -117,6 +118,34 @@ defmodule Surface.Components.Form.DateTimeLocalInputConfigTest do
         end
 
       assert html =~ ~r/class="default_class"/
+    end
+  end
+
+  test "component inherits :default_class from Form.Input" do
+    using_config Input, default_class: "inherited_default_class" do
+      html =
+        render_surface do
+          ~F"""
+          <DateTimeLocalInput/>
+          """
+        end
+
+      assert html =~ ~r/class="inherited_default_class"/
+    end
+  end
+
+  test ":default_class config overrides inherited :default_class from Form.Input" do
+    using_config Input, default_class: "inherited_default_class" do
+      using_config DateTimeLocalInput, default_class: "default_class" do
+        html =
+          render_surface do
+            ~F"""
+            <DateTimeLocalInput/>
+            """
+          end
+
+        assert html =~ ~r/class="default_class"/
+      end
     end
   end
 end

--- a/test/surface/components/form/email_input_test.exs
+++ b/test/surface/components/form/email_input_test.exs
@@ -118,6 +118,7 @@ end
 defmodule Surface.Components.Form.EmailInputConfigTest do
   use Surface.ConnCase
 
+  alias Surface.Components.Form.Input
   alias Surface.Components.Form.EmailInput
 
   test ":default_class config" do
@@ -130,6 +131,34 @@ defmodule Surface.Components.Form.EmailInputConfigTest do
         end
 
       assert html =~ ~r/class="default_class"/
+    end
+  end
+
+  test "component inherits :default_class from Form.Input" do
+    using_config Input, default_class: "inherited_default_class" do
+      html =
+        render_surface do
+          ~F"""
+          <EmailInput/>
+          """
+        end
+
+      assert html =~ ~r/class="inherited_default_class"/
+    end
+  end
+
+  test ":default_class config overrides inherited :default_class from Form.Input" do
+    using_config Input, default_class: "inherited_default_class" do
+      using_config EmailInput, default_class: "default_class" do
+        html =
+          render_surface do
+            ~F"""
+            <EmailInput/>
+            """
+          end
+
+        assert html =~ ~r/class="default_class"/
+      end
     end
   end
 end

--- a/test/surface/components/form/file_input_test.exs
+++ b/test/surface/components/form/file_input_test.exs
@@ -137,6 +137,7 @@ end
 defmodule Surface.Components.Form.FileInputConfigTest do
   use Surface.ConnCase
 
+  alias Surface.Components.Form.Input
   alias Surface.Components.Form.FileInput
 
   test ":default_class config" do
@@ -149,6 +150,34 @@ defmodule Surface.Components.Form.FileInputConfigTest do
         end
 
       assert html =~ ~r/class="default_class"/
+    end
+  end
+
+  test "component inherits :default_class from Form.Input" do
+    using_config Input, default_class: "inherited_default_class" do
+      html =
+        render_surface do
+          ~F"""
+          <FileInput/>
+          """
+        end
+
+      assert html =~ ~r/class="inherited_default_class"/
+    end
+  end
+
+  test ":default_class config overrides inherited :default_class from Form.Input" do
+    using_config Input, default_class: "inherited_default_class" do
+      using_config FileInput, default_class: "default_class" do
+        html =
+          render_surface do
+            ~F"""
+            <FileInput/>
+            """
+          end
+
+        assert html =~ ~r/class="default_class"/
+      end
     end
   end
 end

--- a/test/surface/components/form/number_input_test.exs
+++ b/test/surface/components/form/number_input_test.exs
@@ -118,6 +118,7 @@ end
 defmodule Surface.Components.Form.NumberInputConfigTest do
   use Surface.ConnCase
 
+  alias Surface.Components.Form.Input
   alias Surface.Components.Form.NumberInput
 
   test ":default_class config" do
@@ -130,6 +131,34 @@ defmodule Surface.Components.Form.NumberInputConfigTest do
         end
 
       assert html =~ ~r/class="default_class"/
+    end
+  end
+
+  test "component inherits :default_class from Form.Input" do
+    using_config Input, default_class: "inherited_default_class" do
+      html =
+        render_surface do
+          ~F"""
+          <NumberInput/>
+          """
+        end
+
+      assert html =~ ~r/class="inherited_default_class"/
+    end
+  end
+
+  test ":default_class config overrides inherited :default_class from Form.Input" do
+    using_config Input, default_class: "inherited_default_class" do
+      using_config NumberInput, default_class: "default_class" do
+        html =
+          render_surface do
+            ~F"""
+            <NumberInput/>
+            """
+          end
+
+        assert html =~ ~r/class="default_class"/
+      end
     end
   end
 end

--- a/test/surface/components/form/password_input_test.exs
+++ b/test/surface/components/form/password_input_test.exs
@@ -118,6 +118,7 @@ end
 defmodule Surface.Components.Form.PasswordInputConfigTest do
   use Surface.ConnCase
 
+  alias Surface.Components.Form.Input
   alias Surface.Components.Form.PasswordInput
 
   test ":default_class config" do
@@ -130,6 +131,34 @@ defmodule Surface.Components.Form.PasswordInputConfigTest do
         end
 
       assert html =~ ~r/class="default_class"/
+    end
+  end
+
+  test "component inherits :default_class from Form.Input" do
+    using_config Input, default_class: "inherited_default_class" do
+      html =
+        render_surface do
+          ~F"""
+          <PasswordInput/>
+          """
+        end
+
+      assert html =~ ~r/class="inherited_default_class"/
+    end
+  end
+
+  test ":default_class config overrides inherited :default_class from Form.Input" do
+    using_config Input, default_class: "inherited_default_class" do
+      using_config PasswordInput, default_class: "default_class" do
+        html =
+          render_surface do
+            ~F"""
+            <PasswordInput/>
+            """
+          end
+
+        assert html =~ ~r/class="default_class"/
+      end
     end
   end
 end

--- a/test/surface/components/form/radio_button_test.exs
+++ b/test/surface/components/form/radio_button_test.exs
@@ -105,6 +105,7 @@ end
 defmodule Surface.Components.Form.RadioButtonConfigTest do
   use Surface.ConnCase
 
+  alias Surface.Components.Form.Input
   alias Surface.Components.Form.RadioButton
 
   test ":default_class config" do
@@ -117,6 +118,34 @@ defmodule Surface.Components.Form.RadioButtonConfigTest do
         end
 
       assert html =~ ~r/class="default_class"/
+    end
+  end
+
+  test "component inherits :default_class from Form.Input" do
+    using_config Input, default_class: "inherited_default_class" do
+      html =
+        render_surface do
+          ~F"""
+          <RadioButton/>
+          """
+        end
+
+      assert html =~ ~r/class="inherited_default_class"/
+    end
+  end
+
+  test ":default_class config overrides inherited :default_class from Form.Input" do
+    using_config Input, default_class: "inherited_default_class" do
+      using_config RadioButton, default_class: "default_class" do
+        html =
+          render_surface do
+            ~F"""
+            <RadioButton/>
+            """
+          end
+
+        assert html =~ ~r/class="default_class"/
+      end
     end
   end
 end

--- a/test/surface/components/form/range_input_test.exs
+++ b/test/surface/components/form/range_input_test.exs
@@ -131,6 +131,7 @@ end
 defmodule Surface.Components.Form.RangeInputConfigTest do
   use Surface.ConnCase
 
+  alias Surface.Components.Form.Input
   alias Surface.Components.Form.RangeInput
 
   test ":default_class config" do
@@ -143,6 +144,34 @@ defmodule Surface.Components.Form.RangeInputConfigTest do
         end
 
       assert html =~ ~r/class="default_class"/
+    end
+  end
+
+  test "component inherits :default_class from Form.Input" do
+    using_config Input, default_class: "inherited_default_class" do
+      html =
+        render_surface do
+          ~F"""
+          <RangeInput/>
+          """
+        end
+
+      assert html =~ ~r/class="inherited_default_class"/
+    end
+  end
+
+  test ":default_class config overrides inherited :default_class from Form.Input" do
+    using_config Input, default_class: "inherited_default_class" do
+      using_config RangeInput, default_class: "default_class" do
+        html =
+          render_surface do
+            ~F"""
+            <RangeInput/>
+            """
+          end
+
+        assert html =~ ~r/class="default_class"/
+      end
     end
   end
 end

--- a/test/surface/components/form/search_input_test.exs
+++ b/test/surface/components/form/search_input_test.exs
@@ -118,6 +118,7 @@ end
 defmodule Surface.Components.Form.SearchInputConfigTest do
   use Surface.ConnCase
 
+  alias Surface.Components.Form.Input
   alias Surface.Components.Form.SearchInput
 
   test ":default_class config" do
@@ -130,6 +131,34 @@ defmodule Surface.Components.Form.SearchInputConfigTest do
         end
 
       assert html =~ ~r/class="default_class"/
+    end
+  end
+
+  test "component inherits :default_class from Form.Input" do
+    using_config Input, default_class: "inherited_default_class" do
+      html =
+        render_surface do
+          ~F"""
+          <SearchInput/>
+          """
+        end
+
+      assert html =~ ~r/class="inherited_default_class"/
+    end
+  end
+
+  test ":default_class config overrides inherited :default_class from Form.Input" do
+    using_config Input, default_class: "inherited_default_class" do
+      using_config SearchInput, default_class: "default_class" do
+        html =
+          render_surface do
+            ~F"""
+            <SearchInput/>
+            """
+          end
+
+        assert html =~ ~r/class="default_class"/
+      end
     end
   end
 end

--- a/test/surface/components/form/telephone_input_test.exs
+++ b/test/surface/components/form/telephone_input_test.exs
@@ -118,6 +118,7 @@ end
 defmodule Surface.Components.Form.TelephoneInputConfigTest do
   use Surface.ConnCase
 
+  alias Surface.Components.Form.Input
   alias Surface.Components.Form.TelephoneInput
 
   test ":default_class config" do
@@ -130,6 +131,34 @@ defmodule Surface.Components.Form.TelephoneInputConfigTest do
         end
 
       assert html =~ ~r/class="default_class"/
+    end
+  end
+
+  test "component inherits :default_class from Form.Input" do
+    using_config Input, default_class: "inherited_default_class" do
+      html =
+        render_surface do
+          ~F"""
+          <TelephoneInput/>
+          """
+        end
+
+      assert html =~ ~r/class="inherited_default_class"/
+    end
+  end
+
+  test ":default_class config overrides inherited :default_class from Form.Input" do
+    using_config Input, default_class: "inherited_default_class" do
+      using_config TelephoneInput, default_class: "default_class" do
+        html =
+          render_surface do
+            ~F"""
+            <TelephoneInput/>
+            """
+          end
+
+        assert html =~ ~r/class="default_class"/
+      end
     end
   end
 end

--- a/test/surface/components/form/text_input_test.exs
+++ b/test/surface/components/form/text_input_test.exs
@@ -118,6 +118,7 @@ end
 defmodule Surface.Components.Form.TextInputConfigTest do
   use Surface.ConnCase
 
+  alias Surface.Components.Form.Input
   alias Surface.Components.Form.TextInput
 
   test ":default_class config" do
@@ -130,6 +131,34 @@ defmodule Surface.Components.Form.TextInputConfigTest do
         end
 
       assert html =~ ~r/class="default_class"/
+    end
+  end
+
+  test "component inherits :default_class from Form.Input" do
+    using_config Input, default_class: "inherited_default_class" do
+      html =
+        render_surface do
+          ~F"""
+          <TextInput/>
+          """
+        end
+
+      assert html =~ ~r/class="inherited_default_class"/
+    end
+  end
+
+  test ":default_class config overrides inherited :default_class from Form.Input" do
+    using_config Input, default_class: "inherited_default_class" do
+      using_config TextInput, default_class: "default_class" do
+        html =
+          render_surface do
+            ~F"""
+            <TextInput/>
+            """
+          end
+
+        assert html =~ ~r/class="default_class"/
+      end
     end
   end
 end

--- a/test/surface/components/form/textarea_test.exs
+++ b/test/surface/components/form/textarea_test.exs
@@ -124,6 +124,7 @@ end
 defmodule Surface.Components.Form.TextAreaConfigTest do
   use Surface.ConnCase
 
+  alias Surface.Components.Form.Input
   alias Surface.Components.Form.TextArea
 
   test ":default_class config" do
@@ -136,6 +137,34 @@ defmodule Surface.Components.Form.TextAreaConfigTest do
         end
 
       assert html =~ ~r/class="default_class"/
+    end
+  end
+
+  test "component inherits :default_class from Form.Input" do
+    using_config Input, default_class: "inherited_default_class" do
+      html =
+        render_surface do
+          ~F"""
+          <TextArea/>
+          """
+        end
+
+      assert html =~ ~r/class="inherited_default_class"/
+    end
+  end
+
+  test ":default_class config overrides inherited :default_class from Form.Input" do
+    using_config Input, default_class: "inherited_default_class" do
+      using_config TextArea, default_class: "default_class" do
+        html =
+          render_surface do
+            ~F"""
+            <TextArea/>
+            """
+          end
+
+        assert html =~ ~r/class="default_class"/
+      end
     end
   end
 end

--- a/test/surface/components/form/time_input_test.exs
+++ b/test/surface/components/form/time_input_test.exs
@@ -118,6 +118,7 @@ end
 defmodule Surface.Components.Form.TimeInputConfigTest do
   use Surface.ConnCase
 
+  alias Surface.Components.Form.Input
   alias Surface.Components.Form.TimeInput
 
   test ":default_class config" do
@@ -130,6 +131,34 @@ defmodule Surface.Components.Form.TimeInputConfigTest do
         end
 
       assert html =~ ~r/class="default_class"/
+    end
+  end
+
+  test "component inherits :default_class from Form.Input" do
+    using_config Input, default_class: "inherited_default_class" do
+      html =
+        render_surface do
+          ~F"""
+          <TimeInput/>
+          """
+        end
+
+      assert html =~ ~r/class="inherited_default_class"/
+    end
+  end
+
+  test ":default_class config overrides inherited :default_class from Form.Input" do
+    using_config Input, default_class: "inherited_default_class" do
+      using_config TimeInput, default_class: "default_class" do
+        html =
+          render_surface do
+            ~F"""
+            <TimeInput/>
+            """
+          end
+
+        assert html =~ ~r/class="default_class"/
+      end
     end
   end
 end

--- a/test/surface/components/form/url_input_test.exs
+++ b/test/surface/components/form/url_input_test.exs
@@ -118,6 +118,7 @@ end
 defmodule Surface.Components.Form.UrlInputConfigTest do
   use Surface.ConnCase
 
+  alias Surface.Components.Form.Input
   alias Surface.Components.Form.UrlInput
 
   test ":default_class config" do
@@ -130,6 +131,34 @@ defmodule Surface.Components.Form.UrlInputConfigTest do
         end
 
       assert html =~ ~r/class="default_class"/
+    end
+  end
+
+  test "component inherits :default_class from Form.Input" do
+    using_config Input, default_class: "inherited_default_class" do
+      html =
+        render_surface do
+          ~F"""
+          <UrlInput/>
+          """
+        end
+
+      assert html =~ ~r/class="inherited_default_class"/
+    end
+  end
+
+  test ":default_class config overrides inherited :default_class from Form.Input" do
+    using_config Input, default_class: "inherited_default_class" do
+      using_config UrlInput, default_class: "default_class" do
+        html =
+          render_surface do
+            ~F"""
+            <UrlInput/>
+            """
+          end
+
+        assert html =~ ~r/class="default_class"/
+      end
     end
   end
 end


### PR DESCRIPTION
Only some of the Input components (e.g. `TextInput`) make use of `get_default_class()` to inherit the default_class configured for `Form.Input`.
This mechanism should be used consequently on every component that make use of Form.Input. It may be discussed if `Checkbox` and `FileInpu`t should be exceptions, because they often require different markup anyway.
