### PR TITLE
Migrate to Phoenix.HTML.Tag.attributes_escape/1

### DIFF
--- a/lib/surface/compiler/eex_engine.ex
+++ b/lib/surface/compiler/eex_engine.ex
@@ -73,6 +73,7 @@ defmodule Surface.Compiler.EExEngine do
     {:__block__, [], children}
   end
 
+  defp to_expression({:safe, value}, _buffer, _state), do: {:safe, value}
   defp to_expression({:text, value}, _buffer, _state), do: {:safe, value}
 
   defp to_expression(%AST.AttributeExpr{value: expr}, _buffer, _state), do: expr

--- a/lib/surface/components/form/checkbox.ex
+++ b/lib/surface/components/form/checkbox.ex
@@ -18,7 +18,7 @@ defmodule Surface.Components.Form.Checkbox do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [checkbox: 3]
-  import Surface.Components.Utils, only: [events_to_attrs: 1]
+  import Surface.Components.Utils, only: [events_to_opts: 1]
   import Surface.Components.Form.Utils
 
   @doc "The value to be sent when the checkbox is checked. Defaults to \"true\""
@@ -40,11 +40,19 @@ defmodule Surface.Components.Form.Checkbox do
       ])
 
     attr_opts = props_to_attr_opts(assigns, class: get_default_class())
-    event_attrs = events_to_attrs(assigns)
+    event_opts = events_to_opts(assigns)
+
+    opts =
+      assigns.opts
+      |> Keyword.merge(helper_opts)
+      |> Keyword.merge(attr_opts)
+      |> Keyword.merge(event_opts)
+
+    assigns = assign(assigns, opts: opts)
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>
-    {checkbox(form, field, helper_opts ++ attr_opts ++ @opts ++ event_attrs)}
+    {checkbox(form, field, @opts)}
     </InputContext>
     """
   end

--- a/lib/surface/components/form/color_input.ex
+++ b/lib/surface/components/form/color_input.ex
@@ -19,13 +19,13 @@ defmodule Surface.Components.Form.ColorInput do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [color_input: 3]
-  import Surface.Components.Utils, only: [events_to_attrs: 1]
+  import Surface.Components.Utils, only: [events_to_opts: 1]
   import Surface.Components.Form.Utils
 
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, [:value, class: get_default_class()])
-    event_attrs = events_to_attrs(assigns)
+    event_attrs = events_to_opts(assigns)
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>

--- a/lib/surface/components/form/date_input.ex
+++ b/lib/surface/components/form/date_input.ex
@@ -19,13 +19,13 @@ defmodule Surface.Components.Form.DateInput do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [date_input: 3]
-  import Surface.Components.Utils, only: [events_to_attrs: 1]
+  import Surface.Components.Utils, only: [events_to_opts: 1]
   import Surface.Components.Form.Utils
 
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, [:value, class: get_default_class()])
-    event_attrs = events_to_attrs(assigns)
+    event_attrs = events_to_opts(assigns)
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>

--- a/lib/surface/components/form/datetime_local_input.ex
+++ b/lib/surface/components/form/datetime_local_input.ex
@@ -19,13 +19,13 @@ defmodule Surface.Components.Form.DateTimeLocalInput do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [datetime_local_input: 3]
-  import Surface.Components.Utils, only: [events_to_attrs: 1]
+  import Surface.Components.Utils, only: [events_to_opts: 1]
   import Surface.Components.Form.Utils
 
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, [:value, class: get_default_class()])
-    event_attrs = events_to_attrs(assigns)
+    event_attrs = events_to_opts(assigns)
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>

--- a/lib/surface/components/form/email_input.ex
+++ b/lib/surface/components/form/email_input.ex
@@ -18,13 +18,13 @@ defmodule Surface.Components.Form.EmailInput do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [email_input: 3]
-  import Surface.Components.Utils, only: [events_to_attrs: 1]
+  import Surface.Components.Utils, only: [events_to_opts: 1]
   import Surface.Components.Form.Utils
 
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, [:value, class: get_default_class()])
-    event_attrs = events_to_attrs(assigns)
+    event_attrs = events_to_opts(assigns)
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>

--- a/lib/surface/components/form/file_input.ex
+++ b/lib/surface/components/form/file_input.ex
@@ -22,13 +22,13 @@ defmodule Surface.Components.Form.FileInput do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [file_input: 3]
-  import Surface.Components.Utils, only: [events_to_attrs: 1]
+  import Surface.Components.Utils, only: [events_to_opts: 1]
   import Surface.Components.Form.Utils
 
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, [:value, class: get_default_class()])
-    event_attrs = events_to_attrs(assigns)
+    event_attrs = events_to_opts(assigns)
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>

--- a/lib/surface/components/form/hidden_input.ex
+++ b/lib/surface/components/form/hidden_input.ex
@@ -18,13 +18,13 @@ defmodule Surface.Components.Form.HiddenInput do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [hidden_input: 3]
-  import Surface.Components.Utils, only: [events_to_attrs: 1]
+  import Surface.Components.Utils, only: [events_to_opts: 1]
   import Surface.Components.Form.Utils
 
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, [:value, :class])
-    event_attrs = events_to_attrs(assigns)
+    event_attrs = events_to_opts(assigns)
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>

--- a/lib/surface/components/form/label.ex
+++ b/lib/surface/components/form/label.ex
@@ -15,7 +15,7 @@ defmodule Surface.Components.Form.Label do
   use Surface.Component
   use Surface.Components.Events
 
-  import Surface.Components.Utils, only: [events_to_attrs: 1]
+  import Surface.Components.Utils, only: [events_to_opts: 1]
   import Surface.Components.Form.Utils
   alias Surface.Components.Form.Input.InputContext
 
@@ -44,7 +44,7 @@ defmodule Surface.Components.Form.Label do
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, class: get_config(:default_class))
-    event_attrs = events_to_attrs(assigns)
+    event_attrs = events_to_opts(assigns)
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>

--- a/lib/surface/components/form/number_input.ex
+++ b/lib/surface/components/form/number_input.ex
@@ -18,13 +18,13 @@ defmodule Surface.Components.Form.NumberInput do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [number_input: 3]
-  import Surface.Components.Utils, only: [events_to_attrs: 1]
+  import Surface.Components.Utils, only: [events_to_opts: 1]
   import Surface.Components.Form.Utils
 
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, [:value, class: get_default_class()])
-    event_attrs = events_to_attrs(assigns)
+    event_attrs = events_to_opts(assigns)
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>

--- a/lib/surface/components/form/password_input.ex
+++ b/lib/surface/components/form/password_input.ex
@@ -18,13 +18,13 @@ defmodule Surface.Components.Form.PasswordInput do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [password_input: 3]
-  import Surface.Components.Utils, only: [events_to_attrs: 1]
+  import Surface.Components.Utils, only: [events_to_opts: 1]
   import Surface.Components.Form.Utils
 
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, [:value, class: get_default_class()])
-    event_attrs = events_to_attrs(assigns)
+    event_attrs = events_to_opts(assigns)
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>

--- a/lib/surface/components/form/radio_button.ex
+++ b/lib/surface/components/form/radio_button.ex
@@ -18,7 +18,7 @@ defmodule Surface.Components.Form.RadioButton do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [radio_button: 4]
-  import Surface.Components.Utils, only: [events_to_attrs: 1]
+  import Surface.Components.Utils, only: [events_to_opts: 1]
   import Surface.Components.Form.Utils
 
   @doc "Indicates whether or not the radio button is the selected item in the group"
@@ -27,7 +27,7 @@ defmodule Surface.Components.Form.RadioButton do
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, [:checked, class: get_default_class()])
-    event_attrs = events_to_attrs(assigns)
+    event_attrs = events_to_opts(assigns)
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>

--- a/lib/surface/components/form/range_input.ex
+++ b/lib/surface/components/form/range_input.ex
@@ -19,7 +19,7 @@ defmodule Surface.Components.Form.RangeInput do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [range_input: 3]
-  import Surface.Components.Utils, only: [events_to_attrs: 1]
+  import Surface.Components.Utils, only: [events_to_opts: 1]
   import Surface.Components.Form.Utils
 
   @doc "Minimum value for the input"
@@ -36,7 +36,7 @@ defmodule Surface.Components.Form.RangeInput do
 
     attr_opts = props_to_attr_opts(assigns, [:value, :min, :max, :step, class: get_default_class()])
 
-    event_attrs = events_to_attrs(assigns)
+    event_attrs = events_to_opts(assigns)
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>

--- a/lib/surface/components/form/reset.ex
+++ b/lib/surface/components/form/reset.ex
@@ -19,7 +19,7 @@ defmodule Surface.Components.Form.Reset do
   use Surface.Components.Events
 
   import Phoenix.HTML.Form, only: [reset: 2]
-  import Surface.Components.Utils, only: [events_to_attrs: 1]
+  import Surface.Components.Utils, only: [events_to_opts: 1]
   import Surface.Components.Form.Utils
 
   @doc "The id of the corresponding input field"
@@ -40,7 +40,7 @@ defmodule Surface.Components.Form.Reset do
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, [:class])
-    event_attrs = events_to_attrs(assigns)
+    event_attrs = events_to_opts(assigns)
 
     ~F"""
     {reset(assigns[:value], helper_opts ++ attr_opts ++ @opts ++ event_attrs)}

--- a/lib/surface/components/form/search_input.ex
+++ b/lib/surface/components/form/search_input.ex
@@ -18,13 +18,13 @@ defmodule Surface.Components.Form.SearchInput do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [search_input: 3]
-  import Surface.Components.Utils, only: [events_to_attrs: 1]
+  import Surface.Components.Utils, only: [events_to_opts: 1]
   import Surface.Components.Form.Utils
 
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, [:value, class: get_default_class()])
-    event_attrs = events_to_attrs(assigns)
+    event_attrs = events_to_opts(assigns)
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>

--- a/lib/surface/components/form/submit.ex
+++ b/lib/surface/components/form/submit.ex
@@ -8,7 +8,7 @@ defmodule Surface.Components.Form.Submit do
   use Surface.Component
   use Surface.Components.Events
 
-  import Surface.Components.Utils, only: [events_to_opts: 1, opts_to_attrs: 1]
+  import Surface.Components.Utils, only: [events_to_opts: 1]
 
   @doc "The label to be used in the button"
   prop label, :string
@@ -23,13 +23,18 @@ defmodule Surface.Components.Form.Submit do
   slot default
 
   def render(assigns) do
-    ~F"""
-    <button type="submit" :attrs={to_attrs(assigns)}><#slot>{@label}</#slot></button>
-    """
-  end
+    props = prop_to_attr_opts(assigns.class, :class)
+    events = events_to_opts(assigns)
 
-  defp to_attrs(assigns) do
-    (prop_to_attr_opts(assigns.class, :class) ++ assigns.opts ++ events_to_opts(assigns))
-    |> opts_to_attrs()
+    opts =
+      assigns.opts
+      |> Keyword.merge(props)
+      |> Keyword.merge(events)
+
+    assigns = assign(assigns, opts: opts)
+
+    ~F"""
+    <button type="submit" :attrs={@opts}><#slot>{@label}</#slot></button>
+    """
   end
 end

--- a/lib/surface/components/form/telephone_input.ex
+++ b/lib/surface/components/form/telephone_input.ex
@@ -18,7 +18,7 @@ defmodule Surface.Components.Form.TelephoneInput do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [telephone_input: 3]
-  import Surface.Components.Utils, only: [events_to_attrs: 1]
+  import Surface.Components.Utils, only: [events_to_opts: 1]
   import Surface.Components.Form.Utils
 
   @doc "A regular expression to validate the entered value"
@@ -27,7 +27,7 @@ defmodule Surface.Components.Form.TelephoneInput do
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, [:value, :pattern, class: get_default_class()])
-    event_attrs = events_to_attrs(assigns)
+    event_attrs = events_to_opts(assigns)
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>

--- a/lib/surface/components/form/text_input.ex
+++ b/lib/surface/components/form/text_input.ex
@@ -18,13 +18,13 @@ defmodule Surface.Components.Form.TextInput do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [text_input: 3]
-  import Surface.Components.Utils, only: [events_to_attrs: 1]
+  import Surface.Components.Utils, only: [events_to_opts: 1]
   import Surface.Components.Form.Utils
 
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, [:value, class: get_default_class()])
-    event_attrs = events_to_attrs(assigns)
+    event_attrs = events_to_opts(assigns)
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>

--- a/lib/surface/components/form/textarea.ex
+++ b/lib/surface/components/form/textarea.ex
@@ -18,7 +18,7 @@ defmodule Surface.Components.Form.TextArea do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [textarea: 3]
-  import Surface.Components.Utils, only: [events_to_attrs: 1]
+  import Surface.Components.Utils, only: [events_to_opts: 1]
   import Surface.Components.Form.Utils
 
   @doc "Specifies the visible number of lines in a text area"
@@ -30,7 +30,7 @@ defmodule Surface.Components.Form.TextArea do
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, [:value, :rows, :cols, class: get_default_class()])
-    event_attrs = events_to_attrs(assigns)
+    event_attrs = events_to_opts(assigns)
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>

--- a/lib/surface/components/form/time_input.ex
+++ b/lib/surface/components/form/time_input.ex
@@ -19,13 +19,13 @@ defmodule Surface.Components.Form.TimeInput do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [time_input: 3]
-  import Surface.Components.Utils, only: [events_to_attrs: 1]
+  import Surface.Components.Utils, only: [events_to_opts: 1]
   import Surface.Components.Form.Utils
 
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, [:value, class: get_default_class()])
-    event_attrs = events_to_attrs(assigns)
+    event_attrs = events_to_opts(assigns)
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>

--- a/lib/surface/components/form/url_input.ex
+++ b/lib/surface/components/form/url_input.ex
@@ -18,13 +18,13 @@ defmodule Surface.Components.Form.UrlInput do
   use Surface.Components.Form.Input
 
   import Phoenix.HTML.Form, only: [url_input: 3]
-  import Surface.Components.Utils, only: [events_to_attrs: 1]
+  import Surface.Components.Utils, only: [events_to_opts: 1]
   import Surface.Components.Form.Utils
 
   def render(assigns) do
     helper_opts = props_to_opts(assigns)
     attr_opts = props_to_attr_opts(assigns, [:value, class: get_default_class()])
-    event_attrs = events_to_attrs(assigns)
+    event_attrs = events_to_opts(assigns)
 
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>

--- a/lib/surface/components/link.ex
+++ b/lib/surface/components/link.ex
@@ -78,9 +78,15 @@ defmodule Surface.Components.Link do
     if method == :get do
       skip_csrf(opts)
     else
-      {data, opts} = Keyword.pop(opts, :data, [])
       {csrf_data, opts} = csrf_data(to, opts)
-      [data: data ++ csrf_data ++ [method: method, to: to], rel: "nofollow"] ++ opts
+
+      data =
+        opts
+        |> Keyword.get(:data, [])
+        |> Keyword.merge(csrf_data)
+        |> Keyword.merge(method: method, to: to)
+
+      Keyword.merge(opts, data: data, rel: "nofollow")
     end
   end
 end

--- a/lib/surface/components/link/button.ex
+++ b/lib/surface/components/link/button.ex
@@ -77,14 +77,25 @@ defmodule Surface.Components.Link.Button do
   end
 
   defp link_method(method, to, opts) do
+    data =
+      opts
+      |> Keyword.get(:data, [])
+      |> Keyword.merge(method: method, to: to)
+
     if method == :get do
-      opts = skip_csrf(opts)
-      {data, opts} = Keyword.pop(opts, :data, [])
-      [data: data ++ [method: method, to: to]] ++ opts
+      opts
+      |> skip_csrf()
+      |> Keyword.merge(data: data)
     else
-      {data, opts} = Keyword.pop(opts, :data, [])
       {csrf_data, opts} = csrf_data(to, opts)
-      [data: data ++ csrf_data ++ [method: method, to: to]] ++ opts
+
+      data =
+        opts
+        |> Keyword.get(:data, [])
+        |> Keyword.merge(csrf_data)
+        |> Keyword.merge(method: method, to: to)
+
+      Keyword.merge(opts, data: data)
     end
   end
 end

--- a/lib/surface/components/live_file_input.ex
+++ b/lib/surface/components/live_file_input.ex
@@ -18,7 +18,7 @@ defmodule Surface.Components.LiveFileInput do
   use Surface.Component
   use Surface.Components.Events
 
-  import Surface.Components.Utils, only: [events_to_attrs: 1]
+  import Surface.Components.Utils, only: [events_to_opts: 1]
   import Surface.Components.Form.Utils, only: [props_to_attr_opts: 2]
 
   @doc "Upload specified via `allow_upload`"
@@ -32,7 +32,7 @@ defmodule Surface.Components.LiveFileInput do
 
   def render(assigns) do
     attr_opts = props_to_attr_opts(assigns, class: get_config(:default_class))
-    event_attrs = events_to_attrs(assigns)
+    event_attrs = events_to_opts(assigns)
 
     ~F"{live_file_input(@upload, attr_opts ++ @opts ++ event_attrs)}"
   end

--- a/lib/surface/components/utils.ex
+++ b/lib/surface/components/utils.ex
@@ -78,19 +78,6 @@ defmodule Surface.Components.Utils do
   def opts_to_attrs(opts) do
     for {key, value} <- opts do
       case key do
-        :phx_capture_click -> {:"phx-capture-click", value}
-        :phx_click -> {:"phx-click", value}
-        :phx_window_focus -> {:"phx-window-focus", value}
-        :phx_window_blur -> {:"phx-window-blur", value}
-        :phx_focus -> {:"phx-focus", value}
-        :phx_blur -> {:"phx-blur", value}
-        :phx_window_keyup -> {:"phx-window-keyup", value}
-        :phx_window_keydown -> {:"phx-window-keydown", value}
-        :phx_keyup -> {:"phx-keyup", value}
-        :phx_keydown -> {:"phx-keydown", value}
-        :phx_target -> {:"phx-target", value}
-        :phx_disable_with -> {:"phx-disable-with", value}
-        :data -> data_to_attrs(value)
         :values -> values_to_attrs(value)
         _ -> {key, value}
       end
@@ -104,12 +91,6 @@ defmodule Surface.Components.Utils do
         :trigger_action -> {:phx_trigger_action, value}
         _ -> {key, value}
       end
-    end
-  end
-
-  defp data_to_attrs(data) when is_list(data) do
-    for {key, value} <- data do
-      {:"data-#{key}", value}
     end
   end
 

--- a/lib/surface/components/utils.ex
+++ b/lib/surface/components/utils.ex
@@ -75,28 +75,12 @@ defmodule Surface.Components.Utils do
     Keyword.delete(opts, :csrf_token)
   end
 
-  def opts_to_attrs(opts) do
-    for {key, value} <- opts do
-      case key do
-        :values -> values_to_attrs(value)
-        _ -> {key, value}
-      end
-    end
-    |> List.flatten()
-  end
-
   def opts_to_phx_opts(opts) do
     for {key, value} <- opts do
       case key do
         :trigger_action -> {:phx_trigger_action, value}
         _ -> {key, value}
       end
-    end
-  end
-
-  defp values_to_attrs(values) when is_list(values) do
-    for {key, value} <- values do
-      {:"phx-value-#{key}", value}
     end
   end
 
@@ -117,21 +101,21 @@ defmodule Surface.Components.Utils do
     |> List.flatten()
   end
 
-  def events_to_attrs(assigns) do
-    assigns
-    |> events_to_opts()
-    |> opts_to_attrs()
-  end
-
   defp values_to_opts([]) do
     []
   end
 
   defp values_to_opts(values) when is_list(values) do
-    {:values, values}
+    values_to_attrs(values)
   end
 
   defp values_to_opts(_values) do
     []
+  end
+
+  defp values_to_attrs(values) when is_list(values) do
+    for {key, value} <- values do
+      {:"phx-value-#{key}", value}
+    end
   end
 end

--- a/lib/surface/type_handler.ex
+++ b/lib/surface/type_handler.ex
@@ -180,7 +180,7 @@ defmodule Surface.TypeHandler do
         {:ok, [~S( ), to_string(name)]}
 
       {:ok, val} ->
-        {:ok, [" ", to_string(name), "=", ~S("), Phoenix.HTML.Safe.to_iodata(val), ~S(")]}
+        {:ok, Phoenix.HTML.Tag.attributes_escape([{name, val}])}
 
       {:error, message} ->
         {:error, message}

--- a/test/surface/components/events_test.exs
+++ b/test/surface/components/events_test.exs
@@ -190,7 +190,7 @@ defmodule Surface.Components.EventsTest do
       end
 
     assert html =~ """
-           <div phx-click="my_click" phx-value-foo="bar" phx-value-hello="world" phx-value-one="2"></div>
+           <div phx-value-foo="bar" phx-value-hello="world" phx-value-one="2" phx-click="my_click"></div>
            """
   end
 end

--- a/test/surface/components/events_test.exs
+++ b/test/surface/components/events_test.exs
@@ -5,10 +5,10 @@ defmodule Surface.Components.EventsTest do
     use Surface.Component
     use Surface.Components.Events
 
-    import Surface.Components.Utils, only: [events_to_attrs: 1]
+    import Surface.Components.Utils, only: [events_to_opts: 1]
 
     def render(assigns) do
-      attrs = events_to_attrs(assigns)
+      attrs = events_to_opts(assigns)
 
       ~F"""
       <div :attrs={attrs} />


### PR DESCRIPTION
Use the newly introduced [`Phoenix.HTML.Tag.attributes_escape/1`](https://github.com/phoenixframework/phoenix_html/pull/331) instead of handrolling our own solution.

@msaraiva @lnr0626 @Malian I tested the new approach with the `Link` and `Link.Button` components, if you think this is the way to go I'll continue cleaning up the rest. The main changes are in [type_handler.ex](https://github.com/surface-ui/surface/compare/master...miguel-s:ms-tag-attributes-escape?expand=1#diff-266fdbcf268ed223050000921d1b6946b9a028b4f7e17c64fee8d3e0a41a2991R183) and [eex_engine.ex](https://github.com/surface-ui/surface/compare/master...miguel-s:ms-tag-attributes-escape?expand=1#diff-96328b37fbe00256a44961d185c56d2b6812ccf64fd5108cbc8cf9b4a1b2f2ecR76). wdyt?