### PR TITLE
Better error message for misplaced closing delimiter

### DIFF
--- a/lib/surface/compiler/tokenizer.ex
+++ b/lib/surface/compiler/tokenizer.ex
@@ -530,6 +530,9 @@ defmodule Surface.Compiler.Tokenizer do
   end
 
   ## handle_attr_name
+  defp handle_attr_name(<<"/", _rest::binary>>, _column, []) do
+    {:error, "unexpected closing tag delimiter `/`"}
+  end
 
   defp handle_attr_name(<<c::utf8, _rest::binary>>, _column, []) when c in @name_stop_chars do
     {:error, "expected attribute name"}

--- a/lib/surface/compiler/tokenizer.ex
+++ b/lib/surface/compiler/tokenizer.ex
@@ -534,8 +534,8 @@ defmodule Surface.Compiler.Tokenizer do
     {:error, "unexpected closing tag delimiter `/`"}
   end
 
-  defp handle_attr_name(<<c::utf8, _rest::binary>> = text, _column, []) when c in @name_stop_chars do
-    {:error, "expected attribute name, got: `#{text}`"}
+  defp handle_attr_name(<<c::utf8, _rest::binary>>, _column, []) when c in @name_stop_chars do
+    {:error, "expected attribute name, got: `#{<<c>>}`"}
   end
 
   defp handle_attr_name(<<c::utf8, _rest::binary>> = text, column, buffer) when c in @name_stop_chars do

--- a/lib/surface/compiler/tokenizer.ex
+++ b/lib/surface/compiler/tokenizer.ex
@@ -534,8 +534,8 @@ defmodule Surface.Compiler.Tokenizer do
     {:error, "unexpected closing tag delimiter `/`"}
   end
 
-  defp handle_attr_name(<<c::utf8, _rest::binary>>, _column, []) when c in @name_stop_chars do
-    {:error, "expected attribute name"}
+  defp handle_attr_name(<<c::utf8, _rest::binary>> = text, _column, []) when c in @name_stop_chars do
+    {:error, "expected attribute name, got: `#{text}`"}
   end
 
   defp handle_attr_name(<<c::utf8, _rest::binary>> = text, column, buffer) when c in @name_stop_chars do

--- a/test/surface/compiler/tokenizer_test.exs
+++ b/test/surface/compiler/tokenizer_test.exs
@@ -519,7 +519,7 @@ defmodule Surface.Compiler.TokenizerTest do
         tokenize!(~S(<div = >))
       end
 
-      assert_raise ParseError, "nofile:1:6: expected attribute name", fn ->
+      assert_raise ParseError, "nofile:1:6: unexpected closing tag delimiter `/`", fn ->
         tokenize!(~S(<div / >))
       end
     end

--- a/test/surface/compiler/tokenizer_test.exs
+++ b/test/surface/compiler/tokenizer_test.exs
@@ -508,14 +508,14 @@ defmodule Surface.Compiler.TokenizerTest do
     end
 
     test "raise on missing attribure name" do
-      assert_raise ParseError, "nofile:2:8: expected attribute name", fn ->
+      assert_raise ParseError, "nofile:2:8: expected attribute name, got: `=\"panel\">`", fn ->
         tokenize!("""
         <div>
           <div ="panel">\
         """)
       end
 
-      assert_raise ParseError, "nofile:1:6: expected attribute name", fn ->
+      assert_raise ParseError, "nofile:1:6: expected attribute name, got: `= >`", fn ->
         tokenize!(~S(<div = >))
       end
 

--- a/test/surface/compiler/tokenizer_test.exs
+++ b/test/surface/compiler/tokenizer_test.exs
@@ -508,14 +508,14 @@ defmodule Surface.Compiler.TokenizerTest do
     end
 
     test "raise on missing attribure name" do
-      assert_raise ParseError, "nofile:2:8: expected attribute name, got: `=\"panel\">`", fn ->
+      assert_raise ParseError, "nofile:2:8: expected attribute name, got: `=`", fn ->
         tokenize!("""
         <div>
           <div ="panel">\
         """)
       end
 
-      assert_raise ParseError, "nofile:1:6: expected attribute name, got: `= >`", fn ->
+      assert_raise ParseError, "nofile:1:6: expected attribute name, got: `=`", fn ->
         tokenize!(~S(<div = >))
       end
 


### PR DESCRIPTION
Improves the error message for space in a closing tag like `<div / >`

### Before
> expected attribute name

### After
> unexpected closing tag delimiter `/`


I also feel that `<div = >` and `<div ="value no name">` could have better error messages too. What do you think?