### PR TITLE
Cleanup usage of `{{ ... }}`

### DIFF
--- a/lib/surface.ex
+++ b/lib/surface.ex
@@ -85,7 +85,7 @@ defmodule Surface do
 
         def render(assigns) do
           ~F"\""
-          <button class="button {{ @kind }}" phx-click={{ @click }}>
+          <button class={"button", @kind} :on-click={@click}>
             <#slot/>
           </button>
           "\""
@@ -312,7 +312,7 @@ defmodule Surface do
   ## Examples
 
     ```
-    <div :if={{ slot_assigned?(:header) }}>
+    <div :if={slot_assigned?(:header)}>
       <#slot name="header"/>
     </div>
     ```

--- a/lib/surface/api.ex
+++ b/lib/surface/api.ex
@@ -506,13 +506,13 @@ defmodule Surface.API do
 
       message = """
       arguments for the default slot in a slotable component are not accessible - instead the arguments \
-      from the parent's #{slot_name} slot will be exposed via `:let={{ ... }}`.
+      from the parent's #{slot_name} slot will be exposed via `:let={...}`.
 
       Hint: You can remove these arguments, pull them up to the parent component, or make this component not slotable \
       and use it inside an explicit template element:
       ```
       <#template name="#{slot_name}">
-        <#{component_name} :let={{ #{prop_example} }}>
+        <#{component_name} :let={#{prop_example}}>
           ...
         </#{component_name}>
       </#template>

--- a/lib/surface/component.ex
+++ b/lib/surface/component.ex
@@ -11,7 +11,7 @@ defmodule Surface.Component do
 
         def render(assigns) do
           ~F"\""
-          <button class="button" phx-click={{ @click }}>
+          <button class="button" :on-click={@click}>
             <#slot/>
           </button>
           "\""

--- a/lib/surface/components/form/checkbox.ex
+++ b/lib/surface/components/form/checkbox.ex
@@ -11,7 +11,7 @@ defmodule Surface.Components.Form.Checkbox do
   ## Examples
 
   ```
-  <Checkbox form="user" field="color" opts={autofocus: "autofocus"}>
+  <Checkbox form="user" field="color" opts={autofocus: "autofocus"} />
   ```
   """
 

--- a/lib/surface/components/form/checkbox.ex
+++ b/lib/surface/components/form/checkbox.ex
@@ -11,7 +11,7 @@ defmodule Surface.Components.Form.Checkbox do
   ## Examples
 
   ```
-  <Checkbox form="user" field="color" opts={{ autofocus: "autofocus" }}>
+  <Checkbox form="user" field="color" opts={autofocus: "autofocus"}>
   ```
   """
 

--- a/lib/surface/components/form/color_input.ex
+++ b/lib/surface/components/form/color_input.ex
@@ -12,7 +12,7 @@ defmodule Surface.Components.Form.ColorInput do
   ## Examples
 
   ```
-  <ColorInput form="user" field="color" opts={{ autofocus: "autofocus" }}>
+  <ColorInput form="user" field="color" opts={autofocus: "autofocus"} />
   ```
   """
 

--- a/lib/surface/components/form/date_input.ex
+++ b/lib/surface/components/form/date_input.ex
@@ -12,7 +12,7 @@ defmodule Surface.Components.Form.DateInput do
   ## Examples
 
   ```
-  <DateInput form="user" field="birthday" opts={autofocus: "autofocus"}>
+  <DateInput form="user" field="birthday" opts={autofocus: "autofocus"} />
   ```
   """
 

--- a/lib/surface/components/form/date_input.ex
+++ b/lib/surface/components/form/date_input.ex
@@ -12,7 +12,7 @@ defmodule Surface.Components.Form.DateInput do
   ## Examples
 
   ```
-  <DateInput form="user" field="birthday" opts={{ autofocus: "autofocus" }}>
+  <DateInput form="user" field="birthday" opts={autofocus: "autofocus"}>
   ```
   """
 

--- a/lib/surface/components/form/date_select.ex
+++ b/lib/surface/components/form/date_select.ex
@@ -13,8 +13,8 @@ defmodule Surface.Components.Form.DateSelect do
   ```
   <DateSelect form="user" field="born_at" />
 
-  <Form for={{ :user }}>
-    <DateSelect field={{ :born_at }} />
+  <Form for={:user}>
+    <DateSelect field={:born_at} />
   </Form>
   ```
   """

--- a/lib/surface/components/form/datetime_local_input.ex
+++ b/lib/surface/components/form/datetime_local_input.ex
@@ -12,7 +12,7 @@ defmodule Surface.Components.Form.DateTimeLocalInput do
   ## Examples
 
   ```
-  <DateTimeLocalInput form="order" field="completed_at" opts={{ autofocus: "autofocus" }} />
+  <DateTimeLocalInput form="order" field="completed_at" opts={autofocus: "autofocus"} />
   ```
   """
 

--- a/lib/surface/components/form/datetime_select.ex
+++ b/lib/surface/components/form/datetime_select.ex
@@ -13,8 +13,8 @@ defmodule Surface.Components.Form.DateTimeSelect do
   ```
   <DateTimeSelect form="user" field="born_at" />
 
-  <Form for={{ :user }}>
-    <DateTimeSelect field={{ :born_at }} />
+  <Form for={:user}>
+    <DateTimeSelect field={:born_at} />
   </Form>
   ```
   """

--- a/lib/surface/components/form/email_input.ex
+++ b/lib/surface/components/form/email_input.ex
@@ -11,7 +11,7 @@ defmodule Surface.Components.Form.EmailInput do
   ## Examples
 
   ```
-  <EmailInput form="user" field="email" opts={autofocus: "autofocus"}>
+  <EmailInput form="user" field="email" opts={autofocus: "autofocus"} />
   ```
   """
 

--- a/lib/surface/components/form/email_input.ex
+++ b/lib/surface/components/form/email_input.ex
@@ -11,7 +11,7 @@ defmodule Surface.Components.Form.EmailInput do
   ## Examples
 
   ```
-  <EmailInput form="user" field="email" opts={{ autofocus: "autofocus" }}>
+  <EmailInput form="user" field="email" opts={autofocus: "autofocus"}>
   ```
   """
 

--- a/lib/surface/components/form/file_input.ex
+++ b/lib/surface/components/form/file_input.ex
@@ -13,8 +13,8 @@ defmodule Surface.Components.Form.FileInput do
   ```
   <FileInput form="user" field="picture" />
 
-  <Form for={{ :user }} opts={{ multipart: true }}>
-    <FileInput field={{ :picture }} />
+  <Form for={:user} opts={multipart: true}>
+    <FileInput field={:picture} />
   </Form>
   ```
   """

--- a/lib/surface/components/form/hidden_input.ex
+++ b/lib/surface/components/form/hidden_input.ex
@@ -11,7 +11,7 @@ defmodule Surface.Components.Form.HiddenInput do
   ## Examples
 
   ```
-  <HiddenInput form="user" field="token" opts={{ autofocus: "autofocus" }}>
+  <HiddenInput form="user" field="token" opts={autofocus: "autofocus"} />
   ```
   """
 

--- a/lib/surface/components/form/number_input.ex
+++ b/lib/surface/components/form/number_input.ex
@@ -11,7 +11,7 @@ defmodule Surface.Components.Form.NumberInput do
   ## Examples
 
   ```
-  <NumberInput form="user" field="age" opts={{ autofocus: "autofocus" }}>
+  <NumberInput form="user" field="age" opts={autofocus: "autofocus"} />
   ```
   """
 

--- a/lib/surface/components/form/password_input.ex
+++ b/lib/surface/components/form/password_input.ex
@@ -11,7 +11,7 @@ defmodule Surface.Components.Form.PasswordInput do
   ## Examples
 
   ```
-  <PasswordInput form="user" field="password" opts={{ autofocus: "autofocus" }} />
+  <PasswordInput form="user" field="password" opts={autofocus: "autofocus"} />
   ```
   """
 

--- a/lib/surface/components/form/radio_button.ex
+++ b/lib/surface/components/form/radio_button.ex
@@ -11,7 +11,7 @@ defmodule Surface.Components.Form.RadioButton do
   ## Examples
 
   ```
-  <RadioButton form="user" field="color" opts={autofocus: "autofocus"}>
+  <RadioButton form="user" field="color" opts={autofocus: "autofocus"} />
   ```
   """
 

--- a/lib/surface/components/form/radio_button.ex
+++ b/lib/surface/components/form/radio_button.ex
@@ -11,7 +11,7 @@ defmodule Surface.Components.Form.RadioButton do
   ## Examples
 
   ```
-  <RadioButton form="user" field="color" opts={{ autofocus: "autofocus" }}>
+  <RadioButton form="user" field="color" opts={autofocus: "autofocus"}>
   ```
   """
 

--- a/lib/surface/components/form/range_input.ex
+++ b/lib/surface/components/form/range_input.ex
@@ -12,7 +12,7 @@ defmodule Surface.Components.Form.RangeInput do
   ## Examples
 
   ```
-  <RangeInput form="volume" field="percent" min="0" max="100" step="5" value="40" opts={{ autofocus: "autofocus" }} />
+  <RangeInput form="volume" field="percent" min="0" max="100" step="5" value="40" opts={autofocus: "autofocus"} />
   ```
   """
 

--- a/lib/surface/components/form/reset.ex
+++ b/lib/surface/components/form/reset.ex
@@ -11,7 +11,7 @@ defmodule Surface.Components.Form.Reset do
   ## Examples
 
   ```
-  <Reset value="Reset" opts={autofocus: "autofocus"}>
+  <Reset value="Reset" opts={autofocus: "autofocus"} />
   ```
   """
 

--- a/lib/surface/components/form/reset.ex
+++ b/lib/surface/components/form/reset.ex
@@ -11,7 +11,7 @@ defmodule Surface.Components.Form.Reset do
   ## Examples
 
   ```
-  <Reset value="Reset" opts={{ autofocus: "autofocus" }}>
+  <Reset value="Reset" opts={autofocus: "autofocus"}>
   ```
   """
 

--- a/lib/surface/components/form/search_input.ex
+++ b/lib/surface/components/form/search_input.ex
@@ -11,7 +11,7 @@ defmodule Surface.Components.Form.SearchInput do
   ## Examples
 
   ```
-  <SearchInput form="song" field="title" opts={{ autofocus: "autofocus" }} />
+  <SearchInput form="song" field="title" opts={autofocus: "autofocus"} />
   ```
   """
 

--- a/lib/surface/components/form/telephone_input.ex
+++ b/lib/surface/components/form/telephone_input.ex
@@ -11,7 +11,7 @@ defmodule Surface.Components.Form.TelephoneInput do
   ## Examples
 
   ```
-  <TelephoneInput form="user" field="phone" opts={{ autofocus: "autofocus" }} />
+  <TelephoneInput form="user" field="phone" opts={autofocus: "autofocus"} />
   ```
   """
 

--- a/lib/surface/components/form/text_input.ex
+++ b/lib/surface/components/form/text_input.ex
@@ -11,7 +11,7 @@ defmodule Surface.Components.Form.TextInput do
   ## Examples
 
   ```
-  <TextInput form="user" field="name" opts={{ autofocus: "autofocus" }} />
+  <TextInput form="user" field="name" opts={autofocus: "autofocus"} />
   ```
   """
 

--- a/lib/surface/components/form/textarea.ex
+++ b/lib/surface/components/form/textarea.ex
@@ -11,7 +11,7 @@ defmodule Surface.Components.Form.TextArea do
   ## Examples
 
   ```
-  <TextArea form="user" field="summary" cols="5" rows="10" opts={{ autofocus: "autofocus" }}>
+  <TextArea form="user" field="summary" cols="5" rows="10" opts={autofocus: "autofocus"}>
   ```
   """
 

--- a/lib/surface/components/form/textarea.ex
+++ b/lib/surface/components/form/textarea.ex
@@ -11,7 +11,7 @@ defmodule Surface.Components.Form.TextArea do
   ## Examples
 
   ```
-  <TextArea form="user" field="summary" cols="5" rows="10" opts={autofocus: "autofocus"}>
+  <TextArea form="user" field="summary" cols="5" rows="10" opts={autofocus: "autofocus"} />
   ```
   """
 

--- a/lib/surface/components/form/time_input.ex
+++ b/lib/surface/components/form/time_input.ex
@@ -12,7 +12,7 @@ defmodule Surface.Components.Form.TimeInput do
   ## Examples
 
   ```
-  <TimeInput form="user" field="name" opts={{ autofocus: "autofocus" }} />
+  <TimeInput form="user" field="name" opts={autofocus: "autofocus"} />
   ```
   """
 

--- a/lib/surface/components/form/time_select.ex
+++ b/lib/surface/components/form/time_select.ex
@@ -13,8 +13,8 @@ defmodule Surface.Components.Form.TimeSelect do
   ```
   <TimeSelect form="alarm" field="time" />
 
-  <Form for={{ :alarm }}>
-    <TimeSelect field={{ :time }} />
+  <Form for={:alarm}>
+    <TimeSelect field={:time} />
   </Form>
   ```
   """

--- a/lib/surface/components/form/url_input.ex
+++ b/lib/surface/components/form/url_input.ex
@@ -11,7 +11,7 @@ defmodule Surface.Components.Form.UrlInput do
   ## Examples
 
   ```
-  <UrlInput form="user" field="name" opts={{ autofocus: "autofocus" }}>
+  <UrlInput form="user" field="name" opts={autofocus: "autofocus"} />
   ```
   """
 

--- a/lib/surface/components/link.ex
+++ b/lib/surface/components/link.ex
@@ -13,8 +13,8 @@ defmodule Surface.Components.Link do
     label="user"
     to="/users/1"
     class="is-danger"
-    method={{ :delete }}
-    opts={{ data: [confirm: "Really?"] }}
+    method={:delete}
+    opts={data: [confirm: "Really?"]}
   />
 
   <Link

--- a/lib/surface/components/link/button.ex
+++ b/lib/surface/components/link/button.ex
@@ -15,8 +15,8 @@ defmodule Surface.Components.Link.Button do
     label="user"
     to="/users/1"
     class="is-danger"
-    method={{ :delete }}
-    opts={{ data: [confirm: "Really?"] }}
+    method={:delete}
+    opts={data: [confirm: "Really?"]}
   />
 
   <Button

--- a/lib/surface/components/raw.ex
+++ b/lib/surface/components/raw.ex
@@ -6,7 +6,7 @@ defmodule Surface.Components.Raw do
   template engine.
 
   > **Note**: By skipping translation, all Surface specific features
-  are automatically disabled, including code interpolation with `{{...}}`,
+  are automatically disabled, including code interpolation with `{...}`,
   syntactic sugar for attributes and markup validation.
   """
 

--- a/lib/surface/live_component.ex
+++ b/lib/surface/live_component.ex
@@ -15,11 +15,11 @@ defmodule Surface.LiveComponent do
 
         def render(assigns) do
           ~F"\""
-          <div class={{ "modal", "is-active": @show }}>
+          <div class={"modal", "is-active": @show}>
             <div class="modal-background"></div>
             <div class="modal-card">
               <header class="modal-card-head">
-                <p class="modal-card-title">{{ @title }}</p>
+                <p class="modal-card-title">{@title}</p>
               </header>
               <section class="modal-card-body">
                 <#slot/>

--- a/lib/surface/macro_component.ex
+++ b/lib/surface/macro_component.ex
@@ -66,7 +66,7 @@ defmodule Surface.MacroComponent do
           %exception_mod{} = exception
 
           message = """
-          could not evaluate expression {{#{value}}}. Reason:
+          could not evaluate expression {#{value}}. Reason:
 
           (#{inspect(exception_mod)}) #{Exception.message(exception)}
           """

--- a/lib/surface/type_handler/hook.ex
+++ b/lib/surface/type_handler/hook.ex
@@ -55,7 +55,7 @@ defmodule Surface.TypeHandler.Hook do
 
         Example with options:
 
-          <div :hook={{ "Card", from: CardList }}>
+          <div :hook={"Card", from: CardList}>
         """
 
         {:error, clauses ++ opts, message}

--- a/test/surface/integrations/slot_test.exs
+++ b/test/surface/integrations/slot_test.exs
@@ -1293,12 +1293,12 @@ defmodule Surface.SlotSyncTest do
       end)
 
     assert output =~ ~r"""
-           arguments for the default slot in a slotable component are not accessible - instead the arguments from the parent's cols slot will be exposed via `:let={{ ... }}`.
+           arguments for the default slot in a slotable component are not accessible - instead the arguments from the parent's cols slot will be exposed via `:let={...}`.
 
            Hint: You can remove these arguments, pull them up to the parent component, or make this component not slotable and use it inside an explicit template element:
            ```
            <#template name="cols">
-             <Surface.SlotSyncTest.ColumnWithRenderAndSlotArgs :let={{ info: info }}>
+             <Surface.SlotSyncTest.ColumnWithRenderAndSlotArgs :let={info: info}>
                ...
              </Surface.SlotSyncTest.ColumnWithRenderAndSlotArgs>
            </#template>


### PR DESCRIPTION
Its a shame that we can't doctest components, otherwise we would have caught all these. Maybe I can pair with @wojtekmach on a creative solution ;)