### PR TITLE
docs: Adds changelog and license as extra pages

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -59,6 +59,10 @@ defmodule Surface.MixProject do
         Surface.Compiler,
         Surface.Components,
         Surface.Directive
+      ],
+      extras: [
+        "CHANGELOG.md",
+        "LICENSE.md"
       ]
     ]
   end


### PR DESCRIPTION
Adds the changelog and license to ex_doc's `extras` config to make them accessible from the official hexdocs.pm page.