### PR TITLE
Remove automatic punctuation from generated docs

### DIFF
--- a/lib/surface/api.ex
+++ b/lib/surface/api.ex
@@ -620,7 +620,7 @@ defmodule Surface.API do
     # Events are special properties we treat in a separate doc section
     docs =
       for prop <- get_props(module), prop.type != :event do
-        doc = if prop.doc, do: " - #{prop.doc}.", else: ""
+        doc = if prop.doc, do: " - #{prop.doc}", else: ""
         opts = if prop.opts == [], do: "", else: ", #{format_opts(prop.opts_ast)}"
         "* **#{prop.name}** *#{inspect(prop.type)}#{opts}*#{doc}"
       end
@@ -639,7 +639,7 @@ defmodule Surface.API do
   defp generate_slots_docs(module) do
     docs =
       for slot <- get_slots(module) do
-        doc = if slot.doc, do: " - #{slot.doc}.", else: ""
+        doc = if slot.doc, do: " - #{slot.doc}", else: ""
         opts = if slot.opts == [], do: "", else: ", #{format_opts(slot.opts_ast)}"
         "* **#{slot.name}#{opts}**#{doc}"
       end
@@ -658,7 +658,7 @@ defmodule Surface.API do
   defp generate_events_docs(module) do
     docs =
       for prop <- get_props(module), prop.type == :event do
-        doc = if prop.doc, do: " - #{prop.doc}.", else: ""
+        doc = if prop.doc, do: " - #{prop.doc}", else: ""
         opts = if prop.opts == [], do: "", else: ", #{format_opts(prop.opts_ast)}"
         "* **#{prop.name}#{opts}**#{doc}"
       end


### PR DESCRIPTION
Current implementation can have some unintended effects, e.g. I have an example section for a prop, which has a dangly dot after it:
![image](https://user-images.githubusercontent.com/9250552/127613750-2c9dd17b-b411-480c-a6d9-80460601aa1f.png)

I also prefer to end sentences with proper punctuation myself, which leaves another dangly dot:
![image](https://user-images.githubusercontent.com/9250552/127614178-63b216c7-2451-448c-8226-9f0bd79b7680.png)


I think it would be sensible if punctuation were left to the person documenting the module/properties.