### PR TITLE
Fix directives :if with :values

### DIFF
--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -19,9 +19,9 @@ defmodule Surface.Compiler do
     Surface.Directive.Events,
     Surface.Directive.Show,
     Surface.Directive.Hook,
+    Surface.Directive.Values,
     Surface.Directive.If,
     Surface.Directive.For,
-    Surface.Directive.Values,
     Surface.Directive.Debug
   ]
 

--- a/lib/surface/directive/values.ex
+++ b/lib/surface/directive/values.ex
@@ -15,6 +15,10 @@ defmodule Surface.Directive.Values do
 
   def extract(_, _), do: []
 
+  def process(%AST.Directive{} = directive, %AST.If{children: children}) do
+    process(directive, List.first(children))
+  end
+
   def process(
         %AST.Directive{
           value: %AST.AttributeExpr{value: value} = expr,

--- a/lib/surface/directive/values.ex
+++ b/lib/surface/directive/values.ex
@@ -15,10 +15,6 @@ defmodule Surface.Directive.Values do
 
   def extract(_, _), do: []
 
-  def process(%AST.Directive{} = directive, %AST.If{children: children}) do
-    process(directive, List.first(children))
-  end
-
   def process(
         %AST.Directive{
           value: %AST.AttributeExpr{value: value} = expr,

--- a/test/surface/integrations/directives_test.exs
+++ b/test/surface/integrations/directives_test.exs
@@ -995,6 +995,25 @@ defmodule Surface.DirectivesTest do
              </div>
              """
     end
+
+    test "with :if" do
+      assigns = %{show: true}
+
+      html =
+        render_surface do
+          ~F"""
+          <div :if={@show} :values={foo: "bar"}>
+            Show
+          </div>
+          """
+        end
+
+      assert html =~ """
+             <div phx-value-foo=\"bar\">
+               Show
+             </div>
+             """
+    end
   end
 end
 

--- a/test/surface/integrations/directives_test.exs
+++ b/test/surface/integrations/directives_test.exs
@@ -1013,6 +1013,19 @@ defmodule Surface.DirectivesTest do
                Show
              </div>
              """
+
+      assigns = %{show: false}
+
+      html =
+        render_surface do
+          ~F"""
+          <div :if={@show} :values={foo: "bar"}>
+            Show
+          </div>
+          """
+        end
+
+      assert html == "\n"
     end
   end
 end


### PR DESCRIPTION
### Summary

I found a compiler error when using both the `:if` and `:values` directives on the same html tag.

### Problem

```elixir
<div :if={@show} :values={foo: "bar"}>
  Show
</div>
```
should render as
```html
<div phx-value-foo="bar">
  Show
</div>
```
but instead I'm getting this compiler error

> ** (FunctionClauseError) no function clause matching in Surface.Directive.Values.process/2    
    
    The following arguments were given to Surface.Directive.Values.process/2:
    
        # 1
        %Surface.AST.Directive{meta: #Surface.AST.Meta<checks: [no_undefined_assigns: false], column: 18, file: "/Users/miguel/Developer/surface/test/surface/integrations/directives_test.exs", function_component?: nil, line: 1005, module: nil, node_alias: nil, ...>, module: Surface.Directive.Values, name: :values, value: %Surface.AST.AttributeExpr{constant?: true, meta: #Surface.AST.Meta<checks: [no_undefined_assigns: false], column: 27, file: "/Users/miguel/Developer/surface/test/surface/integrations/directives_test.exs", function_component?: nil, line: 1005, module: nil, node_alias: nil, ...>, original: "foo: \"bar\"", value: {{:., [generated: true], [{:__aliases__, [generated: true, alias: false], [:Surface, :TypeHandler]}, :expr_to_value!]}, [generated: true], [:map, ":values", [], [foo: "bar"], nil, "foo: \"bar\""]}}}
    
        # 2
        %Surface.AST.If{children: [%Surface.AST.Tag{attributes: [], children: [%Surface.AST.Literal{directives: [], value: "\n  Show\n"}], debug: [], directives: [%Surface.AST.Directive{meta: #Surface.AST.Meta<checks: [no_undefined_assigns: false], column: 6, file: "/Users/miguel/Developer/surface/test/surface/integrations/directives_test.exs", function_component?: nil, line: 1005, module: nil, node_alias: nil, ...>, module: Surface.Directive.If, name: :if, value: %Surface.AST.AttributeExpr{constant?: false, meta: #Surface.AST.Meta<checks: [no_undefined_assigns: false], column: 11, file: "/Users/miguel/Developer/surface/test/surface/integrations/directives_test.exs", function_component?: nil, line: 1005, module: nil, node_alias: nil, ...>, original: "@show", value: {{:., [generated: true], [{:__aliases__, [generated: true, alias: false], [:Surface, :TypeHandler]}, :expr_to_value!]}, [generated: true], [:boolean, ":if", [{:@, [line: 1005], [{:show, [line: 1005], nil}]}], [], nil, "@show"]}}}, %Surface.AST.Directive{meta: #Surface.AST.Meta<checks: [no_undefined_assigns: false], column: 18, file: "/Users/miguel/Developer/surface/test/surface/integrations/directives_test.exs", function_component?: nil, line: 1005, module: nil, node_alias: nil, ...>, module: Surface.Directive.Values, name: :values, value: %Surface.AST.AttributeExpr{constant?: true, meta: #Surface.AST.Meta<checks: [no_undefined_assigns: false], column: 27, file: "/Users/miguel/Developer/surface/test/surface/integrations/directives_test.exs", function_component?: nil, line: 1005, module: nil, node_alias: nil, ...>, original: "foo: \"bar\"", value: {{:., [generated: true], [{:__aliases__, [generated: true, alias: false], [:Surface, :TypeHandler]}, :expr_to_value!]}, [generated: true], [:map, ":values", [], [foo: "bar"], nil, "foo: \"bar\""]}}}], element: "div", meta: #Surface.AST.Meta<checks: [no_undefined_assigns: false], column: 2, file: "/Users/miguel/Developer/surface/test/surface/integrations/directives_test.exs", function_component?: nil, line: 1005, module: nil, node_alias: nil, ...>}], condition: %Surface.AST.AttributeExpr{constant?: false, meta: #Surface.AST.Meta<checks: [no_undefined_assigns: false], column: 11, file: "/Users/miguel/Developer/surface/test/surface/integrations/directives_test.exs", function_component?: nil, line: 1005, module: nil, node_alias: nil, ...>, original: "@show", value: {{:., [generated: true], [{:__aliases__, [generated: true, alias: false], [:Surface, :TypeHandler]}, :expr_to_value!]}, [generated: true], [:boolean, ":if", [{:@, [line: 1005], [{:show, [line: 1005], nil}]}], [], nil, "@show"]}}, debug: [], directives: [], else: [], meta: #Surface.AST.Meta<checks: [no_undefined_assigns: false], column: 6, file: "/Users/miguel/Developer/surface/test/surface/integrations/directives_test.exs", function_component?: nil, line: 1005, module: nil, node_alias: nil, ...>}
    
    Attempted function clauses (showing 1 out of 1):
    
        def process(%Surface.AST.Directive{value: %Surface.AST.AttributeExpr{value: value} = expr, meta: meta}, %type{attributes: attributes} = node) when type === Surface.AST.Tag or type === Surface.AST.VoidTag

### Cause

1. The `:if` directives is processed first and wraps the node in a `Surface.AST.If`.
2. The `:values` directive is processed next, but it expects a `Surface.AST.Tag` or `Surface.AST.VoidTag`. It doesn't know how to handle a `Surface.AST.If`.

### Proposed solution

Change the order of processing directives: process `:values` before `:if`.