### PR TITLE
Use input_name instead of input_id for error tag

### DIFF
--- a/lib/surface/components/form/error_tag.ex
+++ b/lib/surface/components/form/error_tag.ex
@@ -21,7 +21,7 @@ defmodule Surface.Components.Form.ErrorTag do
   ]
   ```
 
-  > **Note:** If you don't configure a `default_translator`, Surface will try to translate errors using 
+  > **Note:** If you don't configure a `default_translator`, Surface will try to translate errors using
   a built-in message translator which may not cover all types of errors. If the error cannot
   be translated, a generic `"invalid value"` will be returned and a warning will be emitted,
   reminding the user to set up a proper `default_translator` that can handle such cases.
@@ -56,7 +56,7 @@ defmodule Surface.Components.Form.ErrorTag do
 
   use Surface.Component
 
-  import Phoenix.HTML.Form, only: [input_id: 2]
+  import Phoenix.HTML.Form, only: [input_name: 2]
 
   alias Surface.Components.Form.Input.InputContext
 
@@ -113,7 +113,7 @@ defmodule Surface.Components.Form.ErrorTag do
       <span
         :for={error <- Keyword.get_values(form.errors, field)}
         class={class}
-        phx-feedback-for={@feedback_for || input_id(form, field)}
+        phx-feedback-for={@feedback_for || input_name(form, field)}
       >{translate_error.(error)}</span>
     </InputContext>
     """

--- a/test/surface/components/form/error_tag_test.exs
+++ b/test/surface/components/form/error_tag_test.exs
@@ -42,10 +42,10 @@ defmodule Surface.Components.Form.ErrorTagTest do
       end
 
     assert html =~
-             "<span phx-feedback-for=\"user_name\">is already taken</span>"
+             "<span phx-feedback-for=\"user[name]\">is already taken</span>"
 
     assert html =~
-             "<span phx-feedback-for=\"user_name\">another test error</span>"
+             "<span phx-feedback-for=\"user[name]\">another test error</span>"
   end
 
   test "no errors are shown if changeset.action is empty", %{changeset: changeset} do
@@ -101,7 +101,7 @@ defmodule Surface.Components.Form.ErrorTagTest do
       end
 
     assert html =~
-             "<span class=\"test-class\" phx-feedback-for=\"user_name\">is already taken</span>"
+             "<span class=\"test-class\" phx-feedback-for=\"user[name]\">is already taken</span>"
   end
 
   test "no changeset shows no errors" do
@@ -173,7 +173,7 @@ defmodule Surface.Components.Form.ErrorTagSyncTest do
         end
 
       assert html =~
-               "<span phx-feedback-for=\"user_name\">translated by config translator</span>"
+               "<span phx-feedback-for=\"user[name]\">translated by config translator</span>"
     end
   end
 
@@ -194,10 +194,10 @@ defmodule Surface.Components.Form.ErrorTagSyncTest do
         end
 
       assert html =~
-               "<span phx-feedback-for=\"user_name\">translated by prop translator</span>"
+               "<span phx-feedback-for=\"user[name]\">translated by prop translator</span>"
 
       refute html =~
-               "<span phx-feedback-for=\"user_name\">translated by config translator</span>"
+               "<span phx-feedback-for=\"user[name]\">translated by config translator</span>"
     end
   end
 
@@ -217,7 +217,7 @@ defmodule Surface.Components.Form.ErrorTagSyncTest do
         end
 
       assert html =~
-               "<span class=\"class-from-config\" phx-feedback-for=\"user_name\">is already taken</span>"
+               "<span class=\"class-from-config\" phx-feedback-for=\"user[name]\">is already taken</span>"
     end
   end
 
@@ -237,7 +237,7 @@ defmodule Surface.Components.Form.ErrorTagSyncTest do
         end
 
       assert html =~
-               "<span class=\"class-from-prop\" phx-feedback-for=\"user_name\">is already taken</span>"
+               "<span class=\"class-from-prop\" phx-feedback-for=\"user[name]\">is already taken</span>"
     end
   end
 


### PR DESCRIPTION
The phoenix live view implementation of `error_tag` relies on the `input_name` instead of the `input_id` for the `phx-feedback-for` tag since this PR https://github.com/phoenixframework/phoenix_live_view/pull/1278/files.

I discovered we are using `input_id` in our `ErrorTag` component. It can cause error like the one described in this issue: https://github.com/phoenixframework/phoenix_live_view/issues/1109

I believe we should be aligned with the PhoenixLiveView implementation to keep the behaviour consistent. I spent few hours to understand the bug ^^ 