### PR TITLE
Merge surface_formatter into Surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           - elixir: 1.12.1
             otp: 24.0
             check_formatted: true
-          - elixir: 1.13.0-rc.1
+          - elixir: 1.13.0
             otp: 24.0
             run_plugin_tests: true
             warnings-as-errors: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,14 @@ jobs:
         include:
           - elixir: 1.11.4
             otp: 22.3
-            warnings-as-errors: true
           - elixir: 1.11.4
             otp: 23.3
-            warnings-as-errors: true
           - elixir: 1.12.1
             otp: 24.0
             check_formatted: true
+          - elixir: 1.13.0-rc.1
+            otp: 24.0
+            run_plugin_tests: true
             warnings-as-errors: true
     env:
       MIX_ENV: test
@@ -42,3 +43,6 @@ jobs:
       - run: mix compile --warnings-as-errors
         if: matrix.warnings_as_errors
       - run: mix test
+        if: matrix.run_plugin_tests
+      - run: mix test --exclude plugin
+        if: ${{ !matrix.run_plugin_tests }}

--- a/lib/mix/tasks/surface/surface.format.ex
+++ b/lib/mix/tasks/surface/surface.format.ex
@@ -1,0 +1,500 @@
+defmodule Mix.Tasks.Surface.Format do
+  @shortdoc "Formats Surface ~F sigils and .sface files in the given files/patterns"
+
+  @moduledoc """
+  **To format Surface code using Elixir 1.13 or later, use
+  `Surface.Formatter.Plugin`.**
+
+  Formats Surface `~F` sigils and `.sface` files in the given files and patterns.
+
+  ```bash
+  $ mix surface.format "lib/**/*.{ex,exs}" "test/**/*.{ex,exs}"
+  $ cat path/to/file.ex | mix surface.format -
+  ```
+
+  Takes the same options as `mix format` except for `--check-equivalent`.
+
+  ## Formatting options
+
+  Like `mix format`, the Surface formatter reads a `.formatter.exs` file in the
+  current directory for formatter configuration. The Surface formatter accepts
+  the same options as `mix format`. Read more about the expected format of
+  `.formatter.exs` and the shared configuration options
+  [documented here](https://hexdocs.pm/mix/master/Mix.Tasks.Format.html#module-formatting-options).
+
+  The Surface formatter also takes the following two additional options
+  specified in `.formatter.exs`:
+
+    - `:surface_line_length` overrides `:line_length` only for `mix surface.format`
+      (`:line_length` is used otherwise, or defaults to 98)
+    - `:surface_inputs` overrides `:inputs` only for `mix surface.format`
+      (`:inputs` is used otherwise)
+
+  ## Task-specific options
+
+  The Surface formatter accepts the same task-specific options as `mix format`.
+  [Read documentation for the options documented here.](https://hexdocs.pm/mix/master/Mix.Tasks.Format.html#module-task-specific-options).
+
+  For quick reference, here are some examples of using these options:
+
+  ```bash
+  $ mix surface.format --check-formatted
+  ** (Mix) mix surface.format failed due to --check-formatted.
+  The following files are not formatted:
+    * path/to/component.ex
+    * path/to/file.sface
+  ```
+
+  ```bash
+  $ mix surface.format --dry-run
+  ```
+
+  ```bash
+  $ mix surface.format --dot-formatter path/to/.formatter.exs
+  ```
+
+  You can also use the same syntax as `mix format` for specifying which files to
+  format:
+
+  ```bash
+  $ mix surface.format path/to/file.ex "lib/**/*.{ex,exs}" "test/**/*.{ex,exs}"
+  ```
+  """
+
+  use Mix.Task
+
+  alias Surface.Formatter
+
+  #
+  # Functions unique to surface.format (Everything else is taken from Mix.Tasks.Format)
+  #
+
+  defp format_file_contents!(:stdin, input, opts) do
+    # determine whether the input is Elixir or Surface code by checking if `Code.string_to_quoted` can parse it
+    case Code.string_to_quoted(input) do
+      {:ok, _} ->
+        format_ex_string!(input, opts)
+
+      {:error, _} ->
+        Formatter.format_string!(input, opts)
+    end
+  end
+
+  defp format_file_contents!(file, input, opts) do
+    case Path.extname(file) do
+      ".sface" ->
+        Formatter.format_string!(input, opts)
+
+      _ ->
+        format_ex_string!(input, opts)
+    end
+  end
+
+  defp format_ex_string!(input, opts) do
+    string =
+      ~r/\n( *)~F"""(.*?)"""/s
+      |> Regex.replace(input, fn _match, indentation, surface_code ->
+        # Indent the entire ~F sigil contents based on the indentation of `~F"""`
+        tabs =
+          indentation
+          |> String.length()
+          |> Kernel.div(2)
+
+        opts = Keyword.put(opts, :indent, tabs)
+
+        "\n#{indentation}~F\"\"\"\n#{Formatter.format_string!(surface_code, opts)}#{indentation}\"\"\""
+      end)
+
+    # We do not match on ~F"..." sigils where the first character is `\`
+    # in order to allow for a use case in surface_site, where Surface
+    # code examples are being rendered inside a Markdown component and
+    # contains the string: `~F"\""`
+    string =
+      Regex.replace(~r/~F\"([^\"\\].*?)\"/s, string, fn _match, code ->
+        "~F\"#{Formatter.format_string!(code, opts)}\""
+      end)
+
+    string =
+      Regex.replace(~r/~F\[(.*?)\]/s, string, fn _match, code ->
+        "~F[#{Formatter.format_string!(code, opts)}]"
+      end)
+
+    string =
+      Regex.replace(~r/~F\((.*?)\)/s, string, fn _match, code ->
+        "~F(#{Formatter.format_string!(code, opts)})"
+      end)
+
+    Regex.replace(~r/~F\{(.*?)\}/s, string, fn _match, code ->
+      "~F{#{Formatter.format_string!(code, opts)}}"
+    end)
+  end
+
+  #
+  # The below functions are taken directly from Mix.Tasks.Format with insignificant modification
+  #
+
+  # TODO: Add support for `check_equivalent: :boolean` here
+  @switches [
+    check_formatted: :boolean,
+    dot_formatter: :string,
+    dry_run: :boolean
+  ]
+
+  @manifest "cached_dot_formatter"
+  @manifest_vsn 1
+
+  @impl true
+  def run(args) do
+    {opts, args} = OptionParser.parse!(args, strict: @switches)
+    {dot_formatter, formatter_opts} = eval_dot_formatter(opts)
+
+    {{formatter_opts, subdirectories}, _sources} =
+      eval_deps_and_subdirectories(dot_formatter, [], formatter_opts, [dot_formatter])
+
+    # surface_line_length can be used to override the line_length option
+    formatter_opts =
+      if line_length = formatter_opts[:surface_line_length] do
+        Keyword.put(formatter_opts, :line_length, line_length)
+      else
+        formatter_opts
+      end
+
+    args
+    |> expand_args(dot_formatter, {formatter_opts, subdirectories})
+    |> Task.async_stream(&format_file(&1, opts), ordered: false, timeout: 30000)
+    |> Enum.reduce({[], [], []}, &collect_status/2)
+    |> check!()
+  end
+
+  defp format_file({file, formatter_opts}, task_opts) do
+    {input, extra_opts} = read_file(file)
+    formatted = format_file_contents!(file, input, extra_opts ++ formatter_opts)
+    output = IO.iodata_to_binary([formatted])
+
+    check_equivalent? = Keyword.get(task_opts, :check_equivalent, false)
+    check_formatted? = Keyword.get(task_opts, :check_formatted, false)
+    dry_run? = Keyword.get(task_opts, :dry_run, false)
+
+    cond do
+      check_equivalent? and not equivalent?(input, output) ->
+        {:not_equivalent, file}
+
+      check_formatted? ->
+        if input == output, do: :ok, else: {:not_formatted, file}
+
+      dry_run? ->
+        :ok
+
+      true ->
+        write_or_print(file, input, output)
+    end
+  rescue
+    exception ->
+      {:exit, file, exception, __STACKTRACE__}
+  end
+
+  # This function reads exported configuration from the imported
+  # dependencies and subdirectories and deals with caching the result
+  # of reading such configuration in a manifest file.
+  defp eval_deps_and_subdirectories(dot_formatter, prefix, formatter_opts, sources) do
+    deps = Keyword.get(formatter_opts, :import_deps, [])
+    subs = Keyword.get(formatter_opts, :subdirectories, [])
+
+    if not is_list(deps) do
+      Mix.raise("Expected :import_deps to return a list of dependencies, got: #{inspect(deps)}")
+    end
+
+    if not is_list(subs) do
+      Mix.raise("Expected :subdirectories to return a list of directories, got: #{inspect(subs)}")
+    end
+
+    if deps == [] and subs == [] do
+      {{formatter_opts, []}, sources}
+    else
+      manifest = Path.join(Mix.Project.manifest_path(), @manifest)
+
+      maybe_cache_in_manifest(dot_formatter, manifest, fn ->
+        {subdirectories, sources} = eval_subs_opts(subs, prefix, sources)
+        {{eval_deps_opts(formatter_opts, deps), subdirectories}, sources}
+      end)
+    end
+  end
+
+  defp eval_deps_opts(formatter_opts, deps) do
+    deps_paths = Mix.Project.deps_paths()
+
+    parenless_calls =
+      for dep <- deps,
+          dep_path = assert_valid_dep_and_fetch_path(dep, deps_paths),
+          dep_dot_formatter = Path.join(dep_path, ".formatter.exs"),
+          File.regular?(dep_dot_formatter),
+          dep_opts = eval_file_with_keyword_list(dep_dot_formatter),
+          parenless_call <- dep_opts[:export][:locals_without_parens] || [],
+          uniq: true,
+          do: parenless_call
+
+    Keyword.update(
+      formatter_opts,
+      :locals_without_parens,
+      parenless_calls,
+      &(&1 ++ parenless_calls)
+    )
+  end
+
+  defp eval_subs_opts(subs, prefix, sources) do
+    {subs, sources} =
+      Enum.flat_map_reduce(subs, sources, fn sub, sources ->
+        prefix = Path.join(prefix ++ [sub])
+        {Path.wildcard(prefix), [Path.join(prefix, ".formatter.exs") | sources]}
+      end)
+
+    Enum.flat_map_reduce(subs, sources, fn sub, sources ->
+      sub_formatter = Path.join(sub, ".formatter.exs")
+
+      if File.exists?(sub_formatter) do
+        formatter_opts = eval_file_with_keyword_list(sub_formatter)
+
+        {formatter_opts_and_subs, sources} =
+          eval_deps_and_subdirectories(:in_memory, [sub], formatter_opts, sources)
+
+        {[{sub, formatter_opts_and_subs}], sources}
+      else
+        {[], sources}
+      end
+    end)
+  end
+
+  defp assert_valid_dep_and_fetch_path(dep, deps_paths) when is_atom(dep) do
+    case Map.fetch(deps_paths, dep) do
+      {:ok, path} ->
+        if File.dir?(path) do
+          path
+        else
+          Mix.raise(
+            "Unavailable dependency #{inspect(dep)} given to :import_deps in the formatter configuration. " <>
+              "The dependency cannot be found in the file system, please run \"mix deps.get\" and try again"
+          )
+        end
+
+      :error ->
+        Mix.raise(
+          "Unknown dependency #{inspect(dep)} given to :import_deps in the formatter configuration. " <>
+            "The dependency is not listed in your mix.exs for environment #{inspect(Mix.env())}"
+        )
+    end
+  end
+
+  defp maybe_cache_in_manifest(dot_formatter, manifest, fun) do
+    cond do
+      is_nil(Mix.Project.get()) or dot_formatter != ".formatter.exs" -> fun.()
+      entry = read_manifest(manifest) -> entry
+      true -> write_manifest!(manifest, fun.())
+    end
+  end
+
+  defp read_manifest(manifest) do
+    with {:ok, binary} <- File.read(manifest),
+         {:ok, {@manifest_vsn, entry, sources}} <- safe_binary_to_term(binary),
+         expanded_sources = Enum.flat_map(sources, &Path.wildcard(&1, match_dot: true)),
+         false <- Mix.Utils.stale?([Mix.Project.config_mtime() | expanded_sources], [manifest]) do
+      {entry, sources}
+    else
+      _ -> nil
+    end
+  end
+
+  defp safe_binary_to_term(binary) do
+    {:ok, :erlang.binary_to_term(binary)}
+  rescue
+    _ -> :error
+  end
+
+  defp write_manifest!(manifest, {entry, sources}) do
+    File.mkdir_p!(Path.dirname(manifest))
+    File.write!(manifest, :erlang.term_to_binary({@manifest_vsn, entry, sources}))
+    {entry, sources}
+  end
+
+  defp eval_dot_formatter(opts) do
+    cond do
+      dot_formatter = opts[:dot_formatter] ->
+        {dot_formatter, eval_file_with_keyword_list(dot_formatter)}
+
+      File.regular?(".formatter.exs") ->
+        {".formatter.exs", eval_file_with_keyword_list(".formatter.exs")}
+
+      true ->
+        {".formatter.exs", []}
+    end
+  end
+
+  defp eval_file_with_keyword_list(path) do
+    {opts, _} = Code.eval_file(path)
+
+    unless Keyword.keyword?(opts) do
+      Mix.raise("Expected #{inspect(path)} to return a keyword list, got: #{inspect(opts)}")
+    end
+
+    opts
+  end
+
+  defp read_file(:stdin) do
+    {IO.stream(:stdio, :line) |> Enum.to_list() |> IO.iodata_to_binary(), file: "stdin"}
+  end
+
+  defp read_file(file) do
+    {File.read!(file), file: file}
+  end
+
+  defp expand_args([], dot_formatter, formatter_opts_and_subs) do
+    if no_entries_in_formatter_opts?(formatter_opts_and_subs) do
+      Mix.raise(
+        "Expected one or more files/patterns to be given to mix format " <>
+          "or for a .formatter.exs file to exist with an :inputs, :surface_inputs or :subdirectories key"
+      )
+    end
+
+    dot_formatter
+    |> expand_dot_inputs([], formatter_opts_and_subs, %{})
+    |> Enum.map(fn {file, {_dot_formatter, formatter_opts}} -> {file, formatter_opts} end)
+  end
+
+  defp expand_args(files_and_patterns, _dot_formatter, {formatter_opts, subs}) do
+    files =
+      for file_or_pattern <- files_and_patterns,
+          file <- stdin_or_wildcard(file_or_pattern),
+          uniq: true,
+          do: file
+
+    if files == [] do
+      Mix.raise(
+        "Could not find a file to format. The files/patterns given to command line " <>
+          "did not point to any existing file. Got: #{inspect(files_and_patterns)}"
+      )
+    end
+
+    for file <- files do
+      if file == :stdin do
+        {file, formatter_opts}
+      else
+        split = file |> Path.relative_to_cwd() |> Path.split()
+        {file, find_formatter_opts_for_file(split, {formatter_opts, subs})}
+      end
+    end
+  end
+
+  defp expand_dot_inputs(dot_formatter, prefix, {formatter_opts, subs}, acc) do
+    if no_entries_in_formatter_opts?({formatter_opts, subs}) do
+      Mix.raise("Expected :inputs, :surface_inputs or :subdirectories key in #{dot_formatter}")
+    end
+
+    map =
+      for input <- List.wrap(formatter_opts[:surface_inputs] || formatter_opts[:inputs]),
+          file <- Path.wildcard(Path.join(prefix ++ [input]), match_dot: true),
+          do: {expand_relative_to_cwd(file), {dot_formatter, formatter_opts}},
+          into: %{}
+
+    acc =
+      Map.merge(acc, map, fn file, {dot_formatter1, _}, {dot_formatter2, formatter_opts} ->
+        Mix.shell().error(
+          "Both #{dot_formatter1} and #{dot_formatter2} specify the file " <>
+            "#{Path.relative_to_cwd(file)} in their :inputs or :surface_inputs option. To resolve the " <>
+            "conflict, the configuration in #{dot_formatter1} will be ignored. " <>
+            "Please change the list of :inputs (or :surface_inputs) in one of the formatter files so only " <>
+            "one of them matches #{Path.relative_to_cwd(file)}"
+        )
+
+        {dot_formatter2, formatter_opts}
+      end)
+
+    Enum.reduce(subs, acc, fn {sub, formatter_opts_and_subs}, acc ->
+      sub_formatter = Path.join(sub, ".formatter.exs")
+      expand_dot_inputs(sub_formatter, [sub], formatter_opts_and_subs, acc)
+    end)
+  end
+
+  defp expand_relative_to_cwd(path) do
+    case File.cwd() do
+      {:ok, cwd} -> Path.expand(path, cwd)
+      _ -> path
+    end
+  end
+
+  defp find_formatter_opts_for_file(split, {formatter_opts, subs}) do
+    Enum.find_value(subs, formatter_opts, fn {sub, formatter_opts_and_subs} ->
+      if List.starts_with?(split, Path.split(sub)) do
+        find_formatter_opts_for_file(split, formatter_opts_and_subs)
+      end
+    end)
+  end
+
+  defp stdin_or_wildcard("-"), do: [:stdin]
+  defp stdin_or_wildcard(path), do: path |> Path.expand() |> Path.wildcard(match_dot: true)
+
+  defp no_entries_in_formatter_opts?({formatter_opts, subs}) do
+    is_nil(formatter_opts[:inputs]) and is_nil(formatter_opts[:surface_inputs]) and subs == []
+  end
+
+  defp write_or_print(file, input, output) do
+    cond do
+      file == :stdin -> IO.write(output)
+      input == output -> :ok
+      true -> File.write!(file, output)
+    end
+
+    :ok
+  end
+
+  defp collect_status({:ok, :ok}, acc), do: acc
+
+  defp collect_status({:ok, {:exit, _, _, _} = exit}, {exits, not_equivalent, not_formatted}) do
+    {[exit | exits], not_equivalent, not_formatted}
+  end
+
+  defp collect_status({:ok, {:not_equivalent, file}}, {exits, not_equivalent, not_formatted}) do
+    {exits, [file | not_equivalent], not_formatted}
+  end
+
+  defp collect_status({:ok, {:not_formatted, file}}, {exits, not_equivalent, not_formatted}) do
+    {exits, not_equivalent, [file | not_formatted]}
+  end
+
+  defp check!({[], [], []}) do
+    :ok
+  end
+
+  defp check!({[{:exit, :stdin, exception, stacktrace} | _], _not_equivalent, _not_formatted}) do
+    Mix.shell().error("mix surface.format failed for stdin")
+    reraise exception, stacktrace
+  end
+
+  defp check!({[{:exit, file, exception, stacktrace} | _], _not_equivalent, _not_formatted}) do
+    Mix.shell().error("mix surface.format failed for file: #{Path.relative_to_cwd(file)}")
+    reraise exception, stacktrace
+  end
+
+  defp check!({_exits, [_ | _] = not_equivalent, _not_formatted}) do
+    Mix.raise("""
+    mix surface.format failed due to --check-equivalent.
+    The following files are not equivalent:
+    #{to_bullet_list(not_equivalent)}
+    Please report this bug with the input files at https://github.com/surface-ui/surface_formatter/issues
+    """)
+  end
+
+  defp check!({_exits, _not_equivalent, [_ | _] = not_formatted}) do
+    Mix.raise("""
+    mix surface.format failed due to --check-formatted.
+    The following files are not formatted:
+    #{to_bullet_list(not_formatted)}
+    """)
+  end
+
+  defp to_bullet_list(files) do
+    Enum.map_join(files, "\n", &"  * #{&1 |> to_string() |> Path.relative_to_cwd()}")
+  end
+
+  defp equivalent?(input, output) do
+    input == output
+  end
+end

--- a/lib/mix/tasks/surface/surface.format.ex
+++ b/lib/mix/tasks/surface/surface.format.ex
@@ -133,7 +133,6 @@ defmodule Mix.Tasks.Surface.Format do
   # The below functions are taken directly from Mix.Tasks.Format with insignificant modification
   #
 
-  # TODO: Add support for `check_equivalent: :boolean` here
   @switches [
     check_formatted: :boolean,
     dot_formatter: :string,

--- a/lib/mix/tasks/surface/surface.init.ex
+++ b/lib/mix/tasks/surface/surface.init.ex
@@ -142,15 +142,25 @@ defmodule Mix.Tasks.Surface.Init do
   end
 
   defp patches_for(:formatter, %{formatter: true}) do
-    %{
-      "mix.exs" => [
-        Patches.add_surface_formatter_to_mix_deps()
-      ],
-      ".formatter.exs" => [
-        Patches.add_surface_inputs_to_formatter_config(),
-        Patches.add_surface_to_import_deps_in_formatter_config()
-      ]
-    }
+    if Version.match?(System.version(), ">= 1.13.0") do
+      %{
+        ".formatter.exs" => [
+          Patches.add_sface_files_to_inputs_in_formatter_config(),
+          Patches.add_surface_to_import_deps_in_formatter_config(),
+          Patches.add_formatter_plugin_to_formatter_config()
+        ]
+      }
+    else
+      %{
+        "mix.exs" => [
+          Patches.add_surface_formatter_to_mix_deps()
+        ],
+        ".formatter.exs" => [
+          Patches.add_surface_inputs_to_formatter_config(),
+          Patches.add_surface_to_import_deps_in_formatter_config()
+        ]
+      }
+    end
   end
 
   defp patches_for(:error_tag, %{error_tag: true, using_gettext?: true, web_module: web_module}) do

--- a/lib/mix/tasks/surface/surface.init/patchers/formatter.ex
+++ b/lib/mix/tasks/surface/surface.init/patchers/formatter.ex
@@ -19,4 +19,20 @@ defmodule Mix.Tasks.Surface.Init.Patchers.Formatter do
     |> halt_if(&find_list_item_with_code(&1, dep), :already_patched)
     |> append_list_item(dep)
   end
+
+  def add_input(code, pattern) do
+    code
+    |> parse_string!()
+    |> find_keyword_value(:inputs)
+    |> halt_if(&find_list_item_with_code(&1, pattern), :already_patched)
+    |> append_list_item(pattern)
+  end
+
+  def add_plugin(code, plugin) do
+    code
+    |> parse_string!()
+    |> find_keyword_value(:plugins)
+    |> halt_if(&find_list_item_with_code(&1, plugin), :already_patched)
+    |> append_list_item(plugin)
+  end
 end

--- a/lib/mix/tasks/surface/surface.init/patchers/formatter.ex
+++ b/lib/mix/tasks/surface/surface.init/patchers/formatter.ex
@@ -4,6 +4,7 @@ defmodule Mix.Tasks.Surface.Init.Patchers.Formatter do
   # Common patches for `.formatter`
 
   import Mix.Tasks.Surface.Init.ExPatcher
+  alias Mix.Tasks.Surface.Init.ExPatcher
 
   def add_config(code, key, value) do
     code
@@ -29,10 +30,16 @@ defmodule Mix.Tasks.Surface.Init.Patchers.Formatter do
   end
 
   def add_plugin(code, plugin) do
-    code
-    |> parse_string!()
-    |> find_keyword_value(:plugins)
-    |> halt_if(&find_list_item_with_code(&1, plugin), :already_patched)
-    |> append_list_item(plugin)
+    patcher = parse_string!(code)
+
+    case find_keyword_value(patcher, :plugins) do
+      %ExPatcher{node: nil} ->
+        append_keyword(patcher, :plugins, "[#{plugin}]")
+
+      plugins_patcher ->
+        plugins_patcher
+        |> halt_if(&find_list_item_with_code(&1, plugin), :already_patched)
+        |> append_list_item(plugin)
+    end
   end
 end

--- a/lib/mix/tasks/surface/surface.init/patches.ex
+++ b/lib/mix/tasks/surface/surface.init/patches.ex
@@ -99,6 +99,26 @@ defmodule Mix.Tasks.Surface.Init.Patches do
     }
   end
 
+  def add_sface_files_to_inputs_in_formatter_config() do
+    %{
+      name: "Add sface files to :inputs",
+      patch: &Patchers.Formatter.add_input(&1, ~S("{lib,test}/**/*.sface")),
+      instructions: """
+      In case you'll be using `mix format`, make sure you add the required file patterns
+      to your `.formatter.exs` file.
+
+      # Example
+
+      ```
+      [
+        inputs: ["{lib,test}/**/*.sface", ...],
+        ...
+      ]
+      ```
+      """
+    }
+  end
+
   def add_surface_to_import_deps_in_formatter_config() do
     %{
       name: "Add :surface to :import_deps",
@@ -112,6 +132,26 @@ defmodule Mix.Tasks.Surface.Init.Patches do
       ```
       [
         import_deps: [:ecto, :phoenix, :surface],
+        ...
+      ]
+      ```
+      """
+    }
+  end
+
+  def add_formatter_plugin_to_formatter_config() do
+    %{
+      name: "Add Surface.Formatter.Plugin to :plugins",
+      patch: &Patchers.Formatter.add_plugin(&1, "Surface.Formatter.Plugin"),
+      instructions: """
+      In case you'll be using `mix format`, make sure you add `Surface.Formatter.Plugin`
+      to the `plugins` in your `.formatter.exs` file.
+
+      # Example
+
+      ```
+      [
+        plugins: [Surface.Formatter.Plugin],
         ...
       ]
       ```

--- a/lib/surface/formatter.ex
+++ b/lib/surface/formatter.ex
@@ -1,0 +1,421 @@
+defmodule Surface.Formatter do
+  @moduledoc "Functions for formatting Surface code snippets."
+
+  alias Surface.Formatter.Phases
+
+  @typedoc """
+  Options that can be passed to `Surface.Formatter.format_string!/2`.
+
+    - `:line_length` - Maximum line length before wrapping opening tags
+    - `:indent` - Starting indentation depth depending on the context of the ~F sigil
+  """
+  @type option :: {:line_length, integer} | {:indent, integer}
+
+  @typedoc """
+  The name of an HTML/Surface tag, such as `div`, `ListItem`, or `#Markdown`.
+  """
+  @type tag :: String.t()
+
+  @typedoc "The value of a parsed HTML/Component attribute."
+  @type attribute_value ::
+          integer
+          | boolean
+          | String.t()
+          | {:attribute_expr, interpolated_expression :: String.t(), term}
+          | [String.t()]
+
+  @typedoc "A parsed HTML/Component attribute name and value."
+  @type attribute :: {name :: String.t(), attribute_value, term}
+
+  @typedoc "A node output by `Surface.Compiler.Parser.parse`."
+  @type surface_node ::
+          String.t()
+          | {:interpolation, String.t(), map}
+          | {tag, list(attribute), list(surface_node), map}
+
+  @typedoc """
+  Whitespace nodes that can be rendered by `Surface.Formatter.Render.node/2`.
+
+  The Surface parser does not return these, but formatter phases introduce these nodes
+  in preparation for rendering.
+
+  - `:newline` adds a newline (`\\n`) character
+  - `:space` adds a space (` `) character
+  - `:indent` adds spaces at the appropriate indentation amount
+  - `:indent_one_less` adds spaces at 1 indentation level removed (used for closing tags)
+  """
+  @type whitespace ::
+          :newline
+          | :space
+          | :indent
+          | :indent_one_less
+
+  @typedoc """
+  A node that will ultimately be sent to `Surface.Formatter.Render.node/2` for rendering.
+
+  The output of `Surface.Compiler.Parser.parse` is ran through the various formatting
+  phases, which ultimately output a tree of this type.
+  """
+  @type formatter_node :: surface_node | whitespace
+
+  @doc """
+  Formats the given Surface code string. (Typically the contents of an `~F`
+  sigil or `.sface` file.)
+
+  In short:
+
+    - HTML/Surface elements are indented to the right of their parents.
+    - Attributes are split on multiple lines if the line is too long; otherwise on the same line.
+    - Elixir code snippets (inside `{ }`) are ran through the Elixir code formatter.
+    - Lack of whitespace is preserved, so that intended behaviors are not removed.
+      (For example, `<span>Foo bar baz</span>` will not have newlines or spaces added.)
+
+  Below the **Options** section is a non-exhaustive list of behaviors of the formatter.
+
+  # Options
+
+    * `:line_length` - the line length to aim for when formatting
+    the document. Defaults to 98. As with the Elixir formatter,
+    this value is used as reference but is not always enforced
+    depending on the context.
+
+  # Indentation
+
+  The formatter ensures that children are indented one tab (two spaces) in from
+  their parent.
+
+  # Whitespace
+
+  ## Whitespace that exists
+
+  As in regular HTML, any string of continuous whitespace is considered
+  equivalent to any other string of continuous whitespace. There are four
+  exceptions:
+
+  1. Macro components (with names starting with `#`, such as `<#Markdown>`)
+  2. `<pre>` tags
+  3. `<code>` tags
+  4. `<script>` tags
+
+  The contents of those tags are considered whitespace-sensitive, and developers
+  should sanity check after running the formatter.
+
+  ## Whitespace that doesn't exist (Lack of whitespace)
+
+  As is sometimes the case in HTML, _lack_ of whitespace is considered
+  significant. Instead of attempting to determine which contexts matter, the
+  formatter consistently retains lack of whitespace. This means that the
+  following
+
+  ```html
+  <div><p>Hello</p></div>
+  ```
+
+  will not be changed. However, the following
+
+  ```html
+  <div> <p> Hello </p> </div>
+  ```
+
+  will be formatted as
+
+  ```html
+  <div>
+    <p>
+      Hello
+    </p>
+  </div>
+  ```
+
+  because of the whitespace on either side of each tag.
+
+  To be clear, this example
+
+  ```html
+  <div> <p>Hello</p> </div>
+  ```
+
+  will be formatted as
+
+  ```html
+  <div>
+    <p>Hello</p>
+  </div>
+  ```
+
+  because of the lack of whitespace in between the opening and closing `<p>` tags
+  and their child content.
+
+  ## Splitting children onto separate lines
+
+  In certain scenarios, the formatter will move nodes to their own line:
+
+  (Below, "element" means an HTML element or a Surface component.)
+
+  1. If an element contains other elements as children, it will be surrounded by newlines.
+  2. If there is a space after an opening tag or before a closing tag, it is converted to a newline.
+  3. If a closing tag is put on its own line, the formatter ensures there's a newline before the next sibling node.
+
+  Since SurfaceFormatter doesn't know if a component represents an inline or block element,
+  it does not currently make distinctions between elements that should or should not be
+  moved onto their own lines, other than the above rules.
+
+  This allows inline elements to be placed among text without splitting them onto their own lines:
+
+  ```html
+  The <b>Dialog</b> is a stateless component. All event handlers
+  had to be defined in the parent <b>LiveView</b>.
+  ```
+
+  ## Newline characters
+
+  The formatter will not add extra newlines unprompted beyond moving nodes onto
+  their own line.  However, if the input code has extra newlines, the formatter
+  will retain them but will collapse more than one extra newline into a single
+  one.
+
+  This means that
+
+  ```html
+  <p>Hello</p>
+
+
+
+
+
+  <p>Goodbye</p>
+  ```
+
+  will be formatted as
+
+  ```html
+  <p>Hello</p>
+
+  <p>Goodbye</p>
+  ```
+
+  # HTML attributes and component props
+
+  HTML attributes such as `class` in `<p class="container">` and component
+  props such as `name` in `<Person name="Samantha">` are formatted to make use
+  of Surface features.
+
+  ## Inline literals
+
+  String literals are placed after the `=` without any interpolation brackets (`{ }`). This means that
+
+  ```html
+  <Component foo={"hello"} />
+  ```
+
+  will be formatted as
+
+  ```html
+  <Component foo="hello" />
+  ```
+
+  Also, `true` boolean literals are formatted using the Surface shorthand
+  whereby you can simply write the name of the attribute and it is passed in as
+  `true`. For example,
+
+  ```html
+  <Component secure={true} />
+  ```
+
+  and
+
+  ```html
+  <Component secure=true />
+  ```
+
+  will both be formatted as
+
+  ```html
+  <Component secure />
+  ```
+
+  ## Interpolation (`{ }` brackets)
+
+  Attributes that interpolate Elixir code with `{ }` brackets are ran through
+  the Elixir code formatter.
+
+  This means that:
+
+    - `<Foo num={123456} />` becomes `<Foo num={123_456} />`
+    - `list={[1,2,3]}` becomes `list={[1, 2, 3]}`
+    - `things={%{  one: "1",   two: "2"}}` becomes `things={%{one: "1", two: "2"}}`
+
+  Sometimes the Elixir code formatter will add line breaks in the formatted
+  expression. In that case, SurfaceFormatter will ensure indentation lines up. If
+  there is a single attribute, it will keep the attribute on the same line as the
+  tag name, for example:
+
+  ```html
+  <Component list={[
+    {"foo", foo},
+    {"bar", bar}
+  ]} />
+  ```
+
+  However, if there are multiple attributes it will put them on separate lines:
+
+  ```html
+  <Child
+    list={[
+      {"foo", foo},
+      {"bar", bar}
+    ]}
+    int={123}
+  />
+  ```
+
+  ## Whitespace in string attributes
+
+  ### Code semantics must be maintained
+
+  It's critical that a code formatter never change the semantics of the code
+  it modifies.  In other words, the behavior of a program should never change
+  due to a code formatter.
+
+  The **Whitespace** section above outlines how `SurfaceFormatter` preserves
+  code semantics by refusing to modify contents of `<script>`, `<code>` and
+  `<pre>` tags as well as macro components. And for the same reason, the
+  formatter does not introduce whitespace between HTML tags when there is none.
+
+  ### Code semantics in string attributes
+
+  This principle is also relevant to string attributes, such as:
+
+  ```html
+  <MyComponent string_prop="  string  with  whitespace  " />
+  ```
+
+  `SurfaceFormatter` cannot reliably guess whether application behavior will be
+  changed by formatting the contents of a string. For example, consider a
+  component with the following interface:
+
+  ```html
+  <List items="
+  apples (fuji)
+  oranges (navel)
+  bell peppers (green)
+  " />
+  ```
+
+  The component internally splits on newline characters and outputs the following HTML:
+
+  ```html
+  <ul>
+    <li>apples (fuji)</li>
+    <li>oranges (navel)</li>
+    <li>bell peppers (green)</li>
+  </ul>
+  ```
+
+  If `SurfaceFormatter` assumes it is safe to modify whitespace in string
+  attributes, then the Surface code would likely change to this:
+
+  ```html
+  <List items="apples (fuji) oranges (navel) bell peppers (green)" />
+  ```
+
+  Which would output the following HTML:
+
+  ```html
+  <ul>
+    <li>apples (fuji) oranges (navel) bell peppers (green)</li>
+  </ul>
+  ```
+
+  Notice that the behavior of the application would have changed simply by
+  running the formatter. It is for this reason that `SurfaceFormatter`
+  always retains precisely the same whitespace in attribute strings,
+  including both space and newline characters.
+
+  ## Wrapping attributes on separate lines
+
+  In the **Interpolation (`{ }` brackets)** section we noted that attributes
+  will each be put on their own line if there is more than one attribute and at
+  least one contains a newline after being formatted by the Elixir code
+  formatter.
+
+  There is another scenario where attributes will each be given their own line:
+  **any time the opening tag would exceed `line_length` if put on one line**.
+  This value is provided in `.formatter.exs` and defaults to 98.
+
+  The formatter indents attributes one tab in from the start of the opening tag
+  for readability:
+
+  ```html
+  <div
+    class="very long class value that causes this to exceed the established line length"
+    aria-role="button"
+  >
+  ```
+
+  If you desire to have a separate line length for `mix format` and `mix surface.format`,
+  provide `surface_line_length` in `.formatter.exs` and it will be given precedence
+  when running `mix surface.format`. For example:
+
+  ```elixir
+  # .formatter.exs
+
+  [
+    surface_line_length: 120,
+    import_deps: [...],
+    # ...
+  ]
+  ```
+
+  # Developer Responsibility
+
+  As with all changes (for both `mix format` and `mix surface.format`) it's
+  recommended that developers don't blindly run the formatter on an entire
+  codebase and commit, but instead sanity check each file to ensure the results
+  are desired.
+  """
+  @spec format_string!(String.t(), list(option)) :: String.t()
+  def format_string!(string, opts \\ []) do
+    parsed =
+      string
+      |> String.trim()
+      |> Surface.Compiler.Parser.parse!(translator: Surface.Formatter.NodeTranslator)
+
+    # Ensure the :indent option is set
+    opts = Keyword.put_new(opts, :indent, 0)
+
+    [
+      Phases.TagWhitespace,
+      Phases.Newlines,
+      Phases.SpacesToNewlines,
+      Phases.Indent,
+      Phases.FinalNewline,
+      Phases.BlockExceptions,
+      Phases.Render
+    ]
+    |> Enum.reduce(parsed, fn phase, nodes ->
+      phase.run(nodes, opts)
+    end)
+  end
+
+  @doc """
+  Returns true if the argument is an element (HTML element or surface
+  component), false otherwise.
+  """
+  @spec is_element?(surface_node) :: boolean
+  def is_element?({_, _, _, _}), do: true
+  def is_element?(_), do: false
+
+  @doc """
+  Given a tag, return whether to render the contens verbatim instead of formatting them.
+  Specifically, don't modify contents of macro components or <pre> and <code> tags.
+  """
+  @spec render_contents_verbatim?(tag) :: boolean
+  def render_contents_verbatim?("#template"), do: false
+  def render_contents_verbatim?("#slot"), do: false
+  def render_contents_verbatim?("#" <> _), do: true
+  def render_contents_verbatim?("pre"), do: true
+  def render_contents_verbatim?("code"), do: true
+  def render_contents_verbatim?("script"), do: true
+  def render_contents_verbatim?(tag) when is_binary(tag), do: false
+end

--- a/lib/surface/formatter/node_translator.ex
+++ b/lib/surface/formatter/node_translator.ex
@@ -1,0 +1,164 @@
+defmodule Surface.Formatter.NodeTranslator do
+  @behaviour Surface.Compiler.NodeTranslator
+
+  def handle_init(state), do: state
+
+  def handle_expression(expression, meta, state) do
+    {{:expr, expression, to_meta(meta)}, state}
+  end
+
+  def handle_tagged_expression("^", expression, meta, state) do
+    {{:expr, "^" <> expression, to_meta(meta)}, state}
+  end
+
+  def handle_comment(comment, meta, state) do
+    {{:comment, comment, meta}, state}
+  end
+
+  def handle_node(name, attributes, body, meta, state, _context) do
+    {{name, attributes, body, to_meta(meta)}, state}
+  end
+
+  def handle_block(name, expr, body, meta, state, _context) do
+    {{:block, name, expr, body, to_meta(meta)}, state}
+  end
+
+  def handle_subblock(:default, expr, _children, meta, state, %{parent_block: "case"}) do
+    {{:block, :default, expr, [], to_meta(meta)}, state}
+  end
+
+  def handle_subblock(:default, expr, children, meta, state, _context) do
+    {{:block, :default, expr, children, to_meta(meta)}, state}
+  end
+
+  def handle_subblock(name, expr, children, meta, state, _context) do
+    {{:block, name, expr, children, to_meta(meta)}, state}
+  end
+
+  def handle_text(text, state) do
+    {text, state}
+  end
+
+  # TODO: Update these after accepting the expression directly instead of the :root attribute
+  def handle_block_expression(_block_name, nil, _state, _context) do
+    []
+  end
+
+  def handle_block_expression(_block_name, {:expr, expr, expr_meta}, _state, _context) do
+    meta = to_meta(expr_meta)
+    [{:root, {:attribute_expr, expr, meta}, meta}]
+  end
+
+  def handle_attribute(
+        :root,
+        {:tagged_expr, "...", expr, _marker_meta},
+        attr_meta,
+        _state,
+        context
+      ) do
+    {:expr, value, expr_meta} = expr
+    %{tag_name: tag_name} = context
+
+    directive =
+      case tag_name do
+        <<first, _::binary>> when first in ?A..?Z ->
+          ":props"
+
+        _ ->
+          ":attrs"
+      end
+
+    {directive, {:attribute_expr, value, to_meta(expr_meta)}, to_meta(attr_meta)}
+  end
+
+  def handle_attribute(
+        :root,
+        {:tagged_expr, "=", expr, _marker_meta},
+        attr_meta,
+        _state,
+        context
+      ) do
+    {:expr, value, expr_meta} = expr
+    %{tag_name: tag_name} = context
+
+    original_name = strip_name_from_tagged_expr_equals!(value)
+
+    name =
+      case tag_name do
+        <<first, _::binary>> when first in ?A..?Z ->
+          original_name
+
+        _ ->
+          String.replace(original_name, "_", "-")
+      end
+
+    expr_meta = Map.put(expr_meta, :tagged_expr?, true)
+
+    {name, {:attribute_expr, value, to_meta(expr_meta)}, to_meta(attr_meta)}
+  end
+
+  def handle_attribute(
+        name,
+        {:tagged_expr, "^", {:expr, value, expr_meta}, _marker_meta},
+        attr_meta,
+        _state,
+        _context
+      ) do
+    {name, {:attribute_expr, "^" <> value, to_meta(expr_meta)}, to_meta(attr_meta)}
+  end
+
+  def handle_attribute(name, {:expr, expr, expr_meta}, attr_meta, _state, _context) do
+    {name, {:attribute_expr, expr, to_meta(expr_meta)}, to_meta(attr_meta)}
+  end
+
+  def handle_attribute(name, value, attr_meta, _state, _context) do
+    {name, value, to_meta(attr_meta)}
+  end
+
+  def context_for_node(name, _meta, _state) do
+    %{tag_name: name}
+  end
+
+  def context_for_subblock(name, _meta, _state, parent_context) do
+    %{sub_block: name, parent_block: Map.get(parent_context, :block_name)}
+  end
+
+  def context_for_block(name, _meta, _state) do
+    %{block_name: name}
+  end
+
+  def to_meta(%{void_tag?: true} = meta) do
+    drop_common_keys(meta)
+  end
+
+  def to_meta(meta) do
+    meta
+    |> Map.drop([:void_tag?])
+    |> drop_common_keys()
+  end
+
+  defp drop_common_keys(meta) do
+    Map.drop(meta, [
+      :column,
+      :file,
+      :line,
+      :self_close,
+      :line_end,
+      :column_end,
+      :node_line_end,
+      :node_column_end,
+      :macro?,
+      :ignored_body?
+    ])
+  end
+
+  defp strip_name_from_tagged_expr_equals!(value) do
+    case Code.string_to_quoted(value) do
+      {:ok, {:@, _, [{name, _, _}]}} when is_atom(name) ->
+        to_string(name)
+
+      {:ok, {name, _, _}} when is_atom(name) ->
+        to_string(name)
+    end
+  end
+end

--- a/lib/surface/formatter/phase.ex
+++ b/lib/surface/formatter/phase.ex
@@ -1,0 +1,84 @@
+defmodule Surface.Formatter.Phase do
+  @moduledoc """
+  A phase implementing a single "rule" for formatting code. These work as middleware
+  between `Surface.Compiler.Parser.parse` and `Surface.Formatter.Render.node/2`
+  to modify node lists before they are rendered.
+
+  Some phases rely on other phases; `@moduledoc`s should make this explicit.
+
+  For reference, the formatter operates by running these phases in the following order:
+
+    - `Surface.Formatter.Phases.TagWhitespace`
+    - `Surface.Formatter.Phases.Newlines`
+    - `Surface.Formatter.Phases.SpacesToNewlines`
+    - `Surface.Formatter.Phases.Indent`
+    - `Surface.Formatter.Phases.FinalNewline`
+    - `Surface.Formatter.Phases.BlockExceptions`
+    - `Surface.Formatter.Phases.Render`
+  """
+
+  alias Surface.Formatter
+
+  @doc "The function implementing the phase. Returns the given nodes with the transformation applied."
+  @callback run(nodes :: [Formatter.formatter_node()], opts :: [Formatter.option()]) :: [
+              Formatter.formatter_node()
+            ]
+
+  @typedoc "A node that takes a list of nodes and returns them back after applying a transformation"
+  @type node_transformer :: (nodes -> nodes)
+
+  @typedoc "A list of nodes"
+  @type nodes :: [Formatter.formatter_node()]
+
+  @doc """
+  Given a list of nodes, find all "element" nodes (HTML elements or Surface components)
+  and transform children of those nodes using the given function.
+
+  Useful for recursing deeply through the entire tree of nodes.
+  """
+  @spec transform_element_children(nodes, node_transformer) :: nodes
+  def transform_element_children(nodes, transform) do
+    Enum.map(nodes, fn
+      {tag, attributes, children, meta} ->
+        {tag, attributes, transform.(children), meta}
+
+      {:block, name, expr, children, meta} ->
+        {:block, name, expr, transform.(children), meta}
+
+      node ->
+        node
+    end)
+  end
+
+  @doc """
+  Given a list of nodes, find all "element" nodes (HTML elements or Surface components)
+  and transform children of those nodes using the given function.
+
+  Recurses deeply through the tree, unlike `transform_element_children`, which only affects
+  a single layer.
+  """
+  def transform_elements_and_descendants(nodes, transform) when is_function(transform, 1) do
+    nodes
+    |> Enum.map(fn
+      {tag, attributes, children, meta} ->
+        children =
+          children
+          |> transform_elements_and_descendants(transform)
+          |> transform.()
+
+        {tag, attributes, children, meta}
+
+      {:block, name, expr, children, meta} ->
+        children =
+          children
+          |> transform_elements_and_descendants(transform)
+          |> transform.()
+
+        {:block, name, expr, children, meta}
+
+      node ->
+        node
+    end)
+    |> Enum.map(transform)
+  end
+end

--- a/lib/surface/formatter/phases/block_exceptions.ex
+++ b/lib/surface/formatter/phases/block_exceptions.ex
@@ -1,0 +1,33 @@
+defmodule Surface.Formatter.Phases.BlockExceptions do
+  @moduledoc """
+  Handle exceptional case for blocks.
+  """
+
+  @behaviour Surface.Formatter.Phase
+  alias Surface.Formatter.Phase
+
+  def run(nodes, _opts) do
+    Phase.transform_elements_and_descendants(nodes, &transform_block/1)
+  end
+
+  def transform_block({:block, "case", expr, sub_blocks, %{has_sub_blocks?: true} = meta}) do
+    # "case" is a special case because its sub blocks are indented, unlike `if`
+    # and `for`; therefore, the last `:indent_one_less` needs to be removed from
+    # the last sub-block and moved to the outer block.
+    #
+    # This code is a bit hacky but kept the rest of the architecture simpler.
+    reversed_sub_blocks = Enum.reverse(sub_blocks)
+    [last_sub_block | rest] = reversed_sub_blocks
+    {:block, "match", match_expr, children, last_meta} = last_sub_block
+
+    modified_sub_blocks = [
+      {:block, "match", match_expr, Enum.slice(children, 0..-2), last_meta} | rest
+    ]
+
+    modified_sub_blocks = Enum.reverse(modified_sub_blocks)
+
+    {:block, "case", expr, [:newline, :indent | modified_sub_blocks] ++ [:indent_one_less], meta}
+  end
+
+  def transform_block(node), do: node
+end

--- a/lib/surface/formatter/phases/final_newline.ex
+++ b/lib/surface/formatter/phases/final_newline.ex
@@ -1,0 +1,9 @@
+defmodule Surface.Formatter.Phases.FinalNewline do
+  @moduledoc "Add a newline after all of the nodes"
+
+  @behaviour Surface.Formatter.Phase
+
+  def run(nodes, _opts) do
+    nodes ++ [:newline]
+  end
+end

--- a/lib/surface/formatter/phases/indent.ex
+++ b/lib/surface/formatter/phases/indent.ex
@@ -1,0 +1,55 @@
+defmodule Surface.Formatter.Phases.Indent do
+  @moduledoc """
+  Adds indentation nodes (`:indent` and `:indent_one_less`) where appropriate.
+
+  `Surface.Formatter.Render.node/2` is responsible for adding the appropriate
+  level of indentation. It keeps track of the indentation level based on how
+  "nested" a node is. While running Formatter Phases, it's not necessary to
+  keep track of that detail.
+
+  `:indent_one_less` exists to notate the indentation that should occur before
+  a closing tag, which is one less than its children.
+
+  Relies on `Newlines` phase, which collapses :newline nodes to at most 2 in a row.
+  """
+
+  @behaviour Surface.Formatter.Phase
+  alias Surface.Formatter.Phase
+
+  def run(nodes, _opts) do
+    # Add initial indent on start of first line
+    indent([:indent | nodes])
+  end
+
+  defp indent(nodes) do
+    # Deeply recurse through nodes and add indentation before newlines
+    nodes
+    |> add_indentation()
+    |> Phase.transform_element_children(&indent/1)
+  end
+
+  def add_indentation(nodes, accumulated \\ [])
+
+  def add_indentation([:newline, :newline | rest], accumulated) do
+    # Two newlines in a row; don't add indentation on the empty line
+    add_indentation(rest, accumulated ++ [:newline, :newline, :indent])
+  end
+
+  def add_indentation([:newline], accumulated) do
+    # The last child is a newline; add indentation for closing tag
+    add_indentation([], accumulated ++ [:newline, :indent_one_less])
+  end
+
+  def add_indentation([:newline | rest], accumulated) do
+    # Indent before the next child
+    add_indentation(rest, accumulated ++ [:newline, :indent])
+  end
+
+  def add_indentation([], accumulated) do
+    accumulated
+  end
+
+  def add_indentation([node | rest], accumulated) do
+    add_indentation(rest, accumulated ++ [node])
+  end
+end

--- a/lib/surface/formatter/phases/newlines.ex
+++ b/lib/surface/formatter/phases/newlines.ex
@@ -1,0 +1,48 @@
+defmodule Surface.Formatter.Phases.Newlines do
+  @moduledoc """
+  Standardizes usage of newlines.
+
+  - Prevents more than 1 empty line in a row.
+  - Prevents an empty line separating an opening/closing tag from the contents inside.
+  """
+
+  @behaviour Surface.Formatter.Phase
+  alias Surface.Formatter.Phase
+
+  def run(nodes, _opts) do
+    nodes
+    |> collapse_newlines()
+    |> prevent_empty_line_at_beginning()
+    |> prevent_empty_line_at_end()
+  end
+
+  defp collapse_newlines(nodes) do
+    nodes
+    |> Enum.chunk_by(&(&1 == :newline))
+    |> Enum.map(fn
+      [:newline, :newline | _] -> [:newline, :newline]
+      nodes -> nodes
+    end)
+    |> Enum.flat_map(&Function.identity/1)
+    |> Phase.transform_element_children(&collapse_newlines/1)
+  end
+
+  defp prevent_empty_line_at_beginning(nodes) do
+    nodes
+    |> case do
+      [:newline, :newline | rest] -> [:newline | rest]
+      _ -> nodes
+    end
+    |> Phase.transform_element_children(&prevent_empty_line_at_beginning/1)
+  end
+
+  defp prevent_empty_line_at_end(nodes) do
+    nodes
+    |> Enum.slice(-2..-1)
+    |> case do
+      [:newline, :newline] -> Enum.slice(nodes, 0..-2)
+      _ -> nodes
+    end
+    |> Phase.transform_element_children(&prevent_empty_line_at_end/1)
+  end
+end

--- a/lib/surface/formatter/phases/render.ex
+++ b/lib/surface/formatter/phases/render.ex
@@ -1,0 +1,471 @@
+defmodule Surface.Formatter.Phases.Render do
+  @moduledoc """
+  Render the formatted Surface code after it has run through the other
+  transforming phases.
+  """
+
+  @behaviour Surface.Formatter.Phase
+  alias Surface.Formatter
+
+  def run(nodes, opts) do
+    nodes
+    |> Enum.map(&render_node(&1, opts))
+    |> List.flatten()
+    |> Enum.join()
+  end
+
+  # Use 2 spaces for a tab
+  @tab "  "
+
+  # Line length of opening tags before splitting attributes onto their own line
+  @default_line_length 98
+
+  @doc """
+  Given a `t:Surface.Formatter.formatter_node/0` node, render it to a string
+  for writing back into a file.
+  """
+  @spec render_node(Formatter.formatter_node(), list(Formatter.option())) :: String.t() | nil
+  def render_node(segment, opts)
+
+  def render_node({:expr, expression, _meta}, opts) do
+    case Regex.run(~r/^\s*#(.*)$/, expression) do
+      nil ->
+        formatted =
+          expression
+          |> String.trim()
+          |> Code.format_string!(opts)
+
+        String.replace(
+          "{#{formatted}}",
+          "\n",
+          "\n#{String.duplicate(@tab, opts[:indent])}"
+        )
+
+      [_, comment] ->
+        # expression is a one-line Elixir comment; convert to a "Surface comment"
+        "{!-- #{String.trim(comment)} --}"
+    end
+  end
+
+  def render_node(:indent, opts) do
+    if opts[:indent] >= 0 do
+      String.duplicate(@tab, opts[:indent])
+    else
+      ""
+    end
+  end
+
+  def render_node(:newline, _opts) do
+    # There are multiple newlines in a row; don't add spaces
+    # if there aren't going to be other characters after it
+    "\n"
+  end
+
+  def render_node(:space, _opts) do
+    " "
+  end
+
+  def render_node({:comment, comment, %{visibility: :public}}, _opts) do
+    if String.contains?(comment, "\n") do
+      comment
+    else
+      contents =
+        comment
+        |> String.replace(~r/^<!--/, "")
+        |> String.replace(~r/-->$/, "")
+        |> String.trim()
+
+      "<!-- #{contents} -->"
+    end
+  end
+
+  def render_node({:comment, comment, %{visibility: :private}}, _opts) do
+    if String.contains?(comment, "\n") do
+      comment
+    else
+      contents =
+        comment
+        |> String.replace(~r/^{!--/, "")
+        |> String.replace(~r/--}$/, "")
+        |> String.trim()
+
+      "{!-- #{contents} --}"
+    end
+  end
+
+  def render_node(:indent_one_less, opts) do
+    # Dedent once; this is before a closing tag, so it should be dedented from children
+    render_node(:indent, indent: opts[:indent] - 1)
+  end
+
+  def render_node(html, _opts) when is_binary(html) do
+    html
+  end
+
+  # default block does not get rendered `{#default}`; just children are rendered
+  def render_node({:block, :default, [], children, _meta}, opts) do
+    next_opts = Keyword.update(opts, :indent, 0, &(&1 + 1))
+    Enum.map(children, &render_node(&1, next_opts))
+  end
+
+  def render_node({:block, name, expr, children, _meta}, opts) do
+    main_block_element = name in ["if", "unless", "for", "case"]
+
+    expr =
+      case expr do
+        [attr] ->
+          attr
+          |> render_attribute([])
+          |> case do
+            {:do_not_indent_newlines, string} ->
+              string
+
+            string ->
+              string
+              |> String.slice(1..-2)
+              |> String.trim()
+          end
+
+        [] ->
+          nil
+      end
+
+    opening =
+      "{##{name}#{if expr, do: " "}#{expr}}"
+      |> String.replace("\n", "\n" <> String.duplicate(@tab, opts[:indent] + 1))
+
+    next_indent =
+      case children do
+        [{:block, _, _, _, _} | _] -> 0
+        _ -> 1
+      end
+
+    next_opts = Keyword.update(opts, :indent, 0, &(&1 + next_indent))
+    rendered_children = Enum.map(children, &render_node(&1, next_opts))
+
+    "#{opening}#{rendered_children}#{if main_block_element do
+      "{/#{name}}"
+    end}"
+  end
+
+  def render_node({"#template", [{"slot", slot_name, _} | attributes], children, meta}, opts) do
+    render_node({":#{slot_name}", attributes, children, meta}, opts)
+  end
+
+  def render_node({tag, attributes, [], _meta}, opts) do
+    render_opening_tag(
+      tag,
+      attributes,
+      Keyword.put(opts, :self_closing, true)
+    )
+  end
+
+  def render_node({tag, attributes, children, _meta}, opts) do
+    rendered_children =
+      if Formatter.render_contents_verbatim?(tag) do
+        Enum.map(children, fn
+          html when is_binary(html) ->
+            # Render out string portions of <pre>/<code>/<#MacroComponent> children
+            # verbatim instead of trimming them.
+            html
+
+          child ->
+            render_node(child, indent: 0)
+        end)
+      else
+        next_opts = Keyword.update(opts, :indent, 0, &(&1 + 1))
+
+        Enum.map(children, &render_node(&1, next_opts))
+      end
+
+    "#{render_opening_tag(tag, attributes, opts)}#{rendered_children}</#{tag}>"
+  end
+
+  defp render_opening_tag(tag, [] = _attributes, opts) do
+    if opts[:self_closing] && not is_void_element?(tag) do
+      "<#{tag} />"
+    else
+      "<#{tag}>"
+    end
+  end
+
+  defp render_opening_tag(tag, attributes, opts) do
+    max_line_length = opts[:line_length] || @default_line_length
+    self_closing = Keyword.get(opts, :self_closing, false)
+    indentation = String.duplicate(@tab, opts[:indent])
+
+    rendered_attributes =
+      Enum.map(
+        attributes,
+        &render_attribute(&1, Keyword.put(opts, :attributes, attributes))
+      )
+
+    attribute_strings =
+      Enum.map(rendered_attributes, fn
+        {:do_not_indent_newlines, attr} -> attr
+        attr -> attr
+      end)
+
+    # calculate length of the entire opening tag if fit on a single line
+    total_attr_lengths =
+      attribute_strings
+      |> Enum.map(&String.length/1)
+      |> Enum.sum()
+
+    # consider tag name, space before each attribute, < and > (and ` /` for self-closing tags)
+    length_on_same_line =
+      total_attr_lengths + String.length(tag) + length(attributes) +
+        if self_closing do
+          4
+        else
+          2
+        end
+
+    put_attributes_on_separate_lines =
+      if length(attributes) > 1 do
+        length_on_same_line > max_line_length or
+          Enum.any?(attribute_strings, &String.contains?(&1, "\n"))
+      else
+        false
+      end
+
+    if put_attributes_on_separate_lines do
+      attr_indentation = String.duplicate(@tab, opts[:indent] + 1)
+
+      indented_attributes =
+        Enum.map(rendered_attributes, fn
+          {:do_not_indent_newlines, attr} ->
+            "#{attr_indentation}#{attr}"
+
+          attr ->
+            # This is pretty hacky, but it's an attempt to get things like
+            #   class={
+            #     "foo",
+            #     @bar,
+            #     baz: true
+            #   }
+            # to look right
+            with_newlines_indented = String.replace(attr, "\n", "\n#{attr_indentation}")
+            "#{attr_indentation}#{with_newlines_indented}"
+        end)
+
+      [
+        "<#{tag}",
+        indented_attributes,
+        "#{indentation}#{if self_closing do
+          "/"
+        end}>"
+      ]
+      |> List.flatten()
+      |> Enum.join("\n")
+    else
+      # We're not splitting attributes onto their own newlines,
+      # but it's possible that an attribute has a newline in it
+      # (for interpolated maps/lists) so ensure those lines are indented.
+      # We're rebuilding the tag from scratch so we can respect
+      # :do_not_indent_newlines attributes.
+      attr_indentation = String.duplicate(@tab, opts[:indent])
+
+      attributes =
+        case rendered_attributes do
+          [] ->
+            ""
+
+          _ ->
+            joined_attributes =
+              rendered_attributes
+              |> Enum.map(fn
+                {:do_not_indent_newlines, attr} -> attr
+                attr -> String.replace(attr, "\n", "\n#{attr_indentation}")
+              end)
+              |> Enum.join(" ")
+
+            # Prefix attributes string with a space (for after tag name)
+            " " <> joined_attributes
+        end
+
+      "<#{tag}#{attributes}#{if self_closing and not is_void_element?(tag) do
+        " /"
+      end}>"
+    end
+  end
+
+  @type render_attribute_option :: {:attributes, [Surface.Formatter.attribute()]}
+
+  @spec render_attribute({String.t(), term, map}, [render_attribute_option]) ::
+          String.t() | {:do_not_indent_newlines, String.t()}
+  defp render_attribute({name, value, _meta}, _opts) when is_binary(value) do
+    # This is a string, and it might contain newlines. By returning
+    # `{:do_not_indent_newlines, formatted}` we instruct `render_node/1`
+    # to leave newlines alone instead of adding extra tabs at the
+    # beginning of the line.
+    #
+    # Before this behavior, the extra lines in the `bar` attribute below
+    # would be further indented each time the formatter was run.
+    #
+    # <Component foo=false bar="a
+    #   b
+    #   c"
+    # />
+    rendered =
+      if name == :root do
+        inspect(value)
+      else
+        "#{name}=\"#{String.trim(value)}\""
+      end
+
+    {:do_not_indent_newlines, rendered}
+  end
+
+  # For `true` boolean attributes, simply including the name of the attribute
+  # without `=true` is shorthand for `=true`.
+  defp render_attribute({":" <> _ = name, true, _meta}, _opts),
+    do: "#{name}={true}"
+
+  defp render_attribute({name, true, _meta}, _opts),
+    do: "#{name}"
+
+  defp render_attribute({name, false, _meta}, _opts),
+    do: "#{name}={false}"
+
+  defp render_attribute({name, value, _meta}, _opts) when is_integer(value),
+    do: "#{name}={#{Code.format_string!("#{value}")}}"
+
+  defp render_attribute({_name, {:attribute_expr, expression, %{tagged_expr?: true}}, _}, _opts) do
+    "{=#{expression}}"
+  end
+
+  defp render_attribute({name, {:attribute_expr, expression, _expr_meta}, _meta}, opts)
+       when name in [":attrs", ":props"] do
+    "{...#{format_attribute_expression(expression, opts)}}"
+  end
+
+  defp render_attribute({:root, {:attribute_expr, expression, _expr_meta}, _meta}, opts) do
+    case format_attribute_expression(expression, opts) do
+      "... " <> expression ->
+        "{...#{expression}}"
+
+      formatted ->
+        "{#{formatted}}"
+    end
+  end
+
+  defp render_attribute({name, {:attribute_expr, expression, _expr_meta}, meta}, opts) do
+    case quoted_wrapped_expression(expression) do
+      [literal] when is_boolean(literal) or is_binary(literal) ->
+        # The expression is a literal value in Surface brackets, e.g. {"foo"} or {true},
+        # that can exclude the brackets, so render it without the brackets
+        render_attribute({name, literal, meta}, opts)
+
+      _ ->
+        "#{name}={#{format_attribute_expression(expression, opts)}}"
+    end
+  end
+
+  @spec quoted_strings_with_newlines(Macro.t() | String.t()) :: [String.t()]
+  # given an attribute expression, return a list of strings that have newlines in them
+  defp quoted_strings_with_newlines(attribute_expression) when is_binary(attribute_expression) do
+    attribute_expression
+    |> quoted_wrapped_expression()
+    |> quoted_strings_with_newlines()
+  end
+
+  defp quoted_strings_with_newlines(nodes) when is_list(nodes) do
+    Enum.flat_map(nodes, fn
+      string when is_binary(string) ->
+        if String.contains?(string, "\n") do
+          [string]
+        else
+          []
+        end
+
+      {:<<>>, _, nodes} when is_list(nodes) ->
+        quoted_strings_with_newlines(nodes)
+
+      _ ->
+        []
+    end)
+    |> List.flatten()
+  end
+
+  defp is_keyword_item_with_interpolated_key?(item) do
+    case item do
+      {{{:., _, [:erlang, :binary_to_atom]}, _, [_, :utf8]}, _} -> true
+      _ -> false
+    end
+  end
+
+  defp is_void_element?(tag) do
+    tag in ~w(area base br col command embed hr img input keygen link meta param source track wbr)
+  end
+
+  defp quoted_wrapped_expression(expression) when is_binary(expression) do
+    # Wrap it in square brackets (and then remove after formatting) to support
+    # Surface sugar like this: `{foo: "bar"}` (equivalent to `{[foo: "bar"]}}`
+    Code.string_to_quoted!("[#{expression}]")
+  rescue
+    _exception ->
+      # With some expressions such as function calls without parentheses
+      # (e.g. `Enum.map @items, & &1.foo`) wrapping in square brackets will
+      # emit invalid syntax, so we must catch that here
+      Code.string_to_quoted!(expression)
+  end
+
+  @spec format_attribute_expression(String.t(), [render_attribute_option]) :: String.t()
+  defp format_attribute_expression(expression, opts) when is_binary(expression) do
+    if has_invisible_brackets?(expression) do
+      # handle keyword lists, which will be stripped of the outer brackets per surface syntax sugar
+      formatted =
+        "[#{expression}]"
+        |> Code.format_string!(locals_without_parens: [...: 1])
+        |> Enum.slice(1..-2)
+        |> to_string()
+
+      if length(Keyword.get(opts, :attributes, [])) > 1 do
+        # handle scenario where list contains string(s) with newlines;
+        # in order to ensure the formatter is idempotent (always emits
+        # the same output when run more than once), we dedent newlines
+        # in strings because multi-line attributes are later indented
+        expression
+        |> quoted_strings_with_newlines()
+        |> Enum.uniq()
+        |> Enum.reduce(formatted, fn string_with_newlines, formatted ->
+          dedented =
+            String.replace(
+              string_with_newlines,
+              "\n#{String.duplicate(@tab, opts[:indent] + 1)}",
+              "\n"
+            )
+
+          String.replace(formatted, string_with_newlines, dedented)
+        end)
+      else
+        formatted
+      end
+    else
+      expression
+      |> Code.format_string!(locals_without_parens: [...: 1])
+      |> to_string()
+    end
+  end
+
+  @spec has_invisible_brackets?(Macro.t() | String.t()) :: boolean
+  defp has_invisible_brackets?(expression) when is_binary(expression) do
+    expression
+    |> quoted_wrapped_expression()
+    |> has_invisible_brackets?()
+  end
+
+  defp has_invisible_brackets?(quoted_wrapped_expression) do
+    # This is a somewhat hacky way of checking if the contents are something like:
+    #
+    #   foo={"bar", @baz, :qux}
+    #   foo={"bar", baz: true}
+    #
+    # which is valid Surface syntax; an outer list wrapping the entire expression is implied.
+    Keyword.keyword?(quoted_wrapped_expression) or
+      (is_list(quoted_wrapped_expression) and length(quoted_wrapped_expression) > 1) or
+      (is_list(quoted_wrapped_expression) and
+         Enum.any?(quoted_wrapped_expression, &is_keyword_item_with_interpolated_key?/1))
+  end
+end

--- a/lib/surface/formatter/phases/spaces_to_newlines.ex
+++ b/lib/surface/formatter/phases/spaces_to_newlines.ex
@@ -1,0 +1,137 @@
+defmodule Surface.Formatter.Phases.SpacesToNewlines do
+  @moduledoc """
+  In a variety of scenarios, converts :space nodes to :newline nodes.
+
+  (Below, "element" means an HTML element or a Surface component.)
+
+  1. If an element contains other elements as children, surround it with newlines.
+  1. If there is a space after an opening tag or before a closing tag, convert it to a newline.
+  1. If there is a closing tag on its own line, ensure there's a newline before the next sibling node.
+  """
+
+  @behaviour Surface.Formatter.Phase
+  alias Surface.{Formatter, Formatter.Phase}
+
+  def run(nodes, _opts) do
+    nodes
+    |> ensure_newlines_surrounding_elements_with_element_children()
+    |> convert_spaces_to_newlines_around_edge_children()
+    |> move_siblings_after_lone_closing_tag_to_new_line()
+  end
+
+  # If an element has an element as a child, ensure it's surrounded by newlines, not spaces
+  defp ensure_newlines_surrounding_elements_with_element_children(nodes, accumulated \\ [])
+
+  defp ensure_newlines_surrounding_elements_with_element_children(
+         [:space, {_, _, children, _} = element, :space | rest],
+         accumulated
+       ) do
+    whitespace =
+      if Enum.any?(children, &Formatter.is_element?/1) do
+        :newline
+      else
+        :space
+      end
+
+    ensure_newlines_surrounding_elements_with_element_children(
+      rest,
+      accumulated ++ [whitespace, element, whitespace]
+    )
+  end
+
+  defp ensure_newlines_surrounding_elements_with_element_children(
+         [{_, _, children, _} = element, :space | rest],
+         accumulated
+       ) do
+    whitespace =
+      if Enum.any?(children, &Formatter.is_element?/1) do
+        :newline
+      else
+        :space
+      end
+
+    ensure_newlines_surrounding_elements_with_element_children(
+      rest,
+      accumulated ++ [element, whitespace]
+    )
+  end
+
+  defp ensure_newlines_surrounding_elements_with_element_children([node | rest], accumulated) do
+    ensure_newlines_surrounding_elements_with_element_children(rest, accumulated ++ [node])
+  end
+
+  defp ensure_newlines_surrounding_elements_with_element_children([], accumulated) do
+    Phase.transform_element_children(
+      accumulated,
+      &ensure_newlines_surrounding_elements_with_element_children/1
+    )
+  end
+
+  # If there is a space before the first child / after the last, convert it to a newline
+  defp convert_spaces_to_newlines_around_edge_children(nodes) do
+    # If there is a space before the first child, and it's an element, convert it to a newline
+    nodes =
+      case nodes do
+        [:space, element | rest] ->
+          [:newline, element | rest]
+
+        _ ->
+          nodes
+      end
+
+    # If there is a space before the first child, and it's an element, convert it to a newline
+    nodes =
+      case Enum.reverse(nodes) do
+        [:space, _element | _rest] ->
+          Enum.slice(nodes, 0..-2) ++ [:newline]
+
+        _ ->
+          nodes
+      end
+
+    nodes
+    |> Phase.transform_element_children(&convert_spaces_to_newlines_around_edge_children/1)
+  end
+
+  # Basically makes sure that this
+  #
+  # <p>
+  #   Foo
+  # </p> <p>Hello</p>
+  #
+  # turns into this
+  #
+  # <p>
+  #   Foo
+  # </p>
+  # <p>Hello</p>
+  defp move_siblings_after_lone_closing_tag_to_new_line(nodes, accumulated \\ [])
+
+  defp move_siblings_after_lone_closing_tag_to_new_line(
+         [{_, _, children, _} = element, :space | rest],
+         accumulated
+       ) do
+    if Enum.any?(children, &(&1 == :newline)) do
+      move_siblings_after_lone_closing_tag_to_new_line(
+        rest,
+        accumulated ++ [element, :newline]
+      )
+    else
+      move_siblings_after_lone_closing_tag_to_new_line(
+        rest,
+        accumulated ++ [element, :space]
+      )
+    end
+  end
+
+  defp move_siblings_after_lone_closing_tag_to_new_line([node | rest], accumulated) do
+    move_siblings_after_lone_closing_tag_to_new_line(rest, accumulated ++ [node])
+  end
+
+  defp move_siblings_after_lone_closing_tag_to_new_line([], accumulated) do
+    Phase.transform_element_children(
+      accumulated,
+      &move_siblings_after_lone_closing_tag_to_new_line/1
+    )
+  end
+end

--- a/lib/surface/formatter/phases/tag_whitespace.ex
+++ b/lib/surface/formatter/phases/tag_whitespace.ex
@@ -1,0 +1,109 @@
+defmodule Surface.Formatter.Phases.TagWhitespace do
+  @moduledoc """
+  Inspects all text nodes and "tags" leading and trailing whitespace
+  by converting it into a `:space` atom or a list of `:newline` atoms.
+
+  This is the first phase of formatting, and all other phases depend on it.
+  """
+
+  @behaviour Surface.Formatter.Phase
+  alias Surface.Formatter
+
+  def run(nodes, _opts) do
+    Enum.flat_map(nodes, &tag_whitespace/1)
+  end
+
+  @doc """
+  This function takes a node provided by `Surface.Compiler.Parser.parse`
+  and converts the leading/trailing whitespace into `t:Surface.Formatter.whitespace/0` nodes.
+  """
+  @spec tag_whitespace(Formatter.surface_node()) :: [
+          Formatter.surface_node() | :newline | :space
+        ]
+  def tag_whitespace(text) when is_binary(text) do
+    # This is a string/text node; analyze and tag the leading and trailing whitespace
+
+    if String.trim(text) == "" do
+      # This is a whitespace-only node; tag the whitespace
+      tag_whitespace_string(text)
+    else
+      # This text contains more than whitespace; analyze and tag the leading
+      # and trailing whitespace separately.
+      leading_whitespace =
+        ~r/^\s+/
+        |> single_match!(text)
+        |> tag_whitespace_string()
+
+      trailing_whitespace =
+        ~r/\s+$/
+        |> single_match!(text)
+        |> tag_whitespace_string()
+
+      # Get each line of the text node, with whitespace trimmed so we can fix indentation
+      lines =
+        text
+        |> String.trim()
+        |> String.split("\n")
+        |> Enum.map(&String.trim/1)
+        |> Enum.intersperse(:newline)
+        |> Enum.reject(&(&1 == ""))
+
+      leading_whitespace ++ lines ++ trailing_whitespace
+    end
+  end
+
+  def tag_whitespace({tag, attributes, children, meta}) do
+    # This is an HTML element or Surface component
+
+    children =
+      if Formatter.render_contents_verbatim?(tag) do
+        # Don't tag the contents of this element; it's in a protected class
+        # of elements in which the contents are not supposed to be touched
+        # (such as <pre>).
+        #
+        # Note that since we're not tagging the whitespace (i.e. converting
+        # sections of the string to :newline and :space atoms), this means
+        # we can adjust the whitespace tags later and we're guaranteed not
+        # to accidentally modify the contents of these "render verbatim" tags.
+        children
+      else
+        # Recurse into tag_whitespace for all of the children of this element/component
+        # so that they get their whitespace tagged as well
+        run(children, [])
+      end
+
+    [{tag, attributes, children, meta}]
+  end
+
+  def tag_whitespace({:block, name, expr, body, meta}) when is_list(body) do
+    [{:block, name, expr, run(body, []), meta}]
+  end
+
+  def tag_whitespace({:expr, _, _} = interpolation), do: [interpolation]
+  def tag_whitespace({:comment, _, _} = comment), do: [comment]
+
+  # Tag a string that only has whitespace, returning [:space] or a list of `:newline`
+  @spec tag_whitespace_string(String.t() | nil) :: list(:space | :newline)
+  defp tag_whitespace_string(nil), do: []
+
+  defp tag_whitespace_string(text) when is_binary(text) do
+    # This span of text is _only_ whitespace
+    newlines =
+      text
+      |> String.graphemes()
+      |> Enum.count(&(&1 == "\n"))
+
+    if newlines > 0 do
+      List.duplicate(:newline, newlines)
+    else
+      [:space]
+    end
+  end
+
+  defp single_match!(regex, string) do
+    case Regex.run(regex, string) do
+      [match] -> match
+      nil -> nil
+    end
+  end
+end

--- a/lib/surface/formatter/plugin.ex
+++ b/lib/surface/formatter/plugin.ex
@@ -56,7 +56,8 @@ defmodule Surface.Formatter.Plugin do
   end
 
   def format(contents, opts) do
-    opts = Keyword.put(opts, :line_length, opts[:surface_line_length] || opts[:line_length])
+    line_length = opts[:surface_line_length] || opts[:line_length]
+    opts = if line_length, do: Keyword.put(opts, :line_length, line_length), else: opts
     Surface.Formatter.format_string!(contents, opts)
   end
 end

--- a/lib/surface/formatter/plugin.ex
+++ b/lib/surface/formatter/plugin.ex
@@ -1,0 +1,62 @@
+defmodule Surface.Formatter.Plugin do
+  @moduledoc """
+  An [Elixir formatter
+  plugin](https://hexdocs.pm/mix/1.13.0-rc.1/Mix.Tasks.Format.html#module-plugins)
+  for Surface code.
+
+  Elixir 1.13 introduced formatter plugins, allowing the Surface formatter to
+  run during `mix format` instead of requiring developers to run `mix
+  surface.format` separately.
+
+  To format Surface code using Elixir 1.12 or earlier, use `mix
+  surface.format`.
+
+  ### `.formatter.exs` setup
+
+  Add to `:plugins` in `.formatter.exs` in order to format `~F` sigils and
+  `.sface` files when running `mix format`.
+
+  Only works on files matching patterns in `:inputs`, so add patterns for
+  all Surface files to ensure they're formatted.
+
+      # in .formatter.exs
+      [
+        ...,
+        plugins: [Surface.Formatter.Plugin]
+
+        # add patterns matching all .sface files and all .ex files with ~F sigils
+        inputs: ["*.{ex,exs}", "{config,lib,test}/**/*.{ex,exs,sface}"],
+
+        # THE FOLLOWING ARE OPTIONAL:
+
+        # set desired line length for both Elixir's code formatter and this one
+        # (only affects opening tags in Surface)
+        line_length: 80,
+
+        # or, set line length only for Surface code (overrides `line_length`)
+        surface_line_length: 84
+      ]
+
+  ### Options
+
+  In `.formatter.exs`, the following options can be provided:
+
+  - `:line_length` - Maximum line length of an opening tag before
+    SurfaceFormatter attempts to wrap it onto multiple lines. This option is
+    used by `Code.format_string!/2` and `mix format` and defaults to 98.
+  - `:surface_line_length` - Overrides `:line_length`; useful for setting
+    separate desired line length for Surface code and non-Surface Elixir code.
+
+  """
+
+  @behaviour Mix.Tasks.Format
+
+  def features(_opts) do
+    [sigils: [:F], extensions: [".sface"]]
+  end
+
+  def format(contents, opts) do
+    opts = Keyword.put(opts, :line_length, opts[:surface_line_length] || opts[:line_length])
+    Surface.Formatter.format_string!(contents, opts)
+  end
+end

--- a/lib/surface/live_view_test.ex
+++ b/lib/surface/live_view_test.ex
@@ -167,7 +167,7 @@ defmodule Surface.LiveViewTest do
   @doc false
   def generate_live_view_ast(render_code, props, env) do
     {func, _} = env.function
-    module = Module.concat([env.module, "(#{func}) at line #{env.line}"])
+    module = Module.concat([env.module, String.replace("(#{func}) at line #{env.line}", "/", "_")])
 
     props_ast =
       for {name, _} <- props do

--- a/test/mix/tasks/surface/surface.format_test.exs
+++ b/test/mix/tasks/surface/surface.format_test.exs
@@ -1,0 +1,85 @@
+defmodule Surface.Mix.Tasks.FormatTest do
+  use ExUnit.Case
+
+  import ExUnit.CaptureIO
+
+  describe "reads from stdin and prints to stdout with formatter" do
+    test "handles an Elixir file" do
+      file = """
+      defmodule Card do
+        use Surface.Component
+
+        def render(assigns) do
+          ~F\"\"\"
+          <div>
+          <ul>
+          <li>
+          <a>
+          Hello
+          </a>
+          </li>
+          </ul>
+          </div>
+          \"\"\"
+        end
+      end
+      """
+
+      formatted = """
+      defmodule Card do
+        use Surface.Component
+
+        def render(assigns) do
+          ~F\"\"\"
+          <div>
+            <ul>
+              <li>
+                <a>
+                  Hello
+                </a>
+              </li>
+            </ul>
+          </div>
+          \"\"\"
+        end
+      end
+      """
+
+      assert formatted ==
+               capture_io(file, fn ->
+                 Mix.Tasks.Surface.Format.run(["-"])
+               end)
+    end
+
+    test "handles a Surface file" do
+      file = """
+      <div>
+      <ul>
+      <li>
+      <a>
+      Hello
+      </a>
+      </li>
+      </ul>
+      </div>
+      """
+
+      formatted = """
+      <div>
+        <ul>
+          <li>
+            <a>
+              Hello
+            </a>
+          </li>
+        </ul>
+      </div>
+      """
+
+      assert formatted ==
+               capture_io(file, fn ->
+                 Mix.Tasks.Surface.Format.run(["-"])
+               end)
+    end
+  end
+end

--- a/test/mix/tasks/surface/util/patches_test.exs
+++ b/test/mix/tasks/surface/util/patches_test.exs
@@ -494,6 +494,65 @@ defmodule Mix.Tasks.Surface.Init.PatchesTest do
     end
   end
 
+  describe "add_formatter_plugin_to_formatter_config" do
+    test "add `plugins: [Surface.Formatter.Plugin]` if :plugins don't exist" do
+      code = """
+      [
+        import_deps: [:phoenix, :ecto, :surface]
+      ]
+      """
+
+      {:patched, updated_code} = Patcher.patch_code(code, Patches.add_formatter_plugin_to_formatter_config())
+
+      assert updated_code == """
+             [
+               import_deps: [:phoenix, :ecto, :surface],
+               plugins: [Surface.Formatter.Plugin]
+             ]
+             """
+    end
+
+    test "add Surface.Formatter.Plugin to :plugins if :plugins already exists" do
+      code = """
+      [
+        import_deps: [:phoenix, :ecto, :surface],
+        plugins: [WhateverPlugin]
+      ]
+      """
+
+      {:patched, updated_code} = Patcher.patch_code(code, Patches.add_formatter_plugin_to_formatter_config())
+
+      assert updated_code == """
+             [
+               import_deps: [:phoenix, :ecto, :surface],
+               plugins: [WhateverPlugin, Surface.Formatter.Plugin]
+             ]
+             """
+    end
+
+    test "don't apply it if already patched" do
+      code = """
+      [
+        import_deps: [:phoenix, :ecto, :surface],
+        plugins: [Surface.Formatter.Plugin]
+      ]
+      """
+
+      assert {:already_patched, ^code} =
+               Patcher.patch_code(code, Patches.add_formatter_plugin_to_formatter_config())
+
+      code = """
+      [
+        import_deps: [:phoenix, :ecto, :surface],
+        plugins: [WhateverPlugin, Surface.Formatter.Plugin]
+      ]
+      """
+
+      assert {:already_patched, ^code} =
+               Patcher.patch_code(code, Patches.add_formatter_plugin_to_formatter_config())
+    end
+  end
+
   describe "add_surface_to_reloadable_compilers_in_endpoint_config" do
     defmodule Elixir.MyTestAppWeb.Endpoint do
       def config(:reloadable_compilers) do

--- a/test/surface/formatter/plugin_test.exs
+++ b/test/surface/formatter/plugin_test.exs
@@ -65,6 +65,7 @@ defmodule Surface.Formatter.PluginTest do
   test ":surface_line_length overrides :line_length" do
     assert_formatter_output(
       "surface_line_length.ex",
+      [line_length: 200, surface_line_length: 50],
       """
       defmodule Foo do
         def render(assigns) do
@@ -88,6 +89,20 @@ defmodule Surface.Formatter.PluginTest do
           \"\"\"
         end
       end
+      """
+    )
+  end
+
+  test "omitting :line_length and :surface_line_length defaults to default line_length" do
+    # reproducing a bug that occurred when both were omitted, with an Elixir expression
+    assert_formatter_output(
+      "config.sface",
+      [],
+      """
+        {@foo}
+      """,
+      """
+      {@foo}
       """
     )
   end

--- a/test/surface/formatter/plugin_test.exs
+++ b/test/surface/formatter/plugin_test.exs
@@ -1,0 +1,94 @@
+defmodule Surface.Formatter.PluginTest do
+  use ExUnit.Case
+  @moduletag :plugin
+
+  # Write a unique file and .formatter.exs for a test, run `mix format` on the
+  # file, and assert whether the input matches the expected output
+  defp assert_formatter_output(filename, dot_formatter_opts \\ [], input_ex, expected) do
+    ex_path = Path.join(System.tmp_dir(), filename)
+    dot_formatter_path = ex_path <> ".formatter.exs"
+    dot_formatter_opts = Keyword.put(dot_formatter_opts, :plugins, [Surface.Formatter.Plugin])
+
+    on_exit(fn ->
+      File.rm(ex_path)
+      File.rm(dot_formatter_path)
+    end)
+
+    File.write!(ex_path, input_ex)
+    File.write!(dot_formatter_path, inspect(dot_formatter_opts))
+
+    Mix.Tasks.Format.run([ex_path, "--dot-formatter", dot_formatter_path])
+
+    assert File.read!(ex_path) == expected
+  end
+
+  test ".sface files are formatted" do
+    assert_formatter_output(
+      "sface_files.sface",
+      """
+      <div>
+        </div>
+      """,
+      """
+      <div>
+      </div>
+      """
+    )
+  end
+
+  test "~F sigils are formatted" do
+    assert_formatter_output(
+      "f_sigils.ex",
+      """
+      defmodule Foo do
+        def bar do
+          ~F\"""
+            <div>
+              </div>
+          \"\"\"
+        end
+      end
+      """,
+      """
+      defmodule Foo do
+        def bar do
+          ~F\"""
+          <div>
+          </div>
+          \"\"\"
+        end
+      end
+      """
+    )
+  end
+
+  test ":surface_line_length overrides :line_length" do
+    assert_formatter_output(
+      "surface_line_length.ex",
+      """
+      defmodule Foo do
+        def render(assigns) do
+          ~F\"""
+          <Component a="12345678901234567890" b="12345678901234567890" c="12345678901234567890" d="12345678901234567890" e="12345678901234567890" />
+          \"\"\"
+        end
+      end
+      """,
+      """
+      defmodule Foo do
+        def render(assigns) do
+          ~F\"""
+          <Component
+            a="12345678901234567890"
+            b="12345678901234567890"
+            c="12345678901234567890"
+            d="12345678901234567890"
+            e="12345678901234567890"
+          />
+          \"\"\"
+        end
+      end
+      """
+    )
+  end
+end

--- a/test/surface/formatter_test.exs
+++ b/test/surface/formatter_test.exs
@@ -4,7 +4,7 @@ defmodule Surface.FormatterTest do
   alias Surface.Formatter
 
   def assert_formatter_outputs(input_code, expected_formatted_result, opts \\ []) do
-    assert expected_formatted_result == Formatter.format_string!(input_code, opts)
+    assert Formatter.format_string!(input_code, opts) == expected_formatted_result
 
     # demonstrate that the output can be parsed by the Surface parser
     Surface.Compiler.Parser.parse!(expected_formatted_result)
@@ -1605,5 +1605,32 @@ defmodule Surface.FormatterTest do
       bar: @bar == "yes"
     } />
     """)
+  end
+
+  test "newlines without trailing whitespace in formatted attribute expressions" do
+    # This demonstrates a bugfix where the empty newline in between case clauses
+    # would be indented with spaces even though there were no contents on the line.
+    assert_formatter_outputs(
+      ~S"""
+      <Component bool_prop attribute={case @foo do
+        "bar" ->
+          true
+        "baz" ->
+          false
+      end} />
+      """,
+      ~S"""
+      <Component
+        bool_prop
+        attribute={case @foo do
+          "bar" ->
+            true
+
+          "baz" ->
+            false
+        end}
+      />
+      """
+    )
   end
 end

--- a/test/surface/formatter_test.exs
+++ b/test/surface/formatter_test.exs
@@ -1,0 +1,1609 @@
+defmodule Surface.FormatterTest do
+  use ExUnit.Case
+
+  alias Surface.Formatter
+
+  def assert_formatter_outputs(input_code, expected_formatted_result, opts \\ []) do
+    assert expected_formatted_result == Formatter.format_string!(input_code, opts)
+
+    # demonstrate that the output can be parsed by the Surface parser
+    Surface.Compiler.Parser.parse!(expected_formatted_result)
+  end
+
+  def assert_formatter_doesnt_change(code, opts \\ []) do
+    assert_formatter_outputs(code, code, opts)
+  end
+
+  describe "[whitespace]" do
+    test "children are indented 1 from parents" do
+      assert_formatter_outputs(
+        """
+        <div>
+        <ul>
+        <li>
+        <a>
+        Hello
+        </a>
+        </li>
+        </ul>
+        </div>
+        """,
+        """
+        <div>
+          <ul>
+            <li>
+              <a>
+                Hello
+              </a>
+            </li>
+          </ul>
+        </div>
+        """
+      )
+    end
+
+    test "Contents of macro components are preserved" do
+      assert_formatter_doesnt_change("""
+      <#MacroComponent>
+      * One
+      * Two
+      ** Three
+      *** Four
+              **** Five
+        -- Once I caught a fish alive
+      </#MacroComponent>
+      """)
+
+      assert_formatter_doesnt_change("""
+      <#MacroComponent>
+       * One
+       * Two
+       ** Three
+       *** Four
+               **** Five
+         -- Once I caught a fish alive
+      </#MacroComponent>
+      """)
+    end
+
+    test "lack of whitespace is preserved" do
+      assert_formatter_outputs(
+        """
+        <div>
+        <dt>{ @tldr }/{ @question }</dt>
+        <dd><#slot /></dd>
+        </div>
+        """,
+        """
+        <div>
+          <dt>{@tldr}/{@question}</dt>
+          <dd><#slot /></dd>
+        </div>
+        """
+      )
+    end
+
+    test "generator attributes are formatted successfully" do
+      assert_formatter_doesnt_change("""
+      <div :for={item <- @items, item.state == :valid}>
+      </div>
+      """)
+    end
+
+    test "attributes wrap after 98 characters by default" do
+      assert_formatter_doesnt_change("""
+      <Component foo="..........." bar="..............." baz="............" qux="..................." />
+      """)
+
+      assert_formatter_outputs(
+        """
+        <Component foo="..........." bar="..............." baz="............" qux="...................." />
+        """,
+        """
+        <Component
+          foo="..........."
+          bar="..............."
+          baz="............"
+          qux="...................."
+        />
+        """
+      )
+    end
+
+    test "attribute wrapping can be configured by :line_length in opts" do
+      assert_formatter_outputs(
+        """
+        <Foo bar="bar" baz="baz"/>
+        """,
+        """
+        <Foo
+          bar="bar"
+          baz="baz"
+        />
+        """,
+        line_length: 20
+      )
+    end
+
+    test "a single attribute always begins on the same line as the opening tag" do
+      # Wrap in another element to help test whether indentation is working properly
+
+      assert_formatter_outputs(
+        """
+        <p>
+        <Foo bio={%{age: 23, name: "John Jacob Jingleheimerschmidt", title: "Lead rockstar 10x ninja brogrammer", reports_to: "James Jacob Jingleheimerschmidt"}}/>
+        </p>
+        """,
+        """
+        <p>
+          <Foo bio={%{
+            age: 23,
+            name: "John Jacob Jingleheimerschmidt",
+            title: "Lead rockstar 10x ninja brogrammer",
+            reports_to: "James Jacob Jingleheimerschmidt"
+          }} />
+        </p>
+        """
+      )
+
+      assert_formatter_outputs(
+        """
+        <p>
+          <Foo urls={["https://hexdocs.pm/elixir/DateTime.html#content", "https://hexdocs.pm/elixir/Exception.html#content"]}/>
+        </p>
+        """,
+        """
+        <p>
+          <Foo urls={[
+            "https://hexdocs.pm/elixir/DateTime.html#content",
+            "https://hexdocs.pm/elixir/Exception.html#content"
+          ]} />
+        </p>
+        """
+      )
+
+      assert_formatter_outputs(
+        """
+        <p>
+        <Foo bar={baz: "BAZ", qux: "QUX", long: "LONG", longer: "LONGER", longest: "LONGEST", wrapping: "WRAPPING", next_line: "NEXT_LINE"} />
+        </p>
+        """,
+        """
+        <p>
+          <Foo bar={
+            baz: "BAZ",
+            qux: "QUX",
+            long: "LONG",
+            longer: "LONGER",
+            longest: "LONGEST",
+            wrapping: "WRAPPING",
+            next_line: "NEXT_LINE"
+          } />
+        </p>
+        """
+      )
+
+      assert_formatter_outputs(
+        """
+        <p>
+        <Foo bar="A really really really really really really long string that makes this line longer than the default 98 characters"/>
+        </p>
+        """,
+        """
+        <p>
+          <Foo bar="A really really really really really really long string that makes this line longer than the default 98 characters" />
+        </p>
+        """
+      )
+    end
+
+    test "(bugfix) a trailing expression does not get an extra newline added" do
+      assert_formatter_doesnt_change("""
+      <p>Foo</p><p>Bar</p>{baz}
+      """)
+    end
+
+    test "Contents of <pre> and <code> tags aren't formatted" do
+      # Note that the output looks pretty messy, but it's because
+      # we're retaining 100% of the exact characters between the
+      # <pre> and </pre> tags, etc.
+      assert_formatter_outputs(
+        """
+        <p>
+        <pre>
+            Four
+         One
+                 Nine
+        </pre> </p> <div> <code>Some code
+        goes    here   </code> </div>
+        """,
+        """
+        <p>
+          <pre>
+            Four
+         One
+                 Nine
+        </pre>
+        </p>
+        <div>
+          <code>Some code
+        goes    here   </code>
+        </div>
+        """
+      )
+    end
+
+    test "<pre>, <code>, <script>, and <#MacroComponent> tags can contain expressions or components, but the string portions are untouched" do
+      # Note that the output looks pretty messy, but it's because
+      # we're retaining 100% of the exact characters between the
+      # <pre> and </pre> tags, etc.
+      #
+      # Also, note that the _opening_ tags are consistently at the same
+      # indentation level because those tags are not inside a context
+      # in which we render children verbatim. (In other words, there's
+      # no risk of changing browser behavior.)
+      assert_formatter_outputs(
+        """
+        <pre>
+        {   @data   }
+              <Component />
+        </pre>
+            <code>
+          { @data }
+          <Component />
+            </code>
+
+
+              <#MacroComponent> Foo {@bar} baz </#MacroComponent>
+
+        <script type="application/javascript">
+             foo();
+           var bar="baz";
+        </script>
+        """,
+        """
+        <pre>
+        {@data}
+              <Component />
+        </pre>
+        <code>
+          {@data}
+          <Component />
+            </code>
+
+        <#MacroComponent> Foo {@bar} baz </#MacroComponent>
+
+        <script type="application/javascript">
+             foo();
+           var bar="baz";
+        </script>
+        """
+      )
+    end
+
+    test "HTML elements rendered in <pre>/<code>/<#MacroComponent> tags are left in their original state" do
+      # Note that the <code> and <#Macro> components (which are too indented)
+      # are brought all the way to the left side, but all of the whitespace
+      # characters therein are left alone.
+      assert_formatter_outputs(
+        """
+        <pre>
+            <div>    <p>  Hello world  </p>  </div>
+          </pre>
+
+          <code>
+              <div>    <p>  Hello world  </p>  </div>
+            </code>
+
+            <#Macro>
+                <div>    <p>  Hello world  </p>  </div>
+              </#Macro>
+        """,
+        """
+        <pre>
+            <div>    <p>  Hello world  </p>  </div>
+          </pre>
+
+        <code>
+              <div>    <p>  Hello world  </p>  </div>
+            </code>
+
+        <#Macro>
+                <div>    <p>  Hello world  </p>  </div>
+              </#Macro>
+        """
+      )
+    end
+
+    test "Attributes are lines up properly when split onto newlines with a multi-line attribute" do
+      assert_formatter_outputs(
+        """
+        <Parent>
+          <Child
+            first={123}
+            second={[
+                    {"foo", application.description},
+                    {"baz", application.product_owner}
+                  ]}
+          />
+        </Parent>
+        """,
+        """
+        <Parent>
+          <Child
+            first={123}
+            second={[
+              {"foo", application.description},
+              {"baz", application.product_owner}
+            ]}
+          />
+        </Parent>
+        """
+      )
+    end
+
+    test "If any attribute is formatted with a newline, attributes are split onto separate lines" do
+      # This is because multiple of them may have newlines, and it could result in odd formatting such as:
+      #
+      # <Foo bar=1 baz={{[
+      #   "bazz",
+      #   "bazz",
+      #   "bazz"
+      # ]}} qux=false />
+      #
+      # The attributes aren't the easiest to read in that case, and we're making the choice not
+      # to open the can of worms of potentially re-ordering attributes, because that introduces
+      # plenty of complexity and might not be desired by users.
+      assert_formatter_outputs(
+        """
+        <Parent>
+          <Child
+            first={ 123 }
+            second={[
+                    {"foo", foo},
+                    {"bar", bar}
+                  ]}
+          />
+        </Parent>
+        """,
+        """
+        <Parent>
+          <Child
+            first={123}
+            second={[
+              {"foo", foo},
+              {"bar", bar}
+            ]}
+          />
+        </Parent>
+        """
+      )
+
+      assert_formatter_outputs(
+        """
+        <Parent>
+          <Child first={[
+          {"foo", foo}, {"bar", bar}
+          ]} second={ 123 } />
+        </Parent>
+        """,
+        """
+        <Parent>
+          <Child
+            first={[
+              {"foo", foo},
+              {"bar", bar}
+            ]}
+            second={123}
+          />
+        </Parent>
+        """
+      )
+    end
+
+    test "tags without children are collapsed if there is no whitespace between them" do
+      assert_formatter_outputs(
+        """
+        <Foo></Foo>
+        """,
+        """
+        <Foo />
+        """
+      )
+
+      # Should these be collapsed?
+      assert_formatter_doesnt_change("""
+      <Foo> </Foo>
+      """)
+    end
+
+    test "lists with invisible brackets in attribute expressions are formatted" do
+      assert_formatter_outputs(
+        ~S"""
+        <Component foo={ "bar", 1, @a_very_long_name_in_assigns <> @another_extremely_long_name_to_make_the_elixir_formatter_wrap_this_expression } />
+        """,
+        ~S"""
+        <Component foo={
+          "bar",
+          1,
+          @a_very_long_name_in_assigns <>
+            @another_extremely_long_name_to_make_the_elixir_formatter_wrap_this_expression
+        } />
+        """
+      )
+    end
+
+    test "existing whitespace in string attributes is not altered when there are multiple attributes" do
+      # The output may not look "clean", but it didn't look "clean" to begin with, and it's the only
+      # way to ensure the formatter doesn't accidentally change the behavior of the resulting code.
+      #
+      # As with the Elixir formatter, it's important that the semantics of the code remain the same.
+      assert_formatter_outputs(
+        """
+        <Component foo={false} bar="a
+          b
+          c"
+        />
+        """,
+        """
+        <Component
+          foo={false}
+          bar="a
+          b
+          c"
+        />
+        """
+      )
+    end
+
+    test "existing whitespace in string attributes is not altered when there is only one attribute" do
+      assert_formatter_doesnt_change("""
+      <foo>
+        <bar>
+          <baz qux="one
+          two" />
+        </bar>
+      </foo>
+      """)
+    end
+
+    test "a single extra newline between children is retained" do
+      assert_formatter_doesnt_change("""
+      <Component>
+        foo
+
+        bar
+      </Component>
+      """)
+    end
+
+    test "multiple extra newlines between children are collapsed to one" do
+      assert_formatter_outputs(
+        """
+        <Component>
+          foo
+
+
+
+          bar
+        </Component>
+        """,
+        """
+        <Component>
+          foo
+
+          bar
+        </Component>
+        """
+      )
+    end
+
+    test "at most one blank newline is retained when an HTML comment exists" do
+      assert_formatter_outputs(
+        ~S"""
+        <div>
+          <Component />
+
+          <!-- Comment -->
+          <AfterComment />
+        </div>
+        """,
+        ~S"""
+        <div>
+          <Component />
+
+          <!-- Comment -->
+          <AfterComment />
+        </div>
+        """
+      )
+    end
+
+    test "inline elements mixed with text are left on the same line by default" do
+      assert_formatter_doesnt_change("""
+      The <b>Dialog</b> is a stateless component. All event handlers
+      had to be defined in the parent <b>LiveView</b>.
+      """)
+
+      assert_formatter_doesnt_change("""
+      <strong>Surface</strong> <i>v{surface_version()}</i> -
+      <a href="http://github.com/msaraiva/surface">github.com/msaraiva/surface</a>.
+      """)
+
+      assert_formatter_doesnt_change("""
+      This <b>Dialog</b> is a stateful component. Cool!
+      """)
+
+      assert_formatter_doesnt_change("""
+      <Card>
+        <Header>
+          A simple card component
+        </Header>
+
+        This is the same Card component but now we're using
+        <strong>typed slotables</strong> instead of <strong>templates</strong>.
+
+        <Footer>
+          <a href="#" class="card-footer-item">Footer Item 1</a>
+          <a href="#" class="card-footer-item">Footer Item 2</a>
+        </Footer>
+      </Card>
+      """)
+    end
+
+    test "when element content and tags aren't left on the same line, the next sibling is pushed to its own line" do
+      assert_formatter_outputs(
+        """
+        <div> <div> Hello </div> { 1 + 1 } <p>Goodbye</p> </div>
+        """,
+        """
+        <div>
+          <div>
+            Hello
+          </div>
+          {1 + 1} <p>Goodbye</p>
+        </div>
+        """
+      )
+
+      assert_formatter_outputs(
+        """
+        <div> <p> <span>Hello</span> </p> { 1 + 1 } <p>Goodbye</p> </div>
+        """,
+        """
+        <div>
+          <p>
+            <span>Hello</span>
+          </p>
+          {1 + 1} <p>Goodbye</p>
+        </div>
+        """
+      )
+    end
+
+    test "(bugfix) newlines aren't removed for no reason" do
+      assert_formatter_doesnt_change("""
+      <Test />
+
+      Example 1
+      <Test />
+
+      Example 2
+
+      <Test />
+      """)
+    end
+
+    test "whitespace padding in code comments is normalized" do
+      assert_formatter_outputs(
+        """
+        {!--  testing   --}
+        <!--     123    -->
+        """,
+        """
+        {!-- testing --}
+        <!-- 123 -->
+        """
+      )
+    end
+
+    test "multiline code comments are rendered as-is (except aligning indentation) to avoid false assumptions about how developers want to format comments" do
+      # The ending state of these comments is a bit quirky.
+      # The formatter refuses to make assumptions about the whitespace in
+      # multiline comments, so it renders them verbatim. However, it renders
+      # the beginning "tag" indented "properly" as a child of its parent.
+      # Developers can respond to this by adjusting the contents in relation
+      # to the opening "tag".
+      #
+      # This is identical to how whitespace is handled for <pre>/<code>/<#MacroComponent>
+      assert_formatter_outputs(
+        """
+        <div>
+        {!--
+
+
+          testing
+
+
+        --}
+        <!--
+        Here is a code comment.
+          It has multiple lines.
+            123
+
+        -->
+        </div>
+        """,
+        """
+        <div>
+          {!--
+
+
+          testing
+
+
+        --}
+          <!--
+        Here is a code comment.
+          It has multiple lines.
+            123
+
+        -->
+        </div>
+        """
+      )
+    end
+  end
+
+  describe "[expressions]" do
+    test "Elixir expressions retain the original code snippet" do
+      assert_formatter_outputs(
+        """
+            <div :if = {1 + 1      }>
+        {"hello "<>"dolly"}
+        </div>
+
+
+
+
+        """,
+        """
+        <div :if={1 + 1}>
+          {"hello " <> "dolly"}
+        </div>
+        """
+      )
+    end
+
+    test "shorthand surface syntax (invisible []) is formatted by Elixir code formatter" do
+      assert_formatter_outputs(
+        "<div class={ foo:        bar }></div>",
+        "<div class={foo: bar} />\n"
+      )
+    end
+
+    test "expressions in attributes" do
+      assert_formatter_outputs(
+        """
+        <div class={  [1, 2, 3]  } />
+        """,
+        """
+        <div class={[1, 2, 3]} />
+        """
+      )
+
+      assert_formatter_outputs(
+        """
+        <div class={foo: "foofoofoofoofoofoofoofoofoofoo", bar: "barbarbarbarbarbarbarbarbarbarbar", baz: "bazbazbazbazbazbazbazbaz"} />
+        """,
+        """
+        <div class={
+          foo: "foofoofoofoofoofoofoofoofoofoo",
+          bar: "barbarbarbarbarbarbarbarbarbarbar",
+          baz: "bazbazbazbazbazbazbazbaz"
+        } />
+        """
+      )
+    end
+
+    test "expressions in attributes of deeply nested elements" do
+      assert_formatter_outputs(
+        """
+        <section>
+        <div>
+        <p class={["foofoofoofoofoofoofoofoofoofoo", "barbarbarbarbarbarbarbarbarbarbar", "bazbazbazbazbazbazbazbaz"]} />
+        </div>
+        </section>
+        """,
+        """
+        <section>
+          <div>
+            <p class={[
+              "foofoofoofoofoofoofoofoofoofoo",
+              "barbarbarbarbarbarbarbarbarbarbar",
+              "bazbazbazbazbazbazbazbaz"
+            ]} />
+          </div>
+        </section>
+        """
+      )
+    end
+
+    test "interpolation in string attributes" do
+      # Note that the formatter does not remove the extra whitespace at the end of the string.
+      # We have no context about whether the whitespace in the given attribute is significant,
+      # so we might break code by modifying it. Therefore, the contents of string attributes
+      # are left alone other than formatting interpolated expressions.
+      assert_formatter_outputs(
+        """
+        <Component foo={"bar #\{@baz}  "}></Component>
+        """,
+        """
+        <Component foo={"bar #\{@baz}  "} />
+        """
+      )
+    end
+
+    test "numbers are formatted with underscores per the Elixir formatter" do
+      assert_formatter_outputs(
+        """
+        <Component int_prop={1000000000} float_prop={123456789.123456789 } />
+        """,
+        """
+        <Component int_prop={1_000_000_000} float_prop={123_456_789.123456789} />
+        """
+      )
+    end
+
+    test "attribute expressions that are a list merged with a keyword list are formatted" do
+      assert_formatter_outputs(
+        """
+        <span class={ "container", "container--dark": @dark_mode } />
+        """,
+        """
+        <span class={"container", "container--dark": @dark_mode} />
+        """
+      )
+    end
+
+    test "attribute expressions with a function call that omits parentheses are formatted" do
+      assert_formatter_outputs(
+        """
+        <Component items={ Enum.map @items, & &1.foo }/>
+        """,
+        """
+        <Component items={Enum.map(@items, & &1.foo)} />
+        """
+      )
+    end
+
+    test "expressions that line-wrap are indented properly" do
+      assert_formatter_outputs(
+        """
+        <Component>
+          { link "Log out", to: Routes.user_session_path(Endpoint, :delete), method: :delete, class: "container"}
+        </Component>
+        """,
+        """
+        <Component>
+          {link("Log out",
+            to: Routes.user_session_path(Endpoint, :delete),
+            method: :delete,
+            class: "container"
+          )}
+        </Component>
+        """
+      )
+    end
+
+    test "(bugfix) attribute expresssions that are keyword lists without brackets and with interpolated string keys are formatted and don't crash" do
+      assert_formatter_outputs(
+        ~S"""
+        <Component attr={"a-#{@b}": c} />
+        """,
+        ~S"""
+        <Component attr={"a-#{@b}": c} />
+        """
+      )
+    end
+
+    test "string literals in attributes are not wrapped in expression brackets" do
+      assert_formatter_outputs(
+        """
+        <Component str_prop={ "some_string_value" } />
+        """,
+        """
+        <Component str_prop="some_string_value" />
+        """
+      )
+    end
+
+    test "an expression with only a code comment is turned into a Surface code comment" do
+      assert_formatter_outputs(
+        """
+        { # Foo}
+        """,
+        """
+        {!-- Foo --}
+        """
+      )
+    end
+
+    test "dynamic attributes are formatted" do
+      assert_formatter_outputs(
+        """
+        <Foo { ... @bar } />
+        """,
+        """
+        <Foo {...@bar} />
+        """
+      )
+
+      assert_formatter_outputs(
+        """
+        <div { ... @attrs } />
+        """,
+        """
+        <div {...@attrs} />
+        """
+      )
+
+      assert_formatter_outputs(
+        """
+        <div :attrs={@foo} />
+        """,
+        """
+        <div {...@foo} />
+        """
+      )
+
+      assert_formatter_outputs(
+        """
+        <Component :props={@foo} />
+        """,
+        """
+        <Component {...@foo} />
+        """
+      )
+
+      # keyword with implicit brackets
+      assert_formatter_outputs(
+        """
+        <Component {... foo: @bar, baz: @qux } />
+        """,
+        """
+        <Component {...foo: @bar, baz: @qux} />
+        """
+      )
+
+      # keyword with explicit brackets
+      assert_formatter_outputs(
+        """
+        <Component {...[foo: @bar, baz: @qux]} />
+        """,
+        """
+        <Component {...[foo: @bar, baz: @qux]} />
+        """
+      )
+
+      # demonstrate that <#slot :args={@foo} /> isn't collapsed
+      assert_formatter_doesnt_change("""
+      <#slot :args={@foo} />
+      """)
+    end
+
+    test "shorthand assigns passthrough attributes are formatted" do
+      assert_formatter_outputs(
+        """
+        <Foo {= @bar} />
+        """,
+        """
+        <Foo {=@bar} />
+        """
+      )
+
+      assert_formatter_outputs(
+        """
+        <Foo {= bar} />
+        """,
+        """
+        <Foo {=bar} />
+        """
+      )
+
+      # demonstrate that the formatter is unopinionated about short or longhand
+      # in this scenario
+      assert_formatter_outputs(
+        """
+        <Foo bar={@bar} />
+        """,
+        """
+        <Foo bar={@bar} />
+        """
+      )
+    end
+
+    test "root prop is formatted" do
+      assert_formatter_outputs(
+        """
+        <MyIf { @var  >  10 } />
+        """,
+        """
+        <MyIf {@var > 10} />
+        """
+      )
+    end
+
+    test "pin operator in expressions" do
+      assert_formatter_outputs(
+        """
+        <div>
+          {^ foo}
+        </div>
+        """,
+        """
+        <div>
+          {^foo}
+        </div>
+        """
+      )
+
+      assert_formatter_outputs(
+        """
+        <div class="card dark">
+          <div class="card-content">
+            {^content_ast}
+          </div>
+          <footer class="card-footer">
+            {^code_ast}
+          </footer>
+        </div>
+        """,
+        """
+        <div class="card dark">
+          <div class="card-content">
+            {^content_ast}
+          </div>
+          <footer class="card-footer">
+            {^code_ast}
+          </footer>
+        </div>
+        """
+      )
+
+      assert_formatter_outputs(
+        """
+        <pre id={^container_id} class={^class} phx-update="ignore"><code id={^id} class={^class} phx-hook="Highlight">{^code_content}</code></pre>
+        """,
+        """
+        <pre id={^container_id} class={^class} phx-update="ignore"><code id={^id} class={^class} phx-hook="Highlight">{^code_content}</code></pre>
+        """
+      )
+    end
+
+    test "true boolean attribute in directive" do
+      assert_formatter_doesnt_change("""
+      <div :if={true} />
+      """)
+    end
+  end
+
+  describe "[blocks]" do
+    test "if../if block expressions" do
+      assert_formatter_outputs(
+        """
+        <div> <div>
+        {#if @greet}
+        <p>
+        Hello
+        </p>
+        {/if}
+        </div> </div>
+        """,
+        """
+        <div>
+          <div>
+            {#if @greet}
+              <p>
+                Hello
+              </p>
+            {/if}
+          </div>
+        </div>
+        """
+      )
+    end
+
+    test "if..elseif..else../if block expressions" do
+      assert_formatter_outputs(
+        """
+        {#if @value == 0}
+
+          <div class="equal">
+            Value {@value} is 0
+          </div>
+
+
+
+
+        {#elseif     @value   >  0 }
+          <div class="greater">
+
+            Value {@value} is greater than 0
+
+          </div>
+        {#else}
+
+
+          <div class="lower">
+
+                  Value {@value} is lower than 0
+          </div>
+        {/if}
+        """,
+        """
+        {#if @value == 0}
+          <div class="equal">
+            Value {@value} is 0
+          </div>
+        {#elseif @value > 0}
+          <div class="greater">
+            Value {@value} is greater than 0
+          </div>
+        {#else}
+          <div class="lower">
+            Value {@value} is lower than 0
+          </div>
+        {/if}
+        """
+      )
+    end
+
+    test "unless../unless block expressions" do
+      assert_formatter_outputs(
+        """
+        <div> <div>
+        {#unless @new_user}
+        <p>
+        Welcome back!
+        </p>
+        {/unless}
+        </div> </div>
+        """,
+        """
+        <div>
+          <div>
+            {#unless @new_user}
+              <p>
+                Welcome back!
+              </p>
+            {/unless}
+          </div>
+        </div>
+        """
+      )
+    end
+
+    test "for..else../for block expressions" do
+      assert_formatter_outputs(
+        """
+        {#for item <- @items}
+
+          Item:   {item}
+        {#else  }
+          No items
+        {/for}
+        """,
+        """
+        {#for item <- @items}
+          Item: {item}
+        {#else}
+          No items
+        {/for}
+        """
+      )
+    end
+
+    test "for..else../for block expressions with multi-line generator" do
+      assert_formatter_outputs(
+        """
+        {#for item <- @some_prop.items,
+        item.type == Some.Long.Complicated.Atom,
+        value = item.some_item_property}
+
+          Item:   {item}
+        {#else  }
+          No items
+        {/for}
+        """,
+        """
+        {#for item <- @some_prop.items,
+            item.type == Some.Long.Complicated.Atom,
+            value = item.some_item_property}
+          Item: {item}
+        {#else}
+          No items
+        {/for}
+        """
+      )
+    end
+
+    test "case block expressions" do
+      assert_formatter_outputs(
+        """
+        {#case  @value }
+
+          {#match [first|_]}
+            <div {=@class}>
+              First {first}
+            </div>
+
+          {#match []}
+
+
+            <div class={@class}>
+              Value is empty
+            </div>
+
+          {#match "string"}
+
+            <p>String match</p>
+
+          {#match _}
+
+            Value is something else
+
+
+        {/case}
+        """,
+        """
+        {#case @value}
+          {#match [first | _]}
+            <div {=@class}>
+              First {first}
+            </div>
+          {#match []}
+            <div class={@class}>
+              Value is empty
+            </div>
+          {#match "string"}
+            <p>String match</p>
+          {#match _}
+            Value is something else
+        {/case}
+        """
+      )
+    end
+
+    test "nested blocks" do
+      assert_formatter_outputs(
+        """
+        {#if @value == 0}
+          {#if @yell}
+            <div class="equal">
+              VALUE {@value} IS 0
+            </div>
+          {#else}
+            {#if @whisper}
+              <div class="equal">
+                {@value}...0
+              </div>
+            {#else}
+              <div class="equal">
+                Value {@value} is 0
+              </div>
+            {/if}
+          {/if}
+        {#else}
+          <div class="lower">
+              Value {@value} is lower than 0
+          </div>
+        {/if}
+        """,
+        """
+        {#if @value == 0}
+          {#if @yell}
+            <div class="equal">
+              VALUE {@value} IS 0
+            </div>
+          {#else}
+            {#if @whisper}
+              <div class="equal">
+                {@value}...0
+              </div>
+            {#else}
+              <div class="equal">
+                Value {@value} is 0
+              </div>
+            {/if}
+          {/if}
+        {#else}
+          <div class="lower">
+            Value {@value} is lower than 0
+          </div>
+        {/if}
+        """
+      )
+
+      assert_formatter_outputs(
+        """
+        {#case @foo}
+          {#match 1}
+            {#case @bar}
+              {#match 2}
+                <div>
+                  foo is 1 and bar is 2
+                </div>
+              {#match _}
+                <div>
+                  bar is not 2
+                </div>
+            {/case}
+          {#match _}
+            foo is not 1
+        {/case}
+        """,
+        """
+        {#case @foo}
+          {#match 1}
+            {#case @bar}
+              {#match 2}
+                <div>
+                  foo is 1 and bar is 2
+                </div>
+              {#match _}
+                <div>
+                  bar is not 2
+                </div>
+            {/case}
+          {#match _}
+            foo is not 1
+        {/case}
+        """
+      )
+    end
+
+    test "line breaks in blocks" do
+      assert_formatter_outputs(
+        """
+        <div>
+          <div>
+            <p>
+              {#if not is_nil(@some_assign.foo) or not is_nil(@some_assign.bar) or not is_nil(@some_assign.bazzzzzzz.qux)}
+                Hello
+              {/if}
+            </p>
+          </div>
+        </div>
+        """,
+        """
+        <div>
+          <div>
+            <p>
+              {#if not is_nil(@some_assign.foo) or not is_nil(@some_assign.bar) or
+                  not is_nil(@some_assign.bazzzzzzz.qux)}
+                Hello
+              {/if}
+            </p>
+          </div>
+        </div>
+        """
+      )
+    end
+
+    test "slots" do
+      assert_formatter_outputs(
+        """
+        <div class="mx-6 my-4">
+          <#slot name="header">
+            <h1 :if={@title} class="lg:hidden text-md text-neutral-600 mt-4 mb-2 font-semibold leading-loose tracking-wide">
+              {@title}
+            </h1>
+          </#slot>
+
+          <#slot />
+        </div>
+        """,
+        """
+        <div class="mx-6 my-4">
+          <#slot name="header">
+            <h1
+              :if={@title}
+              class="lg:hidden text-md text-neutral-600 mt-4 mb-2 font-semibold leading-loose tracking-wide"
+            >
+              {@title}
+            </h1>
+          </#slot>
+
+          <#slot />
+        </div>
+        """
+      )
+    end
+  end
+
+  test "self closing macro components are preserved" do
+    assert_formatter_doesnt_change("""
+    <#MacroComponent />
+    """)
+  end
+
+  test "indent option" do
+    assert_formatter_outputs(
+      """
+      <p>
+      <span>
+      Indented
+      </span>
+      </p>
+      """,
+      """
+            <p>
+              <span>
+                Indented
+              </span>
+            </p>
+      """,
+      indent: 3
+    )
+  end
+
+  test "for docs" do
+    assert_formatter_outputs(
+      """
+       <RootComponent with_many_attributes={ true } causing_this_line_to_wrap={ true} because_it_is_too_long={ "yes, this line is long enough to wrap" }>
+         <!--   HTML public comment (hits the browser)   -->
+         {!--   Surface private comment (does not hit the browser)   --}
+
+
+
+         <div :if={ @show_div }
+         class="container">
+             <p> Text inside paragraph    </p>
+          <span>Text touching parent tags</span>
+         </div>
+
+      <Child  items={[%{name: "Option 1", key: 1}, %{name: "Option 2", key:  2},    %{name: "Option 3", key: 3}, %{name: "Option 4", key: 4}]}>
+        Default slot contents
+      </Child>
+      </RootComponent>
+      """,
+      """
+      <RootComponent
+        with_many_attributes
+        causing_this_line_to_wrap
+        because_it_is_too_long="yes, this line is long enough to wrap"
+      >
+        <!-- HTML public comment (hits the browser) -->
+        {!-- Surface private comment (does not hit the browser) --}
+
+        <div :if={@show_div} class="container">
+          <p>
+            Text inside paragraph
+          </p>
+          <span>Text touching parent tags</span>
+        </div>
+
+        <Child items={[
+          %{name: "Option 1", key: 1},
+          %{name: "Option 2", key: 2},
+          %{name: "Option 3", key: 3},
+          %{name: "Option 4", key: 4}
+        ]}>
+          Default slot contents
+        </Child>
+      </RootComponent>
+      """
+    )
+
+    assert_formatter_outputs(
+      """
+      <div> <p>Hello</p> </div>
+      """,
+      """
+      <div>
+        <p>Hello</p>
+      </div>
+      """
+    )
+
+    assert_formatter_outputs(
+      """
+      <p>Hello</p>
+
+
+
+
+
+      <p>Goodbye</p>
+      """,
+      """
+      <p>Hello</p>
+
+      <p>Goodbye</p>
+      """
+    )
+
+    assert_formatter_outputs(
+      """
+      <section>
+        <p>Hello</p>
+        <p>and</p>
+
+
+
+
+
+        <p>Goodbye</p>
+      </section>
+      """,
+      """
+      <section>
+        <p>Hello</p>
+        <p>and</p>
+
+        <p>Goodbye</p>
+      </section>
+      """
+    )
+  end
+
+  test "void elements do not have slash in single tag" do
+    assert_formatter_outputs(
+      """
+      <area />
+      <base />
+      <br />
+      <col />
+      <hr />
+      <img />
+      <input />
+      <link />
+      <meta />
+      <param />
+      <command />
+      <keygen />
+      <source />
+      """,
+      """
+      <area>
+      <base>
+      <br>
+      <col>
+      <hr>
+      <img>
+      <input>
+      <link>
+      <meta>
+      <param>
+      <command>
+      <keygen>
+      <source>
+      """
+    )
+  end
+
+  test "<#template slot=\"...\"> is formatted in shorthand syntax" do
+    assert_formatter_outputs(
+      """
+      <div>
+        <#template slot="header" :let={value: value}> Foo </#template>
+
+        <#template> Foo </#template>
+      </div>
+      """,
+      """
+      <div>
+        <:header :let={value: value}>
+          Foo
+        </:header>
+
+        <#template>
+          Foo
+        </#template>
+      </div>
+      """
+    )
+  end
+
+  test "<template> tags are not rendered as <#template>" do
+    assert_formatter_outputs(
+      """
+      <template>
+        <p> Foo </p>
+      </template>
+      """,
+      """
+      <template>
+        <p>
+          Foo
+        </p>
+      </template>
+      """
+    )
+  end
+
+  test "Multi-line strings in lists in attributes aren't indented every time the formatter is ran" do
+    assert_formatter_doesnt_change(~S"""
+    <Wrapper>
+      <Wrapper>
+        <First
+          class={
+            "w-full h-12 max-w-full px-4 bg-black-100 hover:bg-black-120 text-base leading-normal
+             text-color-bulma-100 box-border border border-solid border-yellow-100 rounded transition
+             ease-in placeholder-cyan-100 placeholder-opacity-100 disabled:opacity-50
+             disabled:cursor-not-allowed focus:border-red-100 focus:outline-none
+             no-scrollbar invalid:shadow-none invalid:border-green-100 #{@class}",
+            "pl-11": @left_icon,
+            "pr-11": @right_icon,
+            "border-green-100": @error
+          }
+          field={@field}
+          opts={[
+            placeholder: @placeholder,
+            disabled: @disabled,
+            required: @required
+          ]}
+          value={@value}
+          focus={@on_focus}
+          blur={@on_blur}
+        />
+      </Wrapper>
+    </Wrapper>
+    """)
+
+    assert_formatter_outputs(
+      ~S"""
+      <Second
+        class={
+          "w-full h-12 max-w-full px-4 bg-x-100 hover:bg-x-120 text-base leading-normal
+           text-color-y-100 box-border border border-solid border-k-100 rounded transition
+           ease-in placeholder-hhh-100 placeholder-opacity-100 disabled:opacity-50
+           disabled:cursor-not-allowed focus:border-m-100 focus:outline-none
+           no-scrollbar invalid:shadow-none invalid:border-t-100 #{@class}",
+          foo: @foo,
+          bar: @bar == "yes"
+        }
+      />
+      """,
+      ~S"""
+      <Second class={
+        "w-full h-12 max-w-full px-4 bg-x-100 hover:bg-x-120 text-base leading-normal
+           text-color-y-100 box-border border border-solid border-k-100 rounded transition
+           ease-in placeholder-hhh-100 placeholder-opacity-100 disabled:opacity-50
+           disabled:cursor-not-allowed focus:border-m-100 focus:outline-none
+           no-scrollbar invalid:shadow-none invalid:border-t-100 #{@class}",
+        foo: @foo,
+        bar: @bar == "yes"
+      } />
+      """
+    )
+
+    assert_formatter_doesnt_change(~S"""
+    <Third
+      class={
+        "w-full h-12 max-w-full px-4 bg-x-100 hover:bg-x-120 text-base leading-normal
+         text-color-y-100 box-border border border-solid border-k-100 rounded transition
+         ease-in placeholder-h-100 placeholder-opacity-100 disabled:opacity-50
+         disabled:cursor-not-allowed focus:border-m-100 focus:outline-none
+         no-scrollbar invalid:shadow-none invalid:border-t-100 {@class}",
+        @foo,
+        @bar
+      }
+      field={:foo}
+    />
+    """)
+
+    assert_formatter_doesnt_change(~S"""
+    <Fourth class={
+      "w-full h-12 max-w-full px-4 bg-x-100 hover:bg-x-120 text-base leading-normal
+       text-color-y-100 box-border border border-solid border-k-100 rounded transition
+       ease-in placeholder-hhh-100 placeholder-opacity-100 disabled:opacity-50
+       disabled:cursor-not-allowed focus:border-m-100 focus:outline-none
+       no-scrollbar invalid:shadow-none invalid:border-t-100 #{@class}",
+      foo: @foo,
+      bar: @bar == "yes"
+    } />
+    """)
+  end
+end


### PR DESCRIPTION
This merges in the newly released `surface_formatter 0.7.0`, including the `Surface.Formatter.Plugin` Formatter Plugin for Elixir 1.13. 😄 

To do:

- Add Elixir 1.13 into matrix in `.github/workflows/ci.yml` and ensure `Surface.Formatter.PluginTest` only runs for that version of Elixir.
- Update README, which points to separate `surface_formatter` Hex package.
- Add any information from [surface_formatter's README](https://github.com/surface-ui/surface_formatter/blob/master/README.md)? It is not included in this PR, but I think all of the information there is redundant, repeating information inside of other modules included in this PR.

Are there any other architectural or organizational code changes we want to include?