### PR TITLE
Fix compiler injection patches

### DIFF
--- a/lib/mix/tasks/surface/surface.init/ex_patcher.ex
+++ b/lib/mix/tasks/surface/surface.init/ex_patcher.ex
@@ -207,7 +207,7 @@ defmodule Mix.Tasks.Surface.Init.ExPatcher do
   def replace_code(%__MODULE__{code: code} = patcher, fun) when is_function(fun) do
     patch(patcher, [preserve_indentation: false], fn zipper ->
       node = Z.node(zipper)
-      range = Sourceror.get_range(node)
+      range = Sourceror.get_range(node, include_comments: true)
       code_to_replace = get_code_by_range(code, range)
       fun.(code_to_replace)
     end)
@@ -297,7 +297,7 @@ defmodule Mix.Tasks.Surface.Init.ExPatcher do
 
         last_child_zipper ->
           node = Z.node(last_child_zipper)
-          range = Sourceror.get_range(node)
+          range = Sourceror.get_range(node, include_comments: true)
           updated_code = Sourceror.parse_string!(Sourceror.to_string(node) <> string)
 
           change =
@@ -323,7 +323,7 @@ defmodule Mix.Tasks.Surface.Init.ExPatcher do
     patch =
       case fun.(zipper) do
         change when is_binary(change) ->
-          range = zipper |> Z.node() |> Sourceror.get_range()
+          range = zipper |> Z.node() |> Sourceror.get_range(include_comments: true)
           Map.merge(%{change: change, range: range}, Map.new(opts))
 
         patch ->

--- a/lib/mix/tasks/surface/surface.init/ex_patcher.ex
+++ b/lib/mix/tasks/surface/surface.init/ex_patcher.ex
@@ -295,20 +295,34 @@ defmodule Mix.Tasks.Surface.Init.ExPatcher do
           |> Z.node()
           |> Sourceror.to_string()
 
+        {{:., _, _}, _} ->
+          # We can't get the range of the dot call in a qualified call like
+          # `foo.bar()`, so we apply the patch to the parent. We get into this
+          # situation when the qualified call has no arguments: the first child
+          # will be a dot call of the form `{:., meta, [left, identifier]}`
+          # where `identifier` is a bare atom, like `:compilers`. The line
+          # metadata for the identifier lives in the parent call, making it
+          # impossible to generate a patch for the child call alone.
+          append_child_patch(zipper, string)
+
         last_child_zipper ->
-          node = Z.node(last_child_zipper)
-          range = Sourceror.get_range(node, include_comments: true)
-          updated_code = Sourceror.parse_string!(Sourceror.to_string(node) <> string)
-
-          change =
-            last_child_zipper
-            |> Z.replace(updated_code)
-            |> Z.node()
-            |> Sourceror.to_string()
-
-          %{change: change, range: range}
+          append_child_patch(last_child_zipper, string)
       end
     end)
+  end
+
+  defp append_child_patch(zipper, string) do
+    node = Z.node(zipper)
+    range = Sourceror.get_range(node, include_comments: true)
+    updated_code = Sourceror.parse_string!(Sourceror.to_string(node) <> string)
+
+    change =
+      zipper
+      |> Z.replace(updated_code)
+      |> Z.node()
+      |> Sourceror.to_string()
+
+    %{change: change, range: range}
   end
 
   def patch(patcher, opts \\ [], fun)

--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,7 @@ defmodule Surface.MixProject do
       {:phoenix_live_view, "~> 0.16.0"},
       {:floki, "~> 0.25.0", only: :test},
       {:phoenix_ecto, "~> 4.0", only: :test},
-      {:sourceror, "~> 0.8.5"},
+      {:sourceror, "~> 0.9"},
       {:ecto, "~> 3.4.2", only: :test},
       {:ex_doc, ">= 0.19.0", only: :docs}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -19,6 +19,6 @@
   "phoenix_view": {:hex, :phoenix_view, "1.0.0", "fea71ecaaed71178b26dd65c401607de5ec22e2e9ef141389c721b3f3d4d8011", [:mix], [{:phoenix_html, "~> 2.14.2 or ~> 3.0", [hex: :phoenix_html, repo: "hexpm", optional: true]}], "hexpm", "82be3e2516f5633220246e2e58181282c71640dab7afc04f70ad94253025db0c"},
   "plug": {:hex, :plug, "1.12.1", "645678c800601d8d9f27ad1aebba1fdb9ce5b2623ddb961a074da0b96c35187d", [:mix], [{:mime, "~> 1.0 or ~> 2.0", [hex: :mime, repo: "hexpm", optional: false]}, {:plug_crypto, "~> 1.1.1 or ~> 1.2", [hex: :plug_crypto, repo: "hexpm", optional: false]}, {:telemetry, "~> 0.4.3 or ~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "d57e799a777bc20494b784966dc5fbda91eb4a09f571f76545b72a634ce0d30b"},
   "plug_crypto": {:hex, :plug_crypto, "1.2.2", "05654514ac717ff3a1843204b424477d9e60c143406aa94daf2274fdd280794d", [:mix], [], "hexpm", "87631c7ad914a5a445f0a3809f99b079113ae4ed4b867348dd9eec288cecb6db"},
-  "sourceror": {:hex, :sourceror, "0.8.5", "e52cd837eb6733553e1b4d78a5ccda5390733bfa194b9bc09137e4ef27d41e0e", [:mix], [], "hexpm", "119e8fb696bb386e3d57c70a60f82e7a2579b5d212f821e9cecdd5bd15471635"},
+  "sourceror": {:hex, :sourceror, "0.9.0", "77e8f883be9455812d15913582d2985048ef65d7d931072c548e025a6ea58d5a", [:mix], [], "hexpm", "f56fb5b935df7784504f7d1ba074e0aa83299e2ebd64f75268ffcae62a28f331"},
   "telemetry": {:hex, :telemetry, "0.4.3", "a06428a514bdbc63293cd9a6263aad00ddeb66f608163bdec7c8995784080818", [:rebar3], [], "hexpm", "eb72b8365ffda5bed68a620d1da88525e326cb82a75ee61354fc24b844768041"},
 }

--- a/test/mix/tasks/surface/util/patches_test.exs
+++ b/test/mix/tasks/surface/util/patches_test.exs
@@ -51,6 +51,52 @@ defmodule Mix.Tasks.Surface.Init.PatchesTest do
              """
     end
 
+    test "add :surface to compilers when there are no other compilers" do
+      code = """
+      defmodule MyApp.MixProject do
+        use Mix.Project
+
+        def project do
+          [
+            app: :my_app,
+            compilers: Mix.compilers(),
+            start_permanent: Mix.env() == :prod
+          ]
+        end
+
+        defp deps do
+          [
+            {:phoenix, "~> 1.6.0"},
+            {:surface, "~> 0.5.2"}
+          ]
+        end
+      end
+      """
+
+      {:patched, updated_code} = Patcher.patch_code(code, Patches.add_surface_to_mix_compilers())
+
+      assert updated_code == """
+             defmodule MyApp.MixProject do
+               use Mix.Project
+
+               def project do
+                 [
+                   app: :my_app,
+                   compilers: Mix.compilers() ++ [:surface],
+                   start_permanent: Mix.env() == :prod
+                 ]
+               end
+
+               defp deps do
+                 [
+                   {:phoenix, "~> 1.6.0"},
+                   {:surface, "~> 0.5.2"}
+                 ]
+               end
+             end
+             """
+    end
+
     test "don't apply it if already patched" do
       code = """
       defmodule MyApp.MixProject do


### PR DESCRIPTION
This addresses #532 

I left a comment in the code, but the reason for this bug is that when we have a qualified call, like `Mix.compilers()`, the AST will look like this:
```elixir
{{:., inner_metadata, [[:__aliases__, _, [:Mix]}, :compilers]}, outer_metadata, []}
```
Note that `:compilers`(ie the identifier) is a "naked" atom, ie it's not wrapped in a block, so it doesn't have metadata. The line and column information for the identifier lives in the `outer_metadata`, while the dot position information lives in the `inner_metadata`. This means that we can't know the range of the inner `:.` call if we don't have the parent too.

When navigating down such tree, the first child will be the `:.` call, then the arguments follow. If we use `Z.rightmost` to get the last child, but the call doesn't have any arguments like in this case, then the only child we'll get is the `:.` call.

The code generating this patch was trying to generate a patch on this `:.` call, but since that call alone doesn't have enough information to generate a range to patch, it crashed. The solution is basically to check if we landed in such call and if so then work with the parent node.