### PR TITLE
Merge bugfixes from surface_formatter 0.7.3 and 0.7.4

### DIFF
--- a/lib/surface/formatter/phases/render.ex
+++ b/lib/surface/formatter/phases/render.ex
@@ -389,13 +389,30 @@ defmodule Surface.Formatter.Phases.Render do
           []
         end
 
-      {:<<>>, _, nodes} when is_list(nodes) ->
+      [{:do, string}] when is_binary(string) ->
+        if String.contains?(string, "\n") do
+          [string]
+        else
+          []
+        end
+
+      {operation, _, nodes} when is_atom(operation) and is_list(nodes) ->
+        quoted_strings_with_newlines(nodes)
+
+      [{:do, node_or_nodes}] ->
+        quoted_strings_with_newlines(node_or_nodes)
+
+      nodes when is_list(nodes) ->
         quoted_strings_with_newlines(nodes)
 
       _ ->
         []
     end)
     |> List.flatten()
+  end
+
+  defp quoted_strings_with_newlines(node) do
+    quoted_strings_with_newlines([node])
   end
 
   defp is_keyword_item_with_interpolated_key?(item) do

--- a/lib/surface/formatter/phases/render.ex
+++ b/lib/surface/formatter/phases/render.ex
@@ -423,39 +423,39 @@ defmodule Surface.Formatter.Phases.Render do
 
   @spec format_attribute_expression(String.t(), [render_attribute_option]) :: String.t()
   defp format_attribute_expression(expression, opts) when is_binary(expression) do
-    if has_invisible_brackets?(expression) do
-      # handle keyword lists, which will be stripped of the outer brackets per surface syntax sugar
-      formatted =
+    formatted =
+      if has_invisible_brackets?(expression) do
+        # handle keyword lists, which will be stripped of the outer brackets per surface syntax sugar
         "[#{expression}]"
         |> Code.format_string!(locals_without_parens: [...: 1])
         |> Enum.slice(1..-2)
         |> to_string()
-
-      if length(Keyword.get(opts, :attributes, [])) > 1 do
-        # handle scenario where list contains string(s) with newlines;
-        # in order to ensure the formatter is idempotent (always emits
-        # the same output when run more than once), we dedent newlines
-        # in strings because multi-line attributes are later indented
-        expression
-        |> quoted_strings_with_newlines()
-        |> Enum.uniq()
-        |> Enum.reduce(formatted, fn string_with_newlines, formatted ->
-          dedented =
-            String.replace(
-              string_with_newlines,
-              "\n#{String.duplicate(@tab, opts[:indent] + 1)}",
-              "\n"
-            )
-
-          String.replace(formatted, string_with_newlines, dedented)
-        end)
       else
-        formatted
+        expression
+        |> Code.format_string!(locals_without_parens: [...: 1])
+        |> to_string()
       end
-    else
+
+    if length(Keyword.get(opts, :attributes, [])) > 1 do
+      # handle scenario where list contains string(s) with newlines;
+      # in order to ensure the formatter is idempotent (always emits
+      # the same output when run more than once), we dedent newlines
+      # in strings because multi-line attributes are later indented
       expression
-      |> Code.format_string!(locals_without_parens: [...: 1])
-      |> to_string()
+      |> quoted_strings_with_newlines()
+      |> Enum.uniq()
+      |> Enum.reduce(formatted, fn string_with_newlines, formatted ->
+        dedented =
+          String.replace(
+            string_with_newlines,
+            "\n#{String.duplicate(@tab, opts[:indent] + 1)}",
+            "\n"
+          )
+
+        String.replace(formatted, string_with_newlines, dedented)
+      end)
+    else
+      formatted
     end
   end
 

--- a/test/surface/formatter_test.exs
+++ b/test/surface/formatter_test.exs
@@ -755,7 +755,7 @@ defmodule Surface.FormatterTest do
       )
     end
 
-    test "attribute expressions that are a list merged with a keyword list are formatted" do
+    test "attribute expressions that are a list merged with a keyword list" do
       assert_formatter_outputs(
         """
         <span class={ "container", "container--dark": @dark_mode } />
@@ -766,7 +766,7 @@ defmodule Surface.FormatterTest do
       )
     end
 
-    test "attribute expressions with a function call that omits parentheses are formatted" do
+    test "attribute expressions with a function call that omits parentheses" do
       assert_formatter_outputs(
         """
         <Component items={ Enum.map @items, & &1.foo }/>
@@ -796,7 +796,7 @@ defmodule Surface.FormatterTest do
       )
     end
 
-    test "(bugfix) attribute expresssions that are keyword lists without brackets and with interpolated string keys are formatted and don't crash" do
+    test "(bugfix) attribute expresssions that are keyword lists without brackets, with interpolated string keys" do
       assert_formatter_outputs(
         ~S"""
         <Component attr={"a-#{@b}": c} />
@@ -829,7 +829,7 @@ defmodule Surface.FormatterTest do
       )
     end
 
-    test "dynamic attributes are formatted" do
+    test "dynamic attributes" do
       assert_formatter_outputs(
         """
         <Foo { ... @bar } />
@@ -892,7 +892,7 @@ defmodule Surface.FormatterTest do
       """)
     end
 
-    test "shorthand assigns passthrough attributes are formatted" do
+    test "shorthand assigns passthrough attributes" do
       assert_formatter_outputs(
         """
         <Foo {= @bar} />
@@ -923,7 +923,7 @@ defmodule Surface.FormatterTest do
       )
     end
 
-    test "root prop is formatted" do
+    test "root prop" do
       assert_formatter_outputs(
         """
         <MyIf { @var  >  10 } />
@@ -984,6 +984,60 @@ defmodule Surface.FormatterTest do
     test "true boolean attribute in directive" do
       assert_formatter_doesnt_change("""
       <div :if={true} />
+      """)
+    end
+
+    test "strings in attribute expressions with keyword shorthand aren't modified" do
+      # By putting at least 2 attributes in the following examples,
+      # we make sure to hit `Surface.Formatter.Phases.Render.quoted_strings_with_newlines/1`
+      # which is only used with multiple attributes.
+      #
+      # Rendering a multi-attribute node involves extra specialized logic
+      # for dealing with newlines in strings properly.
+
+      assert_formatter_doesnt_change("""
+      <Component
+        id="foo"
+        value={if @bar, do: "baz
+
+        qux"}
+      />
+      """)
+
+      # deeply nested in blocks
+      assert_formatter_doesnt_change("""
+      <Component
+        id="foo"
+        value={if @bar do
+          if @baz do
+            unless @qux do
+              "result
+              with
+              newlines"
+            end
+          end
+        end}
+      />
+      """)
+
+      assert_formatter_doesnt_change("""
+      <Component
+        id="1"
+        value={case @foo do
+          "bar" ->
+            with "qux" <- @baz,
+                 :ok <- value?() do
+              cond do
+                @test != "newliney
+                " ->
+                  "pass"
+              end
+            end
+
+          :baz ->
+            nil
+        end}
+      />
       """)
     end
   end

--- a/test/surface/formatter_test.exs
+++ b/test/surface/formatter_test.exs
@@ -1523,10 +1523,43 @@ defmodule Surface.FormatterTest do
     )
   end
 
-  test "Multi-line strings in lists in attributes aren't indented every time the formatter is ran" do
+  test "Multi-line strings in attributes aren't indented every time the formatter is ran" do
+    # multiple attributes
+    assert_formatter_doesnt_change(~S"""
+    <div
+      class="test"
+      x-data={"{
+        foo: '#{@bar}',
+        baz: '#{@qux}'
+      }"}
+    />
+    """)
+
+    # single attribute
+    assert_formatter_doesnt_change(~S"""
+    <div x-data={"{
+      foo: '#{@bar}',
+      baz: '#{@qux}'
+    }"} />
+    """)
+
+    # nested multiline strings
+    assert_formatter_doesnt_change(~S"""
+    <div x-data={"{
+      foo: '#{@bar}',
+      baz: '#{"[
+        nested
+        multiline
+        string
+      ]"}'
+    }"} />
+    """)
+
+    # lists in attributes
     assert_formatter_doesnt_change(~S"""
     <Wrapper>
       <Wrapper>
+        {!-- indenting this component allowed us to reproduce a bug --}
         <First
           class={
             "w-full h-12 max-w-full px-4 bg-black-100 hover:bg-black-120 text-base leading-normal


### PR DESCRIPTION
Fixes formatting of multi-line strings in attribute expressions, e.g.

```html
<div
  class="test"
  x-data={"{
    foo: '#{@bar}',
    baz: '#{@qux}'
  }"}
/>
```

Prior to the patch, every time the formatter runs it will add an indentation level to the inner contents of the string. For example:

```html
x-data={"{
    foo: '#{@bar}',
    baz: '#{@qux}'
  }"}
```

```html
x-data={"{
      foo: '#{@bar}',
      baz: '#{@qux}'
    }"}
```

```html
x-data={"{
        foo: '#{@bar}',
        baz: '#{@qux}'
      }"}
```

The patched code is somewhat simpler because it turns out some nested conditional logic should not have been conditionally applied.