### PR TITLE
Support nested views

### DIFF
--- a/lib/surface/view.ex
+++ b/lib/surface/view.ex
@@ -88,8 +88,9 @@ defmodule Surface.View do
     view_name =
       module
       |> Module.split()
-      |> List.last()
-      |> Macro.underscore()
+      |> Enum.drop(1)
+      |> Enum.map(&Macro.underscore/1)
+      |> Enum.join("/")
       |> String.replace_trailing("_view", "")
 
     "#{root}/#{view_name}/*.sface"

--- a/test/support/view_test/templates/nested/foo/index.sface
+++ b/test/support/view_test/templates/nested/foo/index.sface
@@ -1,0 +1,1 @@
+Nested hello {@name}!

--- a/test/surface/view_test.exs
+++ b/test/surface/view_test.exs
@@ -1,17 +1,31 @@
+defmodule MyAppWeb.FooView do
+  use Phoenix.View, root: "test/support/view_test/templates"
+  use Surface.View, root: "test/support/view_test/templates"
+end
+
+defmodule MyAppWeb.Nested.FooView do
+  use Phoenix.View, root: "test/support/view_test/templates"
+  use Surface.View, root: "test/support/view_test/templates"
+end
+
 defmodule Surface.ViewTest do
   use ExUnit.Case, async: true
 
-  defmodule FooView do
-    use Phoenix.View, root: "test/support/view_test/templates"
-    use Surface.View, root: "test/support/view_test/templates"
-  end
-
   test "generates render/2 function for sface files found on templates folder" do
     result =
-      FooView.render("index.html", %{name: "world"})
+      MyAppWeb.FooView.render("index.html", %{name: "world"})
       |> Phoenix.HTML.Safe.to_iodata()
       |> IO.iodata_to_binary()
 
     assert result == "Hello world!\n"
+  end
+
+  test "supports nested views" do
+    result =
+      MyAppWeb.Nested.FooView.render("index.html", %{name: "world"})
+      |> Phoenix.HTML.Safe.to_iodata()
+      |> IO.iodata_to_binary()
+
+    assert result == "Nested hello world!\n"
   end
 end

--- a/test/surface/view_test.exs
+++ b/test/surface/view_test.exs
@@ -11,21 +11,23 @@ end
 defmodule Surface.ViewTest do
   use ExUnit.Case, async: true
 
-  test "generates render/2 function for sface files found on templates folder" do
-    result =
-      MyAppWeb.FooView.render("index.html", %{name: "world"})
-      |> Phoenix.HTML.Safe.to_iodata()
-      |> IO.iodata_to_binary()
+  describe "render/2" do
+    test "generates render/2 for sface files found on the templates folder" do
+      result =
+        MyAppWeb.FooView.render("index.html", %{name: "world"})
+        |> Phoenix.HTML.Safe.to_iodata()
+        |> IO.iodata_to_binary()
 
-    assert result == "Hello world!\n"
-  end
+      assert result == "Hello world!\n"
+    end
 
-  test "supports nested views" do
-    result =
-      MyAppWeb.Nested.FooView.render("index.html", %{name: "world"})
-      |> Phoenix.HTML.Safe.to_iodata()
-      |> IO.iodata_to_binary()
+    test "supports nested views" do
+      result =
+        MyAppWeb.Nested.FooView.render("index.html", %{name: "world"})
+        |> Phoenix.HTML.Safe.to_iodata()
+        |> IO.iodata_to_binary()
 
-    assert result == "Nested hello world!\n"
+      assert result == "Nested hello world!\n"
+    end
   end
 end


### PR DESCRIPTION
Adds support for views inside submodules, this was missing on https://github.com/surface-ui/surface/pull/543

After this change,  rendering a sface for `ExampleWeb.Foo.BarView` will look for templates on `lib/example_web/templates/foo/bar/*.sface`. Before the change, it'd search on `lib/example_web/templates/bar/*.sface`