### PR TITLE
Support Inputs' prop for as string

### DIFF
--- a/lib/surface/components/form/inputs.ex
+++ b/lib/surface/components/form/inputs.ex
@@ -18,9 +18,9 @@ defmodule Surface.Components.Form.Inputs do
   prop form, :form
 
   @doc """
-  The name of the field related to the child inputs.
+  An atom or string representing the name of the field related to the child inputs.
   """
-  prop for, :atom
+  prop for, :any
 
   @doc """
   Extra options for `inputs_for/3`.

--- a/lib/surface/components/form/inputs.ex
+++ b/lib/surface/components/form/inputs.ex
@@ -18,7 +18,7 @@ defmodule Surface.Components.Form.Inputs do
   prop form, :form
 
   @doc """
-  An atom or string representing the name of the field related to the child inputs.
+  An atom or string representing the field related to the child inputs.
   """
   prop for, :any
 

--- a/test/surface/components/form/inputs_test.exs
+++ b/test/surface/components/form/inputs_test.exs
@@ -143,4 +143,26 @@ defmodule Surface.Components.Form.InputsTest do
            </form>
            """
   end
+
+  test "property for as string" do
+    html =
+      render_surface do
+        ~F"""
+        <Form for={:parent} opts={csrf_token: "test"}>
+          <Inputs for="children">
+            <TextInput field="name" />
+            <TextInput field="email" />
+          </Inputs>
+        </Form>
+        """
+      end
+
+    assert html =~ """
+           <form action="#" method="post">
+               <input name="_csrf_token" type="hidden" value="test">
+             <input id="parent_children_name" name="parent[children][name]" type="text">
+             <input id="parent_children_email" name="parent[children][email]" type="text">
+           </form>
+           """
+  end
 end


### PR DESCRIPTION
The underlying phoenix's [inputs_for](https://github.com/phoenixframework/phoenix_html/blob/v3.2.0/lib/phoenix_html/form.ex#L438) function accepts it so we should accept it too.