### PR TITLE
fix set `@moduledoc false` in catalogue examples

### DIFF
--- a/lib/surface/catalogue.ex
+++ b/lib/surface/catalogue.ex
@@ -69,7 +69,11 @@ defmodule Surface.Catalogue do
   def get_metadata(module) do
     case Code.fetch_docs(module) do
       {:docs_v1, _, _, "text/markdown", docs, %{catalogue: meta}, _} ->
-        doc = Map.get(docs, "en")
+        doc =
+          if :hidden == docs,
+            do: "",
+            else: Map.get(docs, "en")
+
         meta |> Map.new() |> Map.put(:doc, doc)
 
       _ ->

--- a/test/support/catalogue/fake_example_moduledoc.ex
+++ b/test/support/catalogue/fake_example_moduledoc.ex
@@ -1,0 +1,13 @@
+defmodule Surface.Catalogue.FakeExampleModuleDocFalse do
+  @moduledoc false
+
+  use Surface.Catalogue.Example,
+    subject: Surface.Components.Form,
+    title: "A fake example"
+
+  def render(assigns) do
+    ~F"""
+    The code
+    """
+  end
+end

--- a/test/surface/catalogue/example_test.exs
+++ b/test/surface/catalogue/example_test.exs
@@ -2,6 +2,7 @@ defmodule Surface.Catalogue.ExampleTest do
   use ExUnit.Case
 
   alias Surface.Catalogue.FakeExample
+  alias Surface.Catalogue.FakeExampleModuleDocFalse
 
   test "saves subject as metadata" do
     meta = Surface.Catalogue.get_metadata(FakeExample)
@@ -19,6 +20,12 @@ defmodule Surface.Catalogue.ExampleTest do
     config = Surface.Catalogue.get_config(FakeExample)
 
     assert config[:title] == "A fake example"
+  end
+
+  test "saves render/1's content as metadata when moduledoc is false" do
+    meta = Surface.Catalogue.get_metadata(FakeExampleModuleDocFalse)
+
+    assert meta.code == "The code\n"
   end
 
   test "subject is required" do


### PR DESCRIPTION
To prevent receiving `:hidden`, instead of `%{"en" => "..."}` in
`Surface.Catalogue.get_metadata/1`, when using set `@moduledoc false`.