### PR TITLE
Install latest surface_catalogue on `surface.init --catalogue`

### DIFF
--- a/lib/mix/tasks/surface/surface.init/patches.ex
+++ b/lib/mix/tasks/surface/surface.init/patches.ex
@@ -165,7 +165,7 @@ defmodule Mix.Tasks.Surface.Init.Patches do
     %{
       name: "Add `surface_catalogue` dependency",
       update_deps: [:surface_catalogue],
-      patch: &Patchers.MixExs.add_dep(&1, ":surface_catalogue", ~S("~> 0.2.0")),
+      patch: &Patchers.MixExs.add_dep(&1, ":surface_catalogue", ~S("~> 0.3.0")),
       instructions: """
       Add `surface_catalogue` to the list of dependencies in `mix.exs`.
 
@@ -174,7 +174,7 @@ defmodule Mix.Tasks.Surface.Init.Patches do
       ```
       def deps do
         [
-          {:surface_catalogue, "~> 0.2.0"}
+          {:surface_catalogue, "~> 0.3.0"}
         ]
       end
       ```

--- a/test/mix/tasks/surface/util/patches_test.exs
+++ b/test/mix/tasks/surface/util/patches_test.exs
@@ -189,7 +189,7 @@ defmodule Mix.Tasks.Surface.Init.PatchesTest do
                    {:phoenix, "~> 1.6.0"},
                    {:surface, "~> 0.5.2"},
                    {:plug_cowboy, "~> 2.5"},
-                   {:surface_catalogue, "~> 0.2.0"}
+                   {:surface_catalogue, "~> 0.3.0"}
                  ]
                end
              end


### PR DESCRIPTION
I recently went through the setup guide and tried `mix surface.init --demo --catalogue`.
Using the latest at the moment versions of `surface` (v0.7+) and `phoenix_live_view` (v0.17+) it failed to install `surface_catalogue`.

This should fix the issue =)