### PR TITLE
Stop perpetually indenting expression strings with newlines

### DIFF
--- a/test/surface/formatter_test.exs
+++ b/test/surface/formatter_test.exs
@@ -1722,4 +1722,15 @@ defmodule Surface.FormatterTest do
       """
     )
   end
+
+  test "newlines in strings passed to function calls" do
+    assert_formatter_doesnt_change(~S"""
+    <div>
+      {foo("bar
+        baz
+        qux
+      ")}
+    </div>
+    """)
+  end
 end


### PR DESCRIPTION
### What is this?

This PR fixes a formatter bug reported here: https://github.com/surface-ui/surface_formatter/issues/59
And fixed separately in legacy `surface_formatter` package here: https://github.com/surface-ui/surface_formatter/pull/61

### What is the bug?

Any string with newlines inside of an expression (_not_ an attribute expression) would be indented further each time the formatter ran. Like this:

```elixir
{foo("bar
  baz
  qux
")}
```
```elixir
{foo("bar
    baz
    qux
  ")}
```
```elixir
{foo("bar
      baz
      qux
    ")}
```
```elixir
{foo("bar
        baz
        qux
      ")}