### PR TITLE
Test compiler errors

### DIFF
--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -667,8 +667,11 @@ defmodule Surface.Compiler do
     end
   end
 
-  defp convert_node_to_ast(:macro_component, {"#" <> name, attributes, children, node_meta}, compile_meta) do
-    node_alias = "#" <> name
+  defp convert_node_to_ast(
+         :macro_component,
+         {"#" <> name = node_alias, attributes, children, node_meta},
+         compile_meta
+       ) do
     meta = Helpers.to_meta(node_meta, compile_meta)
     mod = Helpers.actual_component_module!(name, meta.caller)
     meta = Map.merge(meta, %{module: mod, node_alias: node_alias})

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -668,12 +668,13 @@ defmodule Surface.Compiler do
   end
 
   defp convert_node_to_ast(:macro_component, {"#" <> name, attributes, children, node_meta}, compile_meta) do
+    node_alias = "#" <> name
     meta = Helpers.to_meta(node_meta, compile_meta)
     mod = Helpers.actual_component_module!(name, meta.caller)
-    meta = Map.merge(meta, %{module: mod, node_alias: name})
+    meta = Map.merge(meta, %{module: mod, node_alias: node_alias})
 
     with :ok <- Helpers.validate_component_module(mod, name),
-         meta <- Map.merge(meta, %{module: mod, node_alias: name}),
+         meta <- Map.merge(meta, %{module: mod, node_alias: node_alias}),
          true <- function_exported?(mod, :expand, 3),
          {:ok, directives, attributes} <-
            collect_directives(@meta_component_directive_handlers, attributes, meta),
@@ -683,10 +684,11 @@ defmodule Surface.Compiler do
       {:ok, %AST.Container{children: List.wrap(expanded_children), directives: directives, meta: meta}}
     else
       false ->
-        {:error, {"cannot render <#{name}> (MacroComponents must export an expand/3 function)", meta.line}, meta}
+        {:error, {"cannot render <#{node_alias}> (MacroComponents must export an expand/3 function)", meta.line},
+         meta}
 
       error ->
-        handle_convert_node_to_ast_error(name, error, meta)
+        handle_convert_node_to_ast_error(node_alias, error, meta)
     end
   end
 

--- a/test/surface/compiler_test.exs
+++ b/test/surface/compiler_test.exs
@@ -1046,6 +1046,29 @@ defmodule Surface.CompilerSyncTest do
     assert extract_line(output) == 6
   end
 
+  test "VoidTag is a valid HTML root element" do
+    id = :erlang.unique_integer([:positive]) |> to_string()
+
+    view_code = """
+    defmodule TestLiveComponent_#{id} do
+      use Surface.LiveComponent
+
+      def render(assigns) do
+        ~F"\""
+        <br />
+        "\""
+      end
+    end
+    """
+
+    output =
+      capture_io(:standard_error, fn ->
+        {{:module, _, _, _}, _} = Code.eval_string(view_code, [], %{__ENV__ | file: "code.exs", line: 1})
+      end)
+
+    refute output =~ "stateful live components must have a HTML root element"
+  end
+
   test "warning on component with required slot that has a default value" do
     id = :erlang.unique_integer([:positive]) |> to_string()
 

--- a/test/surface/integrations/slot_test.exs
+++ b/test/surface/integrations/slot_test.exs
@@ -1486,4 +1486,24 @@ defmodule Surface.SlotSyncTest do
            ```
            """
   end
+
+  test "use slot entry in element that is not a component" do
+    code = ~s[
+    ~F"""
+    <div>
+      <:body />
+    </div>
+    """
+    ]
+
+    output =
+      capture_io(:standard_error, fn ->
+        Code.eval_string(code, [assigns: %{}], %{__ENV__ | file: "code.exs", line: 1})
+      end)
+
+    assert output =~ ~r"""
+           cannot render <div> \(slot entries are only allowed as children elements of components, but found slot entry for body\)
+             code.exs:3:\
+           """
+  end
 end


### PR DESCRIPTION
Test compiler errors with macro and slot
In macro include `#` in the `node_alias` 