### PR TITLE
Validate components calls required attributes on mix compile task

### DIFF
--- a/lib/mix/tasks/compile/surface.ex
+++ b/lib/mix/tasks/compile/surface.ex
@@ -17,7 +17,11 @@ defmodule Mix.Tasks.Compile.Surface do
   def run(args) do
     {compile_opts, _argv, _err} = OptionParser.parse(args, strict: @switches)
 
-    Mix.Tasks.Compile.Surface.AssetGenerator.run()
+    [
+      Mix.Tasks.Compile.Surface.ValidateComponents.validate(project_modules()),
+      Mix.Tasks.Compile.Surface.AssetGenerator.run()
+    ]
+    |> List.flatten()
     |> handle_diagnostics(compile_opts)
   end
 
@@ -35,10 +39,30 @@ defmodule Mix.Tasks.Compile.Surface do
     end
   end
 
-  defp print_diagnostics(diagnostics) do
-    for %Diagnostic{message: message, severity: :warning} <- diagnostics do
-      IO.warn(message, [])
+  def project_modules do
+    files = Mix.Project.compile_path() |> File.ls!() |> Enum.sort()
+
+    for file <- files, [basename, ""] <- [:binary.split(file, ".beam")] do
+      String.to_atom(basename)
     end
+  end
+
+  defp print_diagnostics(diagnostics) do
+    for %Diagnostic{message: message, severity: severity, file: file, position: position} <- diagnostics do
+      print_diagnostic(message, severity, file, position)
+    end
+  end
+
+  defp print_diagnostic(message, :warning, _file, _line), do: IO.warn(message, [])
+
+  defp print_diagnostic(message, :error, file, line) do
+    error = IO.ANSI.format([:red, "error: "])
+
+    stacktrace =
+      "  #{file}" <>
+        if(line, do: ":#{line}", else: "")
+
+    IO.puts(:stderr, [error, message, ?\n, stacktrace])
   end
 
   defp status(warnings_as_errors, diagnostics) do

--- a/lib/mix/tasks/compile/surface/validate_components.ex
+++ b/lib/mix/tasks/compile/surface/validate_components.ex
@@ -1,0 +1,68 @@
+defmodule Mix.Tasks.Compile.Surface.ValidateComponents do
+  alias Mix.Task.Compiler.Diagnostic
+  alias Surface.AST
+  alias Surface.Compiler.Helpers
+
+  def validate(modules) do
+    for module <- modules,
+        Code.ensure_loaded?(module),
+        function_exported?(module, :__components_calls__, 0) do
+      check_components_calls(module)
+    end
+    |> List.flatten()
+  end
+
+  defp check_components_calls(module) do
+    components_calls = module.__components_calls__()
+    file = module.module_info() |> get_in([:compile, :source]) |> to_string()
+
+    for component_call <- components_calls do
+      validate_properties(file, component_call)
+    end
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp validate_properties(file, component_call) do
+    module = component_call.component
+    props = component_call.props
+    node_alias = component_call.node_alias
+    line = component_call.line
+    directives = component_call.directives
+
+    has_directive_props? = Enum.any?(directives, &match?(%AST.Directive{name: :props}, &1))
+
+    if not has_directive_props? and function_exported?(module, :__props__, 0) do
+      existing_props_names = Enum.map(props, & &1.name)
+      required_props_names = module.__required_props_names__()
+      missing_props_names = required_props_names -- existing_props_names
+
+      for prop_name <- missing_props_names do
+        message = "Missing required property \"#{prop_name}\" for component <#{node_alias}>"
+
+        message =
+          if prop_name == :id and Helpers.is_stateful_component(module) do
+            message <>
+              """
+              \n\nHint: Components using `Surface.LiveComponent` automatically define a required `id` prop to make them stateful.
+              If you meant to create a stateless component, you can switch to `use Surface.Component`.
+              """
+          else
+            message
+          end
+
+        error(message, file, line)
+      end
+    end
+  end
+
+  defp error(message, file, line) do
+    # TODO: Provide column information in diagnostic once we depend on Elixir v1.13+
+    %Diagnostic{
+      compiler_name: "Surface",
+      file: file,
+      message: message,
+      position: line,
+      severity: :error
+    }
+  end
+end

--- a/lib/surface/ast.ex
+++ b/lib/surface/ast.ex
@@ -6,16 +6,18 @@ defmodule Surface.AST.Container do
 
   ## Properties
       * `:children` - children AST nodes
+      * `:attributes` - the specified attributes
       * `:directives` - directives associated with this container
       * `:meta` - compile meta
       * `:debug` - keyword list indicating when debug information should be printed during compilation
   """
-  defstruct [:children, :meta, debug: [], directives: []]
+  defstruct [:children, :meta, debug: [], attributes: [], directives: []]
 
   @type t :: %__MODULE__{
           children: list(Surface.AST.t()),
           debug: list(atom()),
           meta: Surface.AST.Meta.t(),
+          attributes: list(Surface.AST.Attribute.t()),
           directives: list(Surface.AST.Directive.t())
         }
 end
@@ -427,12 +429,14 @@ defmodule Surface.AST.Error do
   ## Properties
       * `:message` - the error message
       * `:meta` - compilation meta data
+      * `:attributes` - the specified attributes
       * `:directives` - directives associated with this error node
   """
-  defstruct [:message, :meta, directives: []]
+  defstruct [:message, :meta, attributes: [], directives: []]
 
   @type t :: %__MODULE__{
           message: binary(),
+          attributes: list(Surface.AST.Attribute.t()),
           directives: list(Surface.AST.Directive.t()),
           meta: Surface.AST.Meta.t()
         }

--- a/lib/surface/base_component.ex
+++ b/lib/surface/base_component.ex
@@ -26,7 +26,7 @@ defmodule Surface.BaseComponent do
       import Surface
       @behaviour unquote(__MODULE__)
 
-      Module.register_attribute(__MODULE__, :__injected_components__, accumulate: true)
+      Module.register_attribute(__MODULE__, :__components_calls__, accumulate: true)
 
       @before_compile unquote(__MODULE__)
 
@@ -54,10 +54,10 @@ defmodule Surface.BaseComponent do
   defmacro __before_compile__(env) do
     components =
       env.module
-      |> Module.get_attribute(:__injected_components__, [])
-      |> Enum.uniq_by(fn {comp, _line} -> comp end)
+      |> Module.get_attribute(:__components_calls__, [])
+      |> Enum.uniq_by(& &1.component)
 
-    for {mod, line} <- components, mod != env.module do
+    for %{component: mod, line: line} <- components, mod != env.module do
       quote line: line do
         require(unquote(mod)).__info__(:module)
       end

--- a/lib/surface/compiler/eex_engine.ex
+++ b/lib/surface/compiler/eex_engine.ex
@@ -787,11 +787,12 @@ defmodule Surface.Compiler.EExEngine do
                module: mod,
                line: line
              } = meta
-         }
+         } = component
          | nodes
        ])
        when not is_nil(mod) do
-    store_component_call(meta.caller.module, mod, line)
+    %{attributes: attributes, directives: directives, meta: %{node_alias: node_alias}} = component
+    store_component_call(meta.caller.module, node_alias, mod, attributes, directives, line)
     [to_dynamic_nested_html(children) | to_dynamic_nested_html(nodes)]
   end
 
@@ -869,13 +870,19 @@ defmodule Surface.Compiler.EExEngine do
         {requires, Map.put(by_name, name, Enum.reverse(slot_entries))}
       end)
 
-    store_component_call(component.meta.caller.module, mod, component.meta.line)
+    %{caller: caller, node_alias: node_alias, line: line} = component.meta
+    %{props: props, directives: directives} = component
+    store_component_call(caller.module, node_alias, mod, props, directives, line)
     [requires, %{component | slot_entries: slot_entries_by_name} | to_dynamic_nested_html(nodes)]
   end
 
-  defp to_dynamic_nested_html([%AST.Error{message: message, meta: %AST.Meta{module: module} = meta} | nodes])
+  defp to_dynamic_nested_html([
+         %AST.Error{message: message, meta: %AST.Meta{module: module, node_alias: node_alias} = meta} = component
+         | nodes
+       ])
        when not is_nil(module) do
-    store_component_call(meta.caller.module, module, meta.line)
+    %{attributes: attributes, directives: directives} = component
+    store_component_call(meta.caller.module, node_alias, module, attributes, directives, meta.line)
 
     [
       ~S(<span style="color: red; border: 2px solid red; padding: 3px"> Error: ),
@@ -1034,10 +1041,10 @@ defmodule Surface.Compiler.EExEngine do
     |> Macro.var(caller.module)
   end
 
-  defp store_component_call(module, component, line) do
+  defp store_component_call(module, node_alias, component, props, directives, line) do
     # No need to store dynamic modules
     if !match?(%Surface.AST.AttributeExpr{}, component) do
-      call = %{component: component, line: line}
+      call = %{node_alias: node_alias, component: component, props: props, directives: directives, line: line}
       Module.put_attribute(module, :__components_calls__, call)
     end
   end

--- a/test/mix/tasks/compile/surface/validate_components_test.exs
+++ b/test/mix/tasks/compile/surface/validate_components_test.exs
@@ -1,0 +1,202 @@
+defmodule Mix.Tasks.Compile.Surface.ValidateComponentsTest do
+  use ExUnit.Case, async: false
+
+  alias Mix.Tasks.Compile.Surface.ValidateComponents
+  alias Mix.Task.Compiler.Diagnostic
+
+  defmodule RequiredPropTitle do
+    use Surface.Component
+    prop title, :string, required: true
+    def render(assigns), do: ~F"{@title}"
+  end
+
+  defmodule MissingRequiredProp do
+    use Surface.Component
+
+    def line, do: __ENV__.line + 4
+
+    def render(assigns) do
+      ~F"""
+      <RequiredPropTitle />
+      """
+    end
+  end
+
+  test "should return diagnostic when missing required prop" do
+    diagnostics = ValidateComponents.validate([MissingRequiredProp])
+    file = to_string(MissingRequiredProp.module_info(:compile)[:source])
+
+    assert diagnostics == [
+             %Diagnostic{
+               compiler_name: "Surface",
+               details: nil,
+               file: file,
+               message: "Missing required property \"title\" for component <RequiredPropTitle>",
+               position: MissingRequiredProp.line(),
+               severity: :error
+             }
+           ]
+  end
+
+  defmodule PropsDirective do
+    use Surface.Component
+
+    def render(assigns) do
+      ~F"""
+      <RequiredPropTitle :props={%{}}/>
+      <RequiredPropTitle {...%{}} />
+      """
+    end
+  end
+
+  test "should not return diagnostic when :props directive is present" do
+    diagnostics = ValidateComponents.validate([PropsDirective])
+    assert diagnostics == []
+  end
+
+  defmodule LiveComponentHasRequiredIdProp do
+    use Surface.LiveComponent
+    def render(assigns), do: ~F"<div />"
+  end
+
+  defmodule MissingIdForLiveComponent do
+    use Surface.Component
+
+    def line, do: __ENV__.line + 4
+
+    def render(assigns) do
+      ~F"""
+      <LiveComponentHasRequiredIdProp />
+      """
+    end
+  end
+
+  test "should return diagnostic when missing automatically define id prop for LiveComponent" do
+    diagnostics = ValidateComponents.validate([MissingIdForLiveComponent])
+    file = to_string(MissingIdForLiveComponent.module_info(:compile)[:source])
+
+    assert diagnostics == [
+             %Mix.Task.Compiler.Diagnostic{
+               compiler_name: "Surface",
+               details: nil,
+               file: file,
+               message: ~S"""
+               Missing required property "id" for component <LiveComponentHasRequiredIdProp>
+
+               Hint: Components using `Surface.LiveComponent` automatically define a required `id` prop to make them stateful.
+               If you meant to create a stateless component, you can switch to `use Surface.Component`.
+               """,
+               position: MissingIdForLiveComponent.line(),
+               severity: :error
+             }
+           ]
+  end
+
+  defmodule MacroWithRequiredPropTitle do
+    use Surface.MacroComponent
+    prop title, :string, required: true
+    prop body, :string, required: true
+
+    def expand(attributes, content, _meta) do
+      title = Surface.AST.find_attribute_value(attributes, :title)
+      body = Surface.AST.find_attribute_value(attributes, :body)
+
+      quote_surface do
+        ~F"""
+        {^title}
+        {^body}
+        """
+      end
+    end
+  end
+
+  defmodule MissingRequiredPropForMacro do
+    use Surface.Component
+
+    alias MacroWithRequiredPropTitle, as: Macro
+    def line, do: __ENV__.line + 4
+
+    def render(assigns) do
+      ~F"""
+      <#Macro body="body text" />
+      """
+    end
+  end
+
+  test "should return diagnostic when missing required prop for macro component" do
+    diagnostics = ValidateComponents.validate([MissingRequiredPropForMacro])
+    file = to_string(MissingRequiredPropForMacro.module_info(:compile)[:source])
+
+    assert diagnostics == [
+             %Diagnostic{
+               compiler_name: "Surface",
+               details: nil,
+               file: file,
+               message: "Missing required property \"title\" for component <#Macro>",
+               position: MissingRequiredPropForMacro.line(),
+               severity: :error
+             }
+           ]
+  end
+
+  defmodule PassingRequiredPropForMacro do
+    use Surface.Component
+
+    alias MacroWithRequiredPropTitle, as: Macro
+    def line, do: __ENV__.line + 4
+
+    def render(assigns) do
+      ~F"""
+      <#Macro title="title text" body="body text" />
+      """
+    end
+  end
+
+  test "should not return diagnostic when required prop is passed to macro component" do
+    diagnostics = ValidateComponents.validate([PassingRequiredPropForMacro])
+    assert diagnostics == []
+  end
+
+  defmodule Recursive do
+    use Surface.Component
+
+    prop list, :list, required: true
+
+    def render(%{list: [item | rest]} = assigns) do
+      ~F"""
+      {item}
+      <Recursive list={rest} />
+      """
+    end
+
+    def render(assigns), do: ~F""
+  end
+
+  defmodule MissingRequiredPropForRecursiveComponent do
+    use Surface.Component
+
+    def line, do: __ENV__.line + 4
+
+    def render(assigns) do
+      ~F"""
+      <Recursive />
+      """
+    end
+  end
+
+  test "should return diagnostic when missing required prop for recursive component" do
+    diagnostics = ValidateComponents.validate([MissingRequiredPropForRecursiveComponent])
+    file = to_string(MissingRequiredPropForRecursiveComponent.module_info(:compile)[:source])
+
+    assert diagnostics == [
+             %Diagnostic{
+               compiler_name: "Surface",
+               details: nil,
+               file: file,
+               message: "Missing required property \"list\" for component <Recursive>",
+               position: MissingRequiredPropForRecursiveComponent.line(),
+               severity: :error
+             }
+           ]
+  end
+end

--- a/test/surface/compiler_test.exs
+++ b/test/surface/compiler_test.exs
@@ -4,12 +4,17 @@ defmodule Surface.CompilerTest do
   defmodule Macro do
     use Surface.MacroComponent
 
-    def expand(_, _, meta) do
+    prop text, :string, required: true
+
+    def expand(attributes, _, meta) do
+      text = Surface.AST.find_attribute_value(attributes, :text).value
+      capitalized_text = String.capitalize(text)
+
       %Surface.AST.Tag{
         element: "div",
         directives: [],
         attributes: [],
-        children: ["I'm a macro"],
+        children: [capitalized_text],
         meta: meta
       }
     end
@@ -464,7 +469,7 @@ defmodule Surface.CompilerTest do
   describe "macro components" do
     test "expanded at top level" do
       code = """
-      <#Macro />
+      <#Macro text="i'm a macro" />
       """
 
       [node | _] = Surface.Compiler.compile(code, 1, __ENV__)
@@ -474,7 +479,7 @@ defmodule Surface.CompilerTest do
 
     test "expanded within a component" do
       code = """
-      <Div><#Macro></#Macro></Div>
+      <Div><#Macro text="i'm a macro"></#Macro></Div>
       """
 
       [node | _] = Surface.Compiler.compile(code, 1, __ENV__)
@@ -503,7 +508,7 @@ defmodule Surface.CompilerTest do
 
     test "expanded within an html tag" do
       code = """
-      <div><#Macro /></div>
+      <div><#Macro text="i'm a macro"/></div>
       """
 
       [node | _] = Surface.Compiler.compile(code, 1, __ENV__)
@@ -516,6 +521,12 @@ defmodule Surface.CompilerTest do
                  }
                ]
              } = node
+    end
+
+    test "should render an error without required prop" do
+      code = "<#Macro />"
+      [node | _] = Surface.Compiler.compile(code, 1, __ENV__)
+      assert %Surface.AST.Error{directives: [], message: "cannot render <#Macro> (missing required props)"} = node
     end
   end
 
@@ -824,42 +835,6 @@ defmodule Surface.CompilerSyncTest do
 
     assert message =~ ~S(undefined assign `@assign`.)
     assert line == 2
-  end
-
-  test "warning on missing required property" do
-    code = """
-    <Column />
-    """
-
-    {:warn, line, message} = run_compile(code, __ENV__)
-
-    assert message =~ ~S(Missing required property "title" for component <Column>)
-    assert line == 1
-  end
-
-  test "warning on missing id for LiveComponent" do
-    code = """
-    <GridLive />
-    """
-
-    {:warn, line, message} = run_compile(code, __ENV__)
-
-    assert message =~ ~S"""
-           Missing required property "id" for component <GridLive>
-
-           Hint: Components using `Surface.LiveComponent` automatically define a required `id` prop to make them stateful.
-           If you meant to create a stateless component, you can switch to `use Surface.Component`.
-           """
-
-    assert line == 1
-  end
-
-  test "disable warning on missing required property when :props is passed" do
-    code = """
-    <Column :props={title: "My Title"}/>
-    """
-
-    assert {:ok, _result} = run_compile(code, __ENV__)
   end
 
   test "warning on stateful components with more than one root element" do


### PR DESCRIPTION
- Renames `__injected_components__` to `__components_calls__`
- Moves validations of required props to the mix task and generate `%Diagnostics` with the `:error` `severity`.
- Macro components won't be expanded without all required props, the errors will come from the mix task


