### PR TITLE
add some missing void tags (per w3.org)

### DIFF
--- a/lib/surface/compiler/tokenizer.ex
+++ b/lib/surface/compiler/tokenizer.ex
@@ -14,15 +14,18 @@ defmodule Surface.Compiler.Tokenizer do
     "base",
     "br",
     "col",
+    "command",
+    "embed",
     "hr",
     "img",
     "input",
+    "keygen",
     "link",
     "meta",
     "param",
-    "command",
-    "keygen",
-    "source"
+    "source",
+    "track",
+    "wbr"
   ]
 
   @type metadata :: %{

--- a/test/surface/compiler/tokenizer_test.exs
+++ b/test/surface/compiler/tokenizer_test.exs
@@ -286,6 +286,11 @@ defmodule Surface.Compiler.TokenizerTest do
       assert [{:tag_open, "#Macro", [], %{self_close: true, macro?: true}}] = tokens
     end
 
+    test "void tag" do
+      tokens = tokenize!("<embed>")
+      assert [{:tag_open, "embed", [], %{void_tag?: true}}] = tokens
+    end
+
     test "compute line and column" do
       tokens =
         tokenize!("""

--- a/test/surface/formatter_test.exs
+++ b/test/surface/formatter_test.exs
@@ -1401,6 +1401,12 @@ defmodule Surface.FormatterTest do
     """)
   end
 
+  test "void tags are preserved" do
+    assert_formatter_doesnt_change("""
+    <embed>
+    """)
+  end
+
   test "indent option" do
     assert_formatter_outputs(
       """


### PR DESCRIPTION
(ref https://www.w3.org/TR/2014/REC-html5-20141028/syntax.html#void-elements -- note that the `command` element is not in that list, but it is used as a void element in the examples here: https://www.w3.org/TR/2011/WD-html5-author-20110809/the-command-element.html.  🤷 )

We ran into a problem with the `embed` element, which seems to be missing from the list of void elements.  Without this change, the formatter re-formats `<embed />` as `<embed>`, and then subsequent formats blow up because the embed has no end tag.