### PR TITLE
Patch live reload pattern for surface layouts

### DIFF
--- a/lib/mix/tasks/surface/surface.init/project_patchers/common.ex
+++ b/lib/mix/tasks/surface/surface.init/project_patchers/common.ex
@@ -17,7 +17,8 @@ defmodule Mix.Tasks.Surface.Init.ProjectPatchers.Common do
     [
       {:patch, "config/dev.exs",
        [
-         add_surface_live_reload_pattern_to_endpoint_config(context_app, web_module, web_path)
+         add_surface_live_reload_pattern_to_endpoint_config(context_app, web_module, web_path),
+         add_surface_live_reload_template_pattern_to_endpoint_config(context_app, web_module, web_path)
        ]},
       {:patch, web_module_path,
        [
@@ -34,12 +35,12 @@ defmodule Mix.Tasks.Surface.Init.ProjectPatchers.Common do
           &1,
           ~s[~r"#{web_path}/(live|views)/.*(ex)$"],
           ~s[~r"#{web_path}/(live|views|components)/.*(ex|sface|js)$"],
-          "sface",
+          "ex|sface|js",
           context_app,
           web_module
         ),
       instructions: """
-      Update the :reload_patterns entry to include surface-related files.
+      Update the :reload_patterns entry to include surface related files.
 
       # Example
 
@@ -48,6 +49,36 @@ defmodule Mix.Tasks.Surface.Init.ProjectPatchers.Common do
         live_reload: [
           patterns: [
             ~r"lib/my_app_web/(live|views|components)/.*(ex|sface|js)$",
+            ...
+          ]
+        ]
+      ```
+      """
+    }
+  end
+
+  def add_surface_live_reload_template_pattern_to_endpoint_config(context_app, web_module, web_path) do
+    %{
+      name: "Update template patterns in :reload_patterns",
+      patch:
+        &FilePatchers.Phoenix.replace_live_reload_pattern_in_endpoint_config(
+          &1,
+          ~s[~r"#{web_path}/templates/.*(eex)$"],
+          ~s[~r"#{web_path}/templates/.*(eex|sface)$"],
+          "eex|sface",
+          context_app,
+          web_module
+        ),
+      instructions: """
+      Update the :reload_patterns template entry to include surface related files.
+
+      # Example
+
+      ```
+      config :my_app, MyAppWeb.Endpoint,
+        live_reload: [
+          patterns: [
+            ~r"lib/my_app_web/templates/.*(eex|sface)$"
             ...
           ]
         ]

--- a/test/mix/tasks/surface/surface.init/project_patchers/common_test.exs
+++ b/test/mix/tasks/surface/surface.init/project_patchers/common_test.exs
@@ -64,6 +64,66 @@ defmodule Mix.Tasks.Surface.Init.ProjectPatchers.CommonTest do
     end
   end
 
+  describe "add_surface_live_reload_template_pattern_to_endpoint_config" do
+    test "update live_reload patterns" do
+      code = """
+      import Config
+
+      # Watch static and templates for browser reloading.
+      config :my_app, MyAppWeb.Endpoint,
+        reloadable_compilers: [:phoenix, :elixir, :surface],
+        live_reload: [
+          patterns: [
+            ~r"lib/my_app_web/(live|views)/.*(ex)$",
+            ~r"lib/my_app_web/templates/.*(eex)$"
+          ]
+        ]
+      """
+
+      {:patched, updated_code} =
+        Patcher.patch_code(
+          code,
+          add_surface_live_reload_template_pattern_to_endpoint_config(:my_app, MyAppWeb, "lib/my_app_web")
+        )
+
+      assert updated_code == """
+             import Config
+
+             # Watch static and templates for browser reloading.
+             config :my_app, MyAppWeb.Endpoint,
+               reloadable_compilers: [:phoenix, :elixir, :surface],
+               live_reload: [
+                 patterns: [
+                   ~r"lib/my_app_web/(live|views)/.*(ex)$",
+                   ~r"lib/my_app_web/templates/.*(eex|sface)$"
+                 ]
+               ]
+             """
+    end
+
+    test "don't apply it if already patched" do
+      code = """
+      import Config
+
+      # Watch static and templates for browser reloading.
+      config :my_app, MyAppWeb.Endpoint,
+        reloadable_compilers: [:phoenix, :elixir, :surface],
+        live_reload: [
+          patterns: [
+            ~r"lib/my_app_web/(live|views)/.*(ex)$",
+            ~r"lib/my_app_web/templates/.*(eex|sface)$"
+          ]
+        ]
+      """
+
+      assert {:already_patched, ^code} =
+               Patcher.patch_code(
+                 code,
+                 add_surface_live_reload_template_pattern_to_endpoint_config(:my_app, MyAppWeb, "lib/my_app_web")
+               )
+    end
+  end
+
   describe "add_import_surface_to_view_macro" do
     test "add import Surface" do
       code = """


### PR DESCRIPTION
This assumes that the reload pattern should be applied regardless of whether the `--layout` option is used.

Fixes issue #596