### PR TITLE
use AST.MacroComponent so that AST.Container don't store component call

### DIFF
--- a/lib/surface/ast.ex
+++ b/lib/surface/ast.ex
@@ -512,11 +512,11 @@ defmodule Surface.AST.MacroComponent do
       * `:module` - the component module
       * `:attributes` - the specified attributes
       * `:directives` - any directives to be applied to this macro
-      * `:body` - the macro body
+      * `:children` - the children after the macro is expanded
       * `:meta` - compilation meta data
       * `:debug` - keyword list indicating when debug information should be printed during compilation
   """
-  defstruct [:module, :name, :attributes, :body, :meta, debug: [], directives: []]
+  defstruct [:module, :name, :attributes, :children, :meta, debug: [], directives: []]
 
   @type t :: %__MODULE__{
           module: module(),
@@ -524,7 +524,7 @@ defmodule Surface.AST.MacroComponent do
           name: binary(),
           attributes: list(Surface.AST.Attribute.t()),
           directives: list(Surface.AST.Directive.t()),
-          body: iodata(),
+          children: list(Surface.AST.t()),
           meta: Surface.AST.Meta.t()
         }
 end

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -686,7 +686,7 @@ defmodule Surface.Compiler do
           expanded_children = mod.expand(attributes, List.to_string(children), meta)
 
           {:ok,
-           %AST.Container{
+           %AST.MacroComponent{
              attributes: attributes,
              children: List.wrap(expanded_children),
              directives: directives,

--- a/lib/surface/compiler/eex_engine.ex
+++ b/lib/surface/compiler/eex_engine.ex
@@ -780,7 +780,7 @@ defmodule Surface.Compiler.EExEngine do
   end
 
   defp to_dynamic_nested_html([
-         %AST.Container{
+         %AST.MacroComponent{
            children: children,
            meta:
              %AST.Meta{

--- a/test/surface/compiler_test.exs
+++ b/test/surface/compiler_test.exs
@@ -474,7 +474,8 @@ defmodule Surface.CompilerTest do
 
       [node | _] = Surface.Compiler.compile(code, 1, __ENV__)
 
-      assert %Surface.AST.Container{children: [%Surface.AST.Tag{children: ["I'm a macro"], element: "div"}]} = node
+      assert %Surface.AST.MacroComponent{children: [%Surface.AST.Tag{children: ["I'm a macro"], element: "div"}]} =
+               node
     end
 
     test "expanded within a component" do
@@ -491,7 +492,7 @@ defmodule Surface.CompilerTest do
                  default: [
                    %Surface.AST.SlotEntry{
                      children: [
-                       %Surface.AST.Container{
+                       %Surface.AST.MacroComponent{
                          children: [
                            %Surface.AST.Tag{
                              children: ["I'm a macro"],
@@ -516,7 +517,7 @@ defmodule Surface.CompilerTest do
       assert %Surface.AST.Tag{
                element: "div",
                children: [
-                 %Surface.AST.Container{
+                 %Surface.AST.MacroComponent{
                    children: [%Surface.AST.Tag{children: ["I'm a macro"], element: "div"}]
                  }
                ]

--- a/test/surface/integrations/transform_test.exs
+++ b/test/surface/integrations/transform_test.exs
@@ -159,7 +159,7 @@ defmodule Surface.TransformTest do
 
     refute_receive {MacroDivToSpan, "transforming node"}
 
-    assert %Surface.AST.Container{} = node
+    assert %Surface.AST.MacroComponent{} = node
   end
 
   test "transform is not run on parse errors" do


### PR DESCRIPTION
To remove validations of missing props on `{#else}` 

```sface
~F"""
<Surface.Components.Link.Button to="...">
{#if @condition}
  true
{#else}
  false
{/if}
</Surface.Components.Link.Button>
"""
```