### PR TITLE
Validate "no root property" on mix compiler

### DIFF
--- a/lib/surface/ast.ex
+++ b/lib/surface/ast.ex
@@ -211,15 +211,17 @@ defmodule Surface.AST.Attribute do
       * `:type` - an atom representing the type of attribute. See Surface.API for the list of supported types
       * `:type_opts` - a keyword list of options for the type
       * `:name` - the name of the attribute (e.g. `:class`)
+      * `:root` - true if the attribute was defined using root notation `{ ... }`. Root attributes won't have `name`.
       * `:value` - a list of nodes that can be concatenated to form the value for this attribute. Potentially contains dynamic data
       * `:meta` - compilation meta data
   """
-  defstruct [:name, :type, :type_opts, :value, :meta]
+  defstruct [:name, :root, :type, :type_opts, :value, :meta]
 
   @type t :: %__MODULE__{
-          type: atom(),
-          type_opts: keyword(),
-          name: atom(),
+          type: atom() | nil,
+          type_opts: keyword() | nil,
+          name: atom() | nil,
+          root: boolean() | nil,
           value: Surface.AST.Literal.t() | Surface.AST.AttributeExpr.t(),
           meta: Surface.AST.Meta.t()
         }

--- a/lib/surface/compiler/eex_engine.ex
+++ b/lib/surface/compiler/eex_engine.ex
@@ -483,7 +483,15 @@ defmodule Surface.Compiler.EExEngine do
   defp collect_component_props(module, attrs) do
     {props, props_acc} =
       Enum.reduce(attrs, {[], %{}}, fn attr, {props, props_acc} ->
-        %AST.Attribute{name: prop_name, type: type, type_opts: type_opts, value: expr} = attr
+        %AST.Attribute{root: root, value: expr} = attr
+
+        {prop_name, type, type_opts} =
+          with true <- root,
+               root_prop when not is_nil(root_prop) <- Enum.find(module.__props__(), & &1.opts[:root]) do
+            {root_prop.name, root_prop.type, root_prop.opts}
+          else
+            _ -> {attr.name, attr.type, attr.type_opts}
+          end
 
         cond do
           module && !module.__validate_prop__(prop_name) ->

--- a/test/mix/tasks/compile/surface/validate_components_test.exs
+++ b/test/mix/tasks/compile/surface/validate_components_test.exs
@@ -239,6 +239,37 @@ defmodule Mix.Tasks.Compile.Surface.ValidateComponentsTest do
            ]
   end
 
+  defmodule StringProp do
+    use Surface.Component
+    prop text, :string
+    def render(assigns), do: ~F[{@text}]
+  end
+
+  test "should return diagnostic when passing a root prop and the component doesn't have one" do
+    component =
+      quote do
+        ~F[<StringProp {"first"} />]
+      end
+      |> compile_surface()
+
+    diagnostics = ValidateComponents.validate([component])
+
+    assert diagnostics == [
+             %Diagnostic{
+               compiler_name: "Surface",
+               details: nil,
+               file: Path.expand("code"),
+               message: """
+               no root property defined for component <StringProp>
+
+               Hint: you can declare a root property using option `root: true`
+               """,
+               position: 0,
+               severity: :warning
+             }
+           ]
+  end
+
   defmodule AccumulateProp do
     use Surface.Component
 

--- a/test/surface/compiler_test.exs
+++ b/test/surface/compiler_test.exs
@@ -240,8 +240,7 @@ defmodule Surface.CompilerTest do
              module: Surface.CompilerTest.Button,
              props: [
                %Surface.AST.Attribute{
-                 name: :label,
-                 type: :string,
+                 root: true,
                  value: %Surface.AST.AttributeExpr{
                    original: "\"click\""
                  }

--- a/test/surface/integrations/properties_test.exs
+++ b/test/surface/integrations/properties_test.exs
@@ -817,30 +817,4 @@ defmodule Surface.PropertiesSyncTest do
            prop `invalid_acc2` default value `3` must be a list when `accumulate: true`
            """
   end
-
-  test "warn if component does not accept a root property" do
-    assigns = %{label: "root"}
-
-    code =
-      quote do
-        ~F"""
-        <StringProp
-          {@label}
-        />
-        """
-      end
-
-    output =
-      capture_io(:standard_error, fn ->
-        compile_surface(code, assigns)
-      end)
-
-    assert output =~ ~r"""
-           no root property defined for component <StringProp>
-
-           Hint: you can declare a root property using option `root: true`
-
-             code:2:\
-           """
-  end
 end

--- a/test/surface/integrations/properties_test.exs
+++ b/test/surface/integrations/properties_test.exs
@@ -113,6 +113,21 @@ defmodule Surface.PropertiesTest do
     end
   end
 
+  defmodule RootGeneratorProp do
+    use Surface.Component
+
+    prop labels, :list, root: true
+    slot default, args: [label: ^labels]
+
+    def render(assigns) do
+      ~F"""
+      {#for label <- @labels}
+        <#slot :args={label: label} />
+      {/for}
+      """
+    end
+  end
+
   describe "atom" do
     test "passing an atom" do
       html =
@@ -658,6 +673,22 @@ defmodule Surface.PropertiesTest do
 
       assert html =~ """
              Label
+             """
+    end
+
+    test "component accepts root generator property" do
+      html =
+        render_surface do
+          ~F"""
+          <RootGeneratorProp {label <- ["Label1", "Label2"]}>
+            Slot: {label}
+          </RootGeneratorProp>
+          """
+        end
+
+      assert html =~ """
+               Slot: Label1
+               Slot: Label2
              """
     end
   end


### PR DESCRIPTION
The compile time dependencies are still present and will be removed later when we remove type information from the AST.