### PR TITLE
Move "Unknown property" warning to mix compiler

### DIFF
--- a/lib/mix/tasks/compile/surface/validate_components.ex
+++ b/lib/mix/tasks/compile/surface/validate_components.ex
@@ -82,12 +82,9 @@ defmodule Mix.Tasks.Compile.Surface.ValidateComponents do
               diagnostics = [warning(message, file, attr.meta.line) | diagnostics]
               {diagnostics, attrs}
 
-            !is_nil(prop) ->
-              diagnostics = [validate_attribute(attr, prop, component_call.node_alias, file, attrs) | diagnostics]
-              {diagnostics, MapSet.put(attrs, prop.name)}
-
             true ->
-              {diagnostics, attrs}
+              diagnostics = [validate_attribute(attr, prop, component_call.node_alias, file, attrs) | diagnostics]
+              {diagnostics, MapSet.put(attrs, attr.name || prop.name)}
           end
       end
 
@@ -102,6 +99,11 @@ defmodule Mix.Tasks.Compile.Surface.ValidateComponents do
 
   defp attr_prop(module, %Surface.AST.Attribute{} = attr) do
     module.__get_prop__(attr.name)
+  end
+
+  defp validate_attribute(attr, nil, node_alias, file, _) do
+    message = "Unknown property \"#{attr.name}\" for component <#{node_alias}>"
+    warning(message, file, attr.meta.line)
   end
 
   defp validate_attribute(attr, prop, node_alias, file, processed_attrs) do

--- a/lib/surface/type_handler.ex
+++ b/lib/surface/type_handler.ex
@@ -208,6 +208,7 @@ defmodule Surface.TypeHandler do
   def runtime_prop_value!(module, name, clauses, opts, node_alias, original, ctx) do
     {type, _opts} =
       attribute_type_and_opts(module, name, %{
+        runtime: true,
         node_alias: node_alias || module,
         caller: %Macro.Env{module: ctx.module},
         file: ctx.file,
@@ -261,12 +262,14 @@ defmodule Surface.TypeHandler do
       {prop.type, prop.opts}
     else
       _ ->
-        IOHelper.warn(
-          "Unknown property \"#{to_string(name)}\" for component <#{meta.node_alias}>",
-          meta.caller,
-          meta.file,
-          meta.line
-        )
+        if Map.get(meta, :runtime, false) do
+          IOHelper.warn(
+            "Unknown property \"#{to_string(name)}\" for component <#{meta.node_alias}>",
+            meta.caller,
+            meta.file,
+            meta.line
+          )
+        end
 
         {:string, []}
     end

--- a/test/mix/tasks/compile/surface/validate_components_test.exs
+++ b/test/mix/tasks/compile/surface/validate_components_test.exs
@@ -6,6 +6,33 @@ defmodule Mix.Tasks.Compile.Surface.ValidateComponentsTest do
   alias Mix.Tasks.Compile.Surface.ValidateComponents
   alias Mix.Task.Compiler.Diagnostic
 
+  defmodule StringProp do
+    use Surface.Component
+    prop text, :string
+    def render(assigns), do: ~F[{@text}]
+  end
+
+  test "should return diagnostic when unkwnown prop is passed to Component" do
+    component =
+      quote do
+        ~F[<StringProp unknown />]
+      end
+      |> compile_surface()
+
+    diagnostics = ValidateComponents.validate([component])
+
+    assert diagnostics == [
+             %Diagnostic{
+               compiler_name: "Surface",
+               details: nil,
+               file: Path.expand("code"),
+               message: "Unknown property \"unknown\" for component <StringProp>",
+               position: 0,
+               severity: :warning
+             }
+           ]
+  end
+
   defmodule RequiredPropTitle do
     use Surface.Component
     prop title, :string, required: true
@@ -237,12 +264,6 @@ defmodule Mix.Tasks.Compile.Surface.ValidateComponentsTest do
                severity: :warning
              }
            ]
-  end
-
-  defmodule StringProp do
-    use Surface.Component
-    prop text, :string
-    def render(assigns), do: ~F[{@text}]
   end
 
   test "should return diagnostic when passing a root prop and the component doesn't have one" do

--- a/test/surface/compiler_test.exs
+++ b/test/surface/compiler_test.exs
@@ -797,22 +797,6 @@ defmodule Surface.CompilerSyncTest do
     assert line == 2
   end
 
-  test "warning on non-existent property" do
-    code = """
-    <div>
-      <Button
-        label="test"
-        nonExistingProp="1"
-      />
-    </div>
-    """
-
-    {:warn, line, message} = run_compile(code, __ENV__)
-
-    assert message =~ ~S(Unknown property "nonExistingProp" for component <Button>)
-    assert line == 4
-  end
-
   test "warning on undefined assign in property" do
     code = """
     <div prop={{ @assign }} />


### PR DESCRIPTION
Runtime warnings, for dynamic components, are still in the TypeHandler