### PR TITLE
Add catalogue_test/1 macro and multiple examples

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -6,7 +6,8 @@ locals_without_parens = [
   data: 3,
   data: 2,
   slot: 1,
-  slot: 2
+  slot: 2,
+  catalogue_test: 1
 ]
 
 [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v0.8.0-dev
 
+  * Add `catalogue_test/1` macro to generate basic tests for catalogue examples and playgrounds
+  * Add `Surface.Catalogue.Examples` to allow defining multiple stateless examples in a single module
+
 ### Breaking Changes
 
   * `<#template slot="slot_name">` has been removed in favor of `<:slot_name>` (#575)

--- a/lib/surface/catalogue/example.ex
+++ b/lib/surface/catalogue/example.ex
@@ -36,7 +36,7 @@ defmodule Surface.Catalogue.Example do
     subject = Surface.Catalogue.fetch_subject!(opts, __MODULE__, __CALLER__)
 
     quote do
-      @config unquote(opts)
+      @__example_config__ unquote(opts)
       @before_compile unquote(__MODULE__)
 
       use Surface.LiveView, unquote(opts)
@@ -47,7 +47,7 @@ defmodule Surface.Catalogue.Example do
       import Surface, except: [sigil_F: 2]
 
       defmacrop sigil_F({:<<>>, _meta, [string]} = ast, opts) do
-        Module.put_attribute(__CALLER__.module, :code, string)
+        Module.put_attribute(__CALLER__.module, :__example_code__, string)
 
         quote do
           Surface.sigil_F(unquote(ast), unquote(opts))
@@ -57,12 +57,12 @@ defmodule Surface.Catalogue.Example do
   end
 
   defmacro __before_compile__(env) do
-    config = Module.get_attribute(env.module, :config)
+    config = Module.get_attribute(env.module, :__example_config__)
     subject = Keyword.fetch!(config, :subject)
     assert = Keyword.get(config, :assert, [])
 
-    code = Module.get_attribute(env.module, :code)
-    line = Module.get_attribute(env.module, :line)
+    code = Module.get_attribute(env.module, :__example_code__)
+    line = Module.get_attribute(env.module, :__example_line__)
 
     doc =
       case Module.get_attribute(env.module, :moduledoc) do
@@ -91,7 +91,7 @@ defmodule Surface.Catalogue.Example do
   end
 
   def __on_definition__(env, :def, :render, [_arg], _guards, _body) do
-    Module.put_attribute(env.module, :line, env.line)
+    Module.put_attribute(env.module, :__example_line__, env.line)
   end
 
   def __on_definition__(_env, _kind, _name, _args, _guards, _body) do

--- a/lib/surface/catalogue/example.ex
+++ b/lib/surface/catalogue/example.ex
@@ -1,6 +1,6 @@
 defmodule Surface.Catalogue.Example do
   @moduledoc """
-  Experimental LiveView to create examples for catalogue tools.
+  A generic LiveView to create a single example for catalogue tools.
 
   ## Options
 
@@ -27,19 +27,22 @@ defmodule Surface.Catalogue.Example do
       the total width that the code box should take. Default is `50`. Note: This configuration
       has no effect when direction is "vertical".
 
+    * `assert` - Optional. When using `catalogue_test/1`, generates simple `=~` assertions for
+      the given text or list of texts.
+
   """
 
   defmacro __using__(opts) do
     subject = Surface.Catalogue.fetch_subject!(opts, __MODULE__, __CALLER__)
 
     quote do
+      @config unquote(opts)
+      @before_compile unquote(__MODULE__)
+
       use Surface.LiveView, unquote(opts)
 
       alias unquote(subject)
       require Surface.Catalogue.Data, as: Data
-
-      @config unquote(opts)
-      @before_compile unquote(__MODULE__)
 
       import Surface, except: [sigil_F: 2]
 
@@ -56,15 +59,42 @@ defmodule Surface.Catalogue.Example do
   defmacro __before_compile__(env) do
     config = Module.get_attribute(env.module, :config)
     subject = Keyword.fetch!(config, :subject)
+    assert = Keyword.get(config, :assert, [])
+
     code = Module.get_attribute(env.module, :code)
+    line = Module.get_attribute(env.module, :line)
+
+    doc =
+      case Module.get_attribute(env.module, :moduledoc) do
+        {_, doc} -> doc
+        _ -> nil
+      end
+
+    examples_configs = [
+      [
+        func: :render,
+        code: code,
+        doc: doc,
+        line: line,
+        assert: assert
+      ]
+    ]
 
     quote do
       @moduledoc catalogue: [
                    type: :example,
                    subject: unquote(subject),
                    config: unquote(config),
-                   code: unquote(code)
+                   examples_configs: unquote(examples_configs)
                  ]
     end
+  end
+
+  def __on_definition__(env, :def, :render, [_arg], _guards, _body) do
+    Module.put_attribute(env.module, :line, env.line)
+  end
+
+  def __on_definition__(_env, _kind, _name, _args, _guards, _body) do
+    :ok
   end
 end

--- a/lib/surface/catalogue/examples.ex
+++ b/lib/surface/catalogue/examples.ex
@@ -1,0 +1,191 @@
+defmodule Surface.Catalogue.Examples do
+  @moduledoc ~S'''
+  A generic LiveView to create multiple examples for catalogue tools.
+
+  Each example must be a function component defined with the module attribute `@example`.
+
+  ## Options
+
+  Besides the buit-in options provided by the LiveView itself, examples can also
+  pass the following options at the module level:
+
+    * `subject` - Required. The target component of the Example.
+
+    * `catalogue` - Optional. A module that implements the `Surface.Catalogue`
+      providing additional information to the catalogue tool. Usually required
+      if you want to share your components as a library.
+
+  Other options can be defined at the module level but also overridden at the
+  function/example level using the `@example` module attribute. They are:
+
+    * `height` - Required (either for the module or function). The height of the Example.
+
+    * `title` - Optional. The title of the example.
+
+    * `body` - Optional. Sets/overrides the attributes of the the Example's body tag.
+      Useful to set a different background or padding.
+
+    * `direction` - Optional. Defines how the example + code boxes should be displayed.
+      Available values are "horizontal" or "vertical". Default is "horizontal" (side-by-side).
+
+    * `code_perc` - Optional. When the direction is "horizontal", defines the percentage of
+      the total width that the code box should take. Default is `50`. Note: This configuration
+      has no effect when direction is "vertical".
+
+    * `assert` - Optional. When using `catalogue_test/1`, generates simple `=~` assertions for
+      the given text or list of texts. This option is available only for Examples, not Playgrounds.
+
+  When defined at the module level, i.e. passing to `use Surface.Catalogue.Example, ...`, the
+  options apply to all examples. Aside from `subject` and `catalogue`, options can be overridden
+  at the function level using the `@example` module attribute.
+
+  ## Examples
+
+  ### Basic usage
+
+  ```
+  @example true
+  def basic_example(assigns) do
+    ~F"""
+    <Button>OK</Button>
+    """
+  end
+  ```
+
+  ### Defining a custom title + docs
+
+  ```
+  @example "Example with docs"
+  @doc "A simple example with documentation"
+  def example_01(assigns) do
+    ~F"""
+    <Button>OK</Button>
+    """
+  end
+  ```
+
+  ### Defining other options
+
+  ```
+  @example [
+    title: "Example and Code split vertically",
+    direction: "vertical",
+    height: "110px"
+  ]
+  def vertical(assigns) do
+    ~F"""
+    <Button size="small" color="info">Small</Button>
+    <Button size="medium" color="warning">Medium</Button>
+    <Button size="large" color="danger">Large</Button>
+    """
+  end
+  ```
+
+  Notice that whenever you want to pass other options using a keyword list as in the
+  example above, in case you need to customize the title, it must to be passed as
+  a key/value option as well.
+  '''
+
+  defmacro __using__(opts) do
+    subject = Surface.Catalogue.fetch_subject!(opts, __MODULE__, __CALLER__)
+    Module.register_attribute(__CALLER__.module, :__examples__, accumulate: true)
+
+    quote do
+      @before_compile unquote(__MODULE__)
+      @on_definition unquote(__MODULE__)
+
+      use Surface.LiveView, unquote(opts)
+
+      alias unquote(subject)
+      require Surface.Catalogue.Data, as: Data
+
+      @config unquote(opts)
+
+      import Surface, except: [sigil_F: 2]
+
+      on_mount({unquote(__MODULE__), :assign_func})
+
+      Module.register_attribute(__MODULE__, :__codes__, accumulate: true)
+
+      defmacrop sigil_F({:<<>>, _meta, [string]} = ast, opts) do
+        Module.put_attribute(__CALLER__.module, :__codes__, string)
+
+        quote do
+          Surface.sigil_F(unquote(ast), unquote(opts))
+        end
+      end
+
+      def render(%{__func__: _} = var!(assigns)) do
+        ~F"""
+        <Component module={__MODULE__} function={@__func__}/>
+        """
+      end
+    end
+  end
+
+  defmacro __before_compile__(env) do
+    config = Module.get_attribute(env.module, :config)
+    subject = Keyword.fetch!(config, :subject)
+    codes = Module.get_attribute(env.module, :__codes__)
+
+    examples_configs =
+      Module.get_attribute(env.module, :__examples__, [[]])
+      |> Enum.zip_with(codes, fn map, code -> Keyword.put(map, :code, code) end)
+      |> Enum.reverse()
+
+    quote do
+      @moduledoc catalogue: [
+                   type: :example,
+                   subject: unquote(subject),
+                   config: unquote(config),
+                   examples_configs: unquote(examples_configs)
+                 ]
+    end
+  end
+
+  def __on_definition__(env, :def, name, [_arg], _guards, _body) when name != :render do
+    doc = Module.get_attribute(env.module, :doc)
+
+    config =
+      env.module
+      |> Module.get_attribute(:example)
+      |> init_config(name, env)
+      |> maybe_put_doc(doc)
+
+    if config do
+      Module.delete_attribute(env.module, :example)
+      Module.put_attribute(env.module, :__examples__, config)
+    end
+  end
+
+  def __on_definition__(_env, _kind, _name, _args, _guards, _body) do
+    :ok
+  end
+
+  @doc false
+  def on_mount(:assign_func, _params, session, socket) do
+    func = session["func"] |> String.to_existing_atom()
+    {:cont, Phoenix.LiveView.assign(socket, __func__: func)}
+  end
+
+  defp init_config(nil, _name, _env), do: nil
+
+  defp init_config(config, name, env) do
+    default_config = [func: name, title: Phoenix.Naming.humanize(name), line: env.line]
+
+    case config do
+      true ->
+        default_config
+
+      title when is_binary(title) ->
+        Keyword.put(default_config, :title, title)
+
+      config when is_list(config) ->
+        Keyword.merge(default_config, config)
+    end
+  end
+
+  defp maybe_put_doc(nil, _doc), do: nil
+  defp maybe_put_doc(config, {_, doc}), do: Keyword.put(config, :doc, doc)
+  defp maybe_put_doc(config, _doc), do: config
+end

--- a/lib/surface/catalogue/examples.ex
+++ b/lib/surface/catalogue/examples.ex
@@ -99,16 +99,16 @@ defmodule Surface.Catalogue.Examples do
       alias unquote(subject)
       require Surface.Catalogue.Data, as: Data
 
-      @config unquote(opts)
+      @__example_config__ unquote(opts)
 
       import Surface, except: [sigil_F: 2]
 
       on_mount({unquote(__MODULE__), :assign_func})
 
-      Module.register_attribute(__MODULE__, :__codes__, accumulate: true)
+      Module.register_attribute(__MODULE__, :__example_codes__, accumulate: true)
 
       defmacrop sigil_F({:<<>>, _meta, [string]} = ast, opts) do
-        Module.put_attribute(__CALLER__.module, :__codes__, string)
+        Module.put_attribute(__CALLER__.module, :__example_codes__, string)
 
         quote do
           Surface.sigil_F(unquote(ast), unquote(opts))
@@ -124,9 +124,9 @@ defmodule Surface.Catalogue.Examples do
   end
 
   defmacro __before_compile__(env) do
-    config = Module.get_attribute(env.module, :config)
+    config = Module.get_attribute(env.module, :__example_config__)
     subject = Keyword.fetch!(config, :subject)
-    codes = Module.get_attribute(env.module, :__codes__)
+    codes = Module.get_attribute(env.module, :__example_codes__)
 
     examples_configs =
       Module.get_attribute(env.module, :__examples__, [[]])

--- a/lib/surface/catalogue/playground.ex
+++ b/lib/surface/catalogue/playground.ex
@@ -62,17 +62,23 @@ defmodule Surface.Catalogue.Playground do
   # Subscribes to receive notification messages from the Playground.
   @doc false
   def subscribe(window_id) do
-    Phoenix.PubSub.subscribe(@pubsub, topic(window_id))
+    if running_pubsub?() do
+      Phoenix.PubSub.subscribe(@pubsub, topic(window_id))
+    end
   end
 
   defp notify_init(window_id, subject, props, events, props_values_with_events) do
-    message = {:playground_init, self(), subject, props, events, props_values_with_events}
-    Phoenix.PubSub.broadcast(@pubsub, topic(window_id), message)
+    if running_pubsub?() do
+      message = {:playground_init, self(), subject, props, events, props_values_with_events}
+      Phoenix.PubSub.broadcast(@pubsub, topic(window_id), message)
+    end
   end
 
   defp notify_event_received(window_id, event, value, props) do
-    message = {:playground_event_received, event, value, props}
-    Phoenix.PubSub.broadcast(@pubsub, topic(window_id), message)
+    if running_pubsub?() do
+      message = {:playground_event_received, event, value, props}
+      Phoenix.PubSub.broadcast(@pubsub, topic(window_id), message)
+    end
   end
 
   defp topic(window_id) do
@@ -187,5 +193,10 @@ defmodule Surface.Catalogue.Playground do
         into: %{} do
       {name, opts[:default]}
     end
+  end
+
+  defp running_pubsub? do
+    pid = Process.whereis(@pubsub)
+    pid && Process.alive?(pid)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule Surface.MixProject do
   end
 
   defp elixirc_paths(:dev), do: ["lib"] ++ catalogues()
-  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(:test), do: ["lib", "test/support"] ++ catalogues()
   defp elixirc_paths(_), do: ["lib"]
 
   defp deps do

--- a/test/support/catalogue/fake_component_in_web_namespace.ex
+++ b/test/support/catalogue/fake_component_in_web_namespace.ex
@@ -1,0 +1,9 @@
+defmodule SurfaceWeb.Components.FakeComponentInWebNamespace do
+  use Surface.Component
+
+  def render(assigns) do
+    ~F"""
+    Fake render
+    """
+  end
+end

--- a/test/support/catalogue/fake_example.ex
+++ b/test/support/catalogue/fake_example.ex
@@ -1,7 +1,8 @@
 defmodule Surface.Catalogue.FakeExample do
   use Surface.Catalogue.Example,
     subject: Surface.Components.Form,
-    title: "A fake example"
+    title: "A fake example",
+    assert: ["The code"]
 
   def render(assigns) do
     ~F"""

--- a/test/support/live_view_test/fake_component.ex
+++ b/test/support/live_view_test/fake_component.ex
@@ -1,0 +1,5 @@
+defmodule Surface.LiveViewTestTest.FakeComponent do
+  use Surface.Component
+
+  def render(assigns), do: ~F[]
+end

--- a/test/support/live_view_test/fake_example.ex
+++ b/test/support/live_view_test/fake_example.ex
@@ -1,0 +1,8 @@
+defmodule Surface.LiveViewTestTest.FakeExample do
+  use Surface.Catalogue.Example,
+    subject: Surface.LiveViewTestTest.FakeComponent,
+    title: "A fake example",
+    assert: "the code"
+
+  def render(assigns), do: ~F[the code]
+end

--- a/test/support/live_view_test/fake_example_for_other_fake_component.ex
+++ b/test/support/live_view_test/fake_example_for_other_fake_component.ex
@@ -1,0 +1,7 @@
+defmodule Surface.LiveViewTestTest.FakeExampleForOtherFakeComponent do
+  use Surface.Catalogue.Example,
+    subject: Surface.LiveViewTestTest.OtherFakeComponent,
+    title: "A fake example"
+
+  def render(assigns), do: ~F[]
+end

--- a/test/support/live_view_test/fake_examples.ex
+++ b/test/support/live_view_test/fake_examples.ex
@@ -1,0 +1,17 @@
+defmodule Surface.LiveViewTestTest.FakeExamples do
+  use Surface.Catalogue.Examples,
+    subject: Surface.LiveViewTestTest.FakeComponent,
+    title: "Fake examples"
+
+  @example true
+  def example_without_opts(assigns), do: ~F[]
+
+  @example title: "Example with opts"
+  def example_with_opts(assigns), do: ~F[]
+
+  @example assert: "the code"
+  def example_with_assert_text(assigns), do: ~F[the code]
+
+  @example assert: ["the", "code"]
+  def example_with_assert_texts(assigns), do: ~F[the code]
+end

--- a/test/support/live_view_test/fake_playground.ex
+++ b/test/support/live_view_test/fake_playground.ex
@@ -1,0 +1,9 @@
+defmodule Surface.LiveViewTestTest.FakePlayground do
+  use Surface.Catalogue.Playground,
+    subject: Surface.LiveViewTestTest.FakeComponent,
+    catalogue: Surface.Components.FakeCatalogue
+
+  data props, :map, default: %{}
+
+  def render(assigns), do: ~F[]
+end

--- a/test/support/live_view_test/other_fake_component.ex
+++ b/test/support/live_view_test/other_fake_component.ex
@@ -1,0 +1,5 @@
+defmodule Surface.LiveViewTestTest.OtherFakeComponent do
+  use Surface.Component
+
+  def render(assigns), do: ~F[]
+end

--- a/test/surface/catalogue/example_test.exs
+++ b/test/surface/catalogue/example_test.exs
@@ -11,9 +11,9 @@ defmodule Surface.Catalogue.ExampleTest do
   end
 
   test "saves render/1's content as metadata" do
-    meta = Surface.Catalogue.get_metadata(FakeExample)
+    [meta] = Surface.Catalogue.get_metadata(FakeExample).examples_configs
 
-    assert meta.code == "The code\n"
+    assert Keyword.fetch!(meta, :code) == "The code\n"
   end
 
   test "saves user config" do
@@ -23,9 +23,9 @@ defmodule Surface.Catalogue.ExampleTest do
   end
 
   test "saves render/1's content as metadata when moduledoc is false" do
-    meta = Surface.Catalogue.get_metadata(FakeExampleModuleDocFalse)
+    [meta] = Surface.Catalogue.get_metadata(FakeExampleModuleDocFalse).examples_configs
 
-    assert meta.code == "The code\n"
+    assert Keyword.fetch!(meta, :code) == "The code\n"
   end
 
   test "subject is required" do

--- a/test/surface/components/catalogue_test.exs
+++ b/test/surface/components/catalogue_test.exs
@@ -1,0 +1,5 @@
+defmodule Surface.Components.CatalogueTest do
+  use Surface.ConnCase, async: true
+
+  catalogue_test :all
+end

--- a/test/surface/live_view_test_test.exs
+++ b/test/surface/live_view_test_test.exs
@@ -1,0 +1,75 @@
+defmodule Surface.LiveViewTestTest.DisableTests do
+  # Overrides __ex_unit__/0 so the tests don't actually run.
+  # If we don't do this tests will run twice.
+  defmacro __before_compile__(_env) do
+    quote do
+      defoverridable __ex_unit__: 0
+
+      def __ex_unit__() do
+        %ExUnit.TestModule{super() | tests: []}
+      end
+    end
+  end
+end
+
+defmodule Surface.LiveViewTestTest.PassingCatalogueSubjectTests do
+  use Surface.ConnCase, async: true
+  @before_compile Surface.LiveViewTestTest.DisableTests
+
+  catalogue_test Surface.LiveViewTestTest.FakeComponent
+end
+
+defmodule Surface.LiveViewTestTest.PassingCatalogueAllTests do
+  use Surface.ConnCase, async: true
+  @before_compile Surface.LiveViewTestTest.DisableTests
+
+  catalogue_test :all
+end
+
+defmodule Surface.LiveViewTestTest.PassingCatalogueAllAndExceptTests do
+  use Surface.ConnCase, async: true
+  @before_compile Surface.LiveViewTestTest.DisableTests
+
+  catalogue_test(:all, except: [Surface.LiveViewTestTest.OtherFakeComponent])
+end
+
+defmodule Surface.LiveViewTestTest do
+  use Surface.ConnCase, async: true
+
+  describe "catalogue_test" do
+    test "passing a module (subject)" do
+      tests = get_test_functions(Surface.LiveViewTestTest.PassingCatalogueSubjectTests)
+
+      assert tests == [
+               # Using Example
+               {:"test Surface.LiveViewTestTest.FakeExample.render", 1},
+               # Using Examples
+               {:"test Surface.LiveViewTestTest.FakeExamples.example_with_assert_text", 1},
+               {:"test Surface.LiveViewTestTest.FakeExamples.example_with_assert_texts", 1},
+               {:"test Surface.LiveViewTestTest.FakeExamples.example_with_opts", 1},
+               {:"test Surface.LiveViewTestTest.FakeExamples.example_without_opts", 1},
+               # Using Playground
+               {:"test Surface.LiveViewTestTest.FakePlayground", 1}
+             ]
+    end
+
+    test "passing :all" do
+      tests = get_test_functions(Surface.LiveViewTestTest.PassingCatalogueAllTests)
+
+      assert {:"test Surface.LiveViewTestTest.FakeExample.render", 1} in tests
+      assert {:"test Surface.LiveViewTestTest.FakeExampleForOtherFakeComponent.render", 1} in tests
+    end
+
+    test "passing :all with the :except option" do
+      tests = get_test_functions(Surface.LiveViewTestTest.PassingCatalogueAllAndExceptTests)
+
+      assert {:"test Surface.LiveViewTestTest.FakeExample.render", 1} in tests
+      refute {:"test Surface.LiveViewTestTest.FakeExampleForOtherFakeComponent.render", 1} in tests
+    end
+  end
+
+  defp get_test_functions(module) do
+    module.module_info(:functions)
+    |> Enum.filter(fn {f, _} -> String.starts_with?("#{f}", "test ") end)
+  end
+end

--- a/test/surface_test.exs
+++ b/test/surface_test.exs
@@ -35,6 +35,44 @@ defmodule SurfaceTest do
     end
   end
 
+  describe "components" do
+    test "retrieve all components" do
+      list = components()
+
+      # We cannot assert if it retrieves deps' components from here since this project cannot
+      # depend on a another project that depends on surface itself. So we just make sure it
+      # retrieves, at least, the list of components of this project.
+      assert SurfaceWeb.Components.FakeComponentInWebNamespace in list
+      assert Surface.Components.Form in list
+      assert Enum not in list
+    end
+
+    test "retrieve only components in the web namespace" do
+      list = components(only_web_namespace: true)
+
+      assert SurfaceWeb.Components.FakeComponentInWebNamespace in list
+      assert Surface.Components.Form not in list
+      assert Enum not in list
+    end
+
+    test "retrieve only components in the current project" do
+      list = components(only_current_project: true)
+
+      assert SurfaceWeb.Components.FakeComponentInWebNamespace in list
+      assert Surface.Components.Form in list
+      assert Enum not in list
+
+      # We cannot test `only_current_project: false` from here since this project cannot
+      # depend on a another project that depends on surface itself. So we just make sure it
+      # retrieves, at least, the list of components of this project.
+      list = components(only_current_project: false)
+
+      assert SurfaceWeb.Components.FakeComponentInWebNamespace in list
+      assert Surface.Components.Form in list
+      assert Enum not in list
+    end
+  end
+
   test "raise error when trying to unquote an undefined variable" do
     message = """
     code.ex:2: undefined variable "content".


### PR DESCRIPTION
## New features

* Add `catalogue_test/1` macro to generate basic tests for catalogue examples and playgrounds
* Add `Surface.Catalogue.Examples` to allow defining multiple stateless examples in a single module
* Add private `Surface.components/2` function to be used by builtin tools (compiler, catalogue, etc.) to retrieve the list of available components.

@tiagoefmoraes after this PR gets merged, the compiler should also use `Surface.components/2` with the proper `only_current_project` and `only_web_namespace` options, which should cover all cases we have. I'm already using that function in both, `surface_catalogue` and the `catalogue_test/2` macro.