### PR TITLE
add a config option to suppress undefined prop warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   * Support using vanilla phoenix function components with slots in surface templates
   * Add `catalogue_test/1` macro to generate basic tests for catalogue examples and playgrounds
   * Add `Surface.Catalogue.Examples` to allow defining multiple stateless examples in a single module
+  * Added optional compiler config
 
 ### Breaking Changes
 

--- a/lib/mix/tasks/compile/surface.ex
+++ b/lib/mix/tasks/compile/surface.ex
@@ -24,11 +24,14 @@ defmodule Mix.Tasks.Compile.Surface do
   * `hooks_output_dir` - defines the folder where the compiler generates the JS hooks files.
     Default is `./assets/js/_hooks/`.
 
+  * `warn_on_undefined_props` - shows warnings when passing assigns that are not defined
+    as props on the component. Default is `true`.
+
   ### Example
 
       config :surface, :compiler,
-        hooks_output_dir: "assets/js/surface"
-
+        hooks_output_dir: "assets/js/surface",
+        warn_on_undefined_props: true
   """
 
   use Mix.Task

--- a/lib/surface/type_handler.ex
+++ b/lib/surface/type_handler.ex
@@ -294,7 +294,7 @@ defmodule Surface.TypeHandler do
       {prop.type, prop.opts}
     else
       _ ->
-        if Map.get(meta, :runtime, false) do
+        if Map.get(meta, :runtime, false) and Keyword.get(Application.get_env(:surface, :compiler, []), :warn_on_undefined_props, true) do
           IOHelper.warn(
             "Unknown property \"#{to_string(name)}\" for component <#{meta.node_alias}>",
             meta.caller,


### PR DESCRIPTION
replaces https://github.com/surface-ui/surface/pull/588