### PR TITLE
add a better error message when incorrectly using the default slot

### DIFF
--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -879,8 +879,7 @@ defmodule Surface.Compiler do
   defp validate_tag_children([]), do: :ok
 
   defp validate_tag_children([%AST.SlotEntry{name: name, meta: meta} | _]) do
-    {:error,
-     "slot entries are not allowed as children of HTML elements. Did you mean <##{name} />?", meta}
+    {:error, "slot entries are not allowed as children of HTML elements. Did you mean <##{name} />?", meta}
   end
 
   defp validate_tag_children([_ | nodes]), do: validate_tag_children(nodes)

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -878,7 +878,8 @@ defmodule Surface.Compiler do
   defp validate_tag_children([]), do: :ok
 
   defp validate_tag_children([%AST.SlotEntry{name: name} | _]) do
-    {:error, "slot entries are only allowed as children elements of components, but found slot entry for #{name}"}
+    {:error,
+     "Slot entries are only allowed as children elements of components. No slot found named slot. Did you mean <##{name} />"}
   end
 
   defp validate_tag_children([_ | nodes]), do: validate_tag_children(nodes)

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -545,6 +545,7 @@ defmodule Surface.Compiler do
          compile_meta
        )}
     else
+      {:error, message, meta} -> handle_convert_node_to_ast_error(name, {:error, message}, meta)
       error -> handle_convert_node_to_ast_error(name, error, meta)
     end
   end
@@ -877,9 +878,9 @@ defmodule Surface.Compiler do
 
   defp validate_tag_children([]), do: :ok
 
-  defp validate_tag_children([%AST.SlotEntry{name: name} | _]) do
+  defp validate_tag_children([%AST.SlotEntry{name: name, meta: meta} | _]) do
     {:error,
-     "Slot entries are only allowed as children elements of components. No slot found named slot. Did you mean <##{name} />"}
+     "slot entries are not allowed as children of HTML elements. Did you mean <##{name} />?", meta}
   end
 
   defp validate_tag_children([_ | nodes]), do: validate_tag_children(nodes)

--- a/test/surface/integrations/slot_test.exs
+++ b/test/surface/integrations/slot_test.exs
@@ -1608,7 +1608,7 @@ defmodule Surface.SlotSyncTest do
       end)
 
     assert output =~ ~r"""
-           cannot render <div> \(slot entries are only allowed as children elements of components, but found slot entry for body\)
+           cannot render <div> \(Slot entries are only allowed as children elements of components. No slot found named slot. Did you mean <#body />\)
              code.exs:3:\
            """
   end

--- a/test/surface/integrations/slot_test.exs
+++ b/test/surface/integrations/slot_test.exs
@@ -1594,22 +1594,23 @@ defmodule Surface.SlotSyncTest do
   end
 
   test "use slot entry in element that is not a component" do
-    code = ~s[
-      ~F"""
-      <div>
-        <:body />
-      </div>
-      """
-      ]
+    code =
+      quote do
+        ~F"""
+        <div>
+          <:slot />
+        </div>
+        """
+      end
 
     output =
       capture_io(:standard_error, fn ->
-        Code.eval_string(code, [assigns: %{}], %{__ENV__ | file: "code.exs", line: 1})
+        compile_surface(code, %{})
       end)
 
     assert output =~ ~r"""
-           cannot render <div> \(Slot entries are only allowed as children elements of components. No slot found named slot. Did you mean <#body />\)
-             code.exs:3:\
+           cannot render <div> \(slot entries are not allowed as children of HTML elements. Did you mean \<\#slot \/\>\?\)
+             code:2:\
            """
   end
 end


### PR DESCRIPTION
Add a better error message as Dave reporting on this issue here: https://github.com/surface-ui/surface/issues/620

<img width="1034" alt="Screen Shot 2022-07-29 at 11 47 30" src="https://user-images.githubusercontent.com/1036970/181799928-1156203f-e1fe-40ac-be57-103c1fd1bbed.png">

<img width="724" alt="Screen Shot 2022-07-29 at 11 48 12" src="https://user-images.githubusercontent.com/1036970/181799932-080e2178-1d1f-4e34-8f44-4d1ed992b3d3.png">
