### PR TITLE
add value attr even when is empty for TextInput

### DIFF
--- a/lib/surface/type_handler.ex
+++ b/lib/surface/type_handler.ex
@@ -198,6 +198,9 @@ defmodule Surface.TypeHandler do
       {:ok, val} ->
         [{name, val}]
 
+      {:ok, :value, ""} ->
+        [{:value, ""}]
+
       {:error, message} ->
         IOHelper.runtime_error(message)
     end

--- a/lib/surface/type_handler/default.ex
+++ b/lib/surface/type_handler/default.ex
@@ -72,6 +72,11 @@ defmodule Surface.TypeHandler.Default do
   end
 
   @impl true
+  def value_to_opts(:value, "") do
+    {:ok, :value, ""}
+  end
+
+  @impl true
   def value_to_opts(_name, value) do
     {:ok, value}
   end


### PR DESCRIPTION
It will solve the issue https://github.com/surface-ui/surface/issues/570

<img width="405" alt="Screen Shot 2022-07-29 at 15 43 21" src="https://user-images.githubusercontent.com/1036970/181832738-46871d49-2a75-4ebb-998f-e2037747a224.png">

before that, the value HTML attribute doesn't show in the HTML code.