### PR TITLE
fix when directive are specified multiple times

### DIFF
--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -272,8 +272,6 @@ defmodule Surface.Compiler do
             the directive `:#{format_directive_name(directive.name)}` has been passed multiple times. Considering only the last value.
 
             Hint: remove all redundant definitions.
-
-            See the directives are supported: https://surface-ui.org/template_syntax#directives
             """
 
             IOHelper.warn(message, meta.caller, meta.file, meta.line)

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -282,7 +282,7 @@ defmodule Surface.Compiler do
               do: MapSet.put(processed_directives, directive.name),
               else: processed_directives
 
-          {mod.process(directive, node), MapSet.put(processed_directives, directive.name)}
+          {mod.process(directive, node), processed_directives}
       end
 
     directives

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -262,11 +262,25 @@ defmodule Surface.Compiler do
   defp node_type(_), do: :text
 
   defp process_directives(%{directives: directives} = node) when is_list(directives) do
+    {directives, _} =
+      for %AST.Directive{module: mod, meta: meta} = directive <- directives,
+          function_exported?(mod, :process, 2),
+          reduce: {node, MapSet.new()} do
+        {node, processed_directives} ->
+          if MapSet.member?(processed_directives, directive.name) and match?(%AST.Tag{}, node) do
+            message = """
+            the directive `#{directive.name}` has been passed multiple times. Considering only the last value.
+
+            Hint: remove all redundant definitions.
+            """
+
+            IOHelper.warn(message, meta.caller, meta.file, meta.line)
+          end
+
+          {mod.process(directive, node), MapSet.put(processed_directives, directive.name)}
+      end
+
     directives
-    |> Enum.filter(fn %AST.Directive{module: mod} -> function_exported?(mod, :process, 2) end)
-    |> Enum.reduce(node, fn %AST.Directive{module: mod} = directive, node ->
-      mod.process(directive, node)
-    end)
   end
 
   defp process_directives(node), do: node

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -272,6 +272,8 @@ defmodule Surface.Compiler do
             the directive `:#{format_directive_name(directive.name)}` has been passed multiple times. Considering only the last value.
 
             Hint: remove all redundant definitions.
+
+            See the directives are supported: https://surface-ui.org/template_syntax#directives
             """
 
             IOHelper.warn(message, meta.caller, meta.file, meta.line)
@@ -292,7 +294,6 @@ defmodule Surface.Compiler do
   end
 
   defp match_ast_node?(node) do
-    # https://surface-ui.org/template_syntax#directives
     match?(%AST.Tag{}, node) or match?(%AST.If{}, node) or match?(%AST.For{}, node)
   end
 

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -269,13 +269,18 @@ defmodule Surface.Compiler do
         {node, processed_directives} ->
           if MapSet.member?(processed_directives, directive.name) and match?(%AST.Tag{}, node) do
             message = """
-            the directive `#{directive.name}` has been passed multiple times. Considering only the last value.
+            the directive `:on-#{directive.name}` has been passed multiple times. Considering only the last value.
 
             Hint: remove all redundant definitions.
             """
 
             IOHelper.warn(message, meta.caller, meta.file, meta.line)
           end
+
+          processed_directives =
+            if to_string(directive.name) in Surface.Directive.Events.names(),
+              do: MapSet.put(processed_directives, directive.name),
+              else: processed_directives
 
           {mod.process(directive, node), MapSet.put(processed_directives, directive.name)}
       end

--- a/lib/surface/directive/events.ex
+++ b/lib/surface/directive/events.ex
@@ -19,6 +19,9 @@ defmodule Surface.Directive.Events do
 
   @phx_events Enum.map(@events, &"phx-#{&1}")
 
+  @doc false
+  def names(), do: @events
+
   def phx_events(), do: @phx_events
 
   def extract({":on-" <> event_name, value, attr_meta}, meta)

--- a/test/mix/tasks/compile/surface/validate_components_test.exs
+++ b/test/mix/tasks/compile/surface/validate_components_test.exs
@@ -106,6 +106,31 @@ defmodule Mix.Tasks.Compile.Surface.ValidateComponentsTest do
            ]
   end
 
+  test "should return diagnostic when directive are specified multiple times" do
+    component =
+      quote do
+        ~F[<StringProp :props={"a"} :props={"b"} />]
+      end
+      |> compile_surface()
+
+    diagnostics = ValidateComponents.validate([component])
+
+    assert diagnostics == [
+             %Mix.Task.Compiler.Diagnostic{
+               compiler_name: "Surface",
+               details: nil,
+               file: Path.expand("code"),
+               message: ~S"""
+               the directive `props` has been passed multiple times. Considering only the last value.
+
+               Hint: remove all redundant definitions.
+               """,
+               position: 0,
+               severity: :warning
+             }
+           ]
+  end
+
   defmodule MacroWithRequiredPropTitle do
     use Surface.MacroComponent
     prop title, :string, required: true

--- a/test/mix/tasks/compile/surface/validate_components_test.exs
+++ b/test/mix/tasks/compile/surface/validate_components_test.exs
@@ -106,10 +106,10 @@ defmodule Mix.Tasks.Compile.Surface.ValidateComponentsTest do
            ]
   end
 
-  test "should return diagnostic when directive are specified multiple times" do
+  test "should return diagnostic when a directive is specified multiple times in a component" do
     component =
       quote do
-        ~F[<StringProp :props={"a"} :props={"b"} />]
+        ~F[<StringProp :if={true} :props={"a"} :props={"b"} />]
       end
       |> compile_surface()
 

--- a/test/surface/compiler_test.exs
+++ b/test/surface/compiler_test.exs
@@ -756,6 +756,35 @@ defmodule Surface.CompilerSyncTest do
     assert line == 2
   end
 
+  test "warning when directive are specified multiple times" do
+    alias Components.But, warn: false
+
+    code = """
+    <div
+      :on-click="a"
+      :on-click="b"
+    ></div>
+    """
+
+    {:warn, line, message} = run_compile(code, __ENV__)
+
+    assert message =~ """
+           the directive `click` has been passed multiple times. Considering only the last value.
+
+           Hint: remove all redundant definitions.
+
+             nofile:3:\
+           """
+
+    assert line == 3
+  end
+
+  test "don't warn when directive are specified multiple times in components" do
+    code = ~s[<Button :props={"a"} :props={"b"} />]
+
+    assert {:ok, _component} = run_compile(code, __ENV__)
+  end
+
   test "warning with hint when a unaliased component cannot be loaded" do
     code = """
     <div>

--- a/test/surface/compiler_test.exs
+++ b/test/surface/compiler_test.exs
@@ -769,7 +769,7 @@ defmodule Surface.CompilerSyncTest do
     {:warn, line, message} = run_compile(code, __ENV__)
 
     assert message =~ """
-           the directive `click` has been passed multiple times. Considering only the last value.
+           the directive `:on-click` has been passed multiple times. Considering only the last value.
 
            Hint: remove all redundant definitions.
 

--- a/test/surface/compiler_test.exs
+++ b/test/surface/compiler_test.exs
@@ -771,6 +771,8 @@ defmodule Surface.CompilerSyncTest do
 
            Hint: remove all redundant definitions.
 
+           See the directives are supported: https://surface-ui.org/template_syntax#directives
+
              nofile:3:\
            """
 
@@ -792,6 +794,8 @@ defmodule Surface.CompilerSyncTest do
            the directive `:if` has been passed multiple times. Considering only the last value.
 
            Hint: remove all redundant definitions.
+
+           See the directives are supported: https://surface-ui.org/template_syntax#directives
 
              nofile:3:\
            """

--- a/test/surface/compiler_test.exs
+++ b/test/surface/compiler_test.exs
@@ -756,9 +756,7 @@ defmodule Surface.CompilerSyncTest do
     assert line == 2
   end
 
-  test "warning when directive are specified multiple times" do
-    alias Components.But, warn: false
-
+  test "warning when a directive is specified multiple times in an HTML element" do
     code = """
     <div
       :on-click="a"
@@ -779,7 +777,29 @@ defmodule Surface.CompilerSyncTest do
     assert line == 3
   end
 
-  test "don't warn when directive are specified multiple times in components" do
+  test "warning when any directive is specified multiple times in an HTML element and not only events" do
+    code = """
+    <div
+      :if={true}
+      :if={true}
+      :on-click="a"
+    ></div>
+    """
+
+    {:warn, line, message} = run_compile(code, __ENV__)
+
+    assert message =~ """
+           the directive `:if` has been passed multiple times. Considering only the last value.
+
+           Hint: remove all redundant definitions.
+
+             nofile:3:\
+           """
+
+    assert line == 3
+  end
+
+  test "don't warn when directive is specified multiple times in components" do
     code = ~s[<Button :props={"a"} :props={"b"} />]
 
     assert {:ok, _component} = run_compile(code, __ENV__)

--- a/test/surface/compiler_test.exs
+++ b/test/surface/compiler_test.exs
@@ -771,8 +771,6 @@ defmodule Surface.CompilerSyncTest do
 
            Hint: remove all redundant definitions.
 
-           See the directives are supported: https://surface-ui.org/template_syntax#directives
-
              nofile:3:\
            """
 
@@ -794,8 +792,6 @@ defmodule Surface.CompilerSyncTest do
            the directive `:if` has been passed multiple times. Considering only the last value.
 
            Hint: remove all redundant definitions.
-
-           See the directives are supported: https://surface-ui.org/template_syntax#directives
 
              nofile:3:\
            """


### PR DESCRIPTION
it should show a warning when specified directive multiple times, like:

```html
<div :on-click="a" :on-click="b"></div>
```