### PR TITLE
Adds option to override the web module on init

### DIFF
--- a/lib/mix/tasks/surface/surface.init.ex
+++ b/lib/mix/tasks/surface/surface.init.ex
@@ -52,6 +52,8 @@ defmodule Mix.Tasks.Surface.Init do
 
     * `--no-install` - do not fetch and install added/updated dependencies.
 
+    * `--web-module` - Configures the name of the Web module. Defaults to `MyAppWeb`.
+
   """
 
   use Mix.Task
@@ -71,7 +73,8 @@ defmodule Mix.Tasks.Surface.Init do
     scoped_css: :boolean,
     error_tag: :boolean,
     install: :boolean,
-    dry_run: :boolean
+    dry_run: :boolean,
+    web_module: :string
   ]
 
   @default_opts [
@@ -85,7 +88,8 @@ defmodule Mix.Tasks.Surface.Init do
     scoped_css: true,
     error_tag: true,
     install: true,
-    dry_run: false
+    dry_run: false,
+    web_module: nil
   ]
 
   @project_patchers [
@@ -135,7 +139,7 @@ defmodule Mix.Tasks.Surface.Init do
     context_app = Mix.Phoenix.context_app()
     web_path = Mix.Phoenix.web_path(context_app)
     base = Module.concat([Mix.Phoenix.base()])
-    web_module = Mix.Phoenix.web_module(base)
+    web_module = web_module_name(base, opts[:web_module])
     web_module_path = web_module_path(context_app)
     using_gettext? = using_gettext?(web_path, web_module)
 
@@ -149,6 +153,14 @@ defmodule Mix.Tasks.Surface.Init do
       web_path: web_path,
       using_gettext?: using_gettext?
     })
+  end
+
+  defp web_module_name(base, nil) do
+    Mix.Phoenix.web_module(base)
+  end
+
+  defp web_module_name(_base, web_module) do
+    Module.concat([web_module])
   end
 
   defp web_module_path(ctx_app) do

--- a/test/mix/tasks/surface/surface.init/integration_test.exs
+++ b/test/mix/tasks/surface/surface.init/integration_test.exs
@@ -24,7 +24,11 @@ defmodule Mix.Tasks.Surface.Init.IntegrationTest do
   test "surfice.init on a fresh project applies all changes", %{project_folder: project_folder} do
     opts = [cd: project_folder]
 
-    output = cmd("mix surface.init --catalogue --demo --layouts --tailwind --yes --no-install --dry-run", opts)
+    output =
+      cmd(
+        "mix surface.init --catalogue --demo --layouts --tailwind --yes --no-install --dry-run --web-module SurfaceInitTestWeb",
+        opts
+      )
 
     assert output == """
            * patching .formatter.exs
@@ -60,7 +64,11 @@ defmodule Mix.Tasks.Surface.Init.IntegrationTest do
   test "surfice.init on an already patched project applies no changes", %{project_folder_patched: project_folder} do
     opts = [cd: project_folder]
 
-    output = cmd("mix surface.init --catalogue --demo --layouts --tailwind --yes --no-install --dry-run", opts)
+    output =
+      cmd(
+        "mix surface.init --catalogue --demo --layouts --tailwind --yes --no-install --dry-run --web-module SurfaceInitTestWeb",
+        opts
+      )
 
     assert compact_output(output) == """
            * patching .formatter.exs (skipped)


### PR DESCRIPTION
I talked to @davydog187 about this...

I had an issue today. My project is named `RandomUUID` but the file is `random_uuid.ex`, not `random_u_u_i_d.ex`.
Given the last part is an acronym, it is correct for the entire part to be capitalized, but I never use the naming convention in phoenix to make that happen automagically (because it looks terrible.)
In this case, I just find/replace the module name after running the phoenix generator. However, this caused a problem when running the Surface init task. It assumes the web module was `RandomUuidWeb`.
This option in the task makes it possible to override that.
It seems like a small footprint change, and I hope it is useful to more people than just me. :D