### PR TITLE
Hide internals of formatter in docs

### DIFF
--- a/lib/mix/tasks/surface/surface.format.ex
+++ b/lib/mix/tasks/surface/surface.format.ex
@@ -2,8 +2,10 @@ defmodule Mix.Tasks.Surface.Format do
   @shortdoc "Formats Surface ~F sigils and .sface files in the given files/patterns"
 
   @moduledoc """
-  **To format Surface code using Elixir 1.13 or later, use
-  `Surface.Formatter.Plugin`.**
+  > #### Formatter Plugin Preferred {: .tip}
+  >
+  > To format Surface code using Elixir 1.13 or later, use
+  > `Surface.Formatter.Plugin`.
 
   Formats Surface `~F` sigils and `.sface` files in the given files and patterns.
 

--- a/lib/surface/formatter.ex
+++ b/lib/surface/formatter.ex
@@ -1,5 +1,5 @@
 defmodule Surface.Formatter do
-  @moduledoc "Functions for formatting Surface code snippets."
+  @moduledoc "Functions for formatting Surface code snippets." && false
 
   alias Surface.Formatter.Phases
 

--- a/lib/surface/formatter/node_translator.ex
+++ b/lib/surface/formatter/node_translator.ex
@@ -1,4 +1,5 @@
 defmodule Surface.Formatter.NodeTranslator do
+  @moduledoc false
   @behaviour Surface.Compiler.NodeTranslator
 
   def handle_init(state), do: state

--- a/lib/surface/formatter/phase.ex
+++ b/lib/surface/formatter/phase.ex
@@ -1,21 +1,21 @@
 defmodule Surface.Formatter.Phase do
   @moduledoc """
-  A phase implementing a single "rule" for formatting code. These work as middleware
-  between `Surface.Compiler.Parser.parse` and `Surface.Formatter.Render.node/2`
-  to modify node lists before they are rendered.
+             A phase implementing a single "rule" for formatting code. These work as middleware
+             between `Surface.Compiler.Parser.parse` and `Surface.Formatter.Render.node/2`
+             to modify node lists before they are rendered.
 
-  Some phases rely on other phases; `@moduledoc`s should make this explicit.
+             Some phases rely on other phases; `@moduledoc`s should make this explicit.
 
-  For reference, the formatter operates by running these phases in the following order:
+             For reference, the formatter operates by running these phases in the following order:
 
-    - `Surface.Formatter.Phases.TagWhitespace`
-    - `Surface.Formatter.Phases.Newlines`
-    - `Surface.Formatter.Phases.SpacesToNewlines`
-    - `Surface.Formatter.Phases.Indent`
-    - `Surface.Formatter.Phases.FinalNewline`
-    - `Surface.Formatter.Phases.BlockExceptions`
-    - `Surface.Formatter.Phases.Render`
-  """
+               - `Surface.Formatter.Phases.TagWhitespace`
+               - `Surface.Formatter.Phases.Newlines`
+               - `Surface.Formatter.Phases.SpacesToNewlines`
+               - `Surface.Formatter.Phases.Indent`
+               - `Surface.Formatter.Phases.FinalNewline`
+               - `Surface.Formatter.Phases.BlockExceptions`
+               - `Surface.Formatter.Phases.Render`
+             """ && false
 
   alias Surface.Formatter
 

--- a/lib/surface/formatter/phases/block_exceptions.ex
+++ b/lib/surface/formatter/phases/block_exceptions.ex
@@ -1,7 +1,7 @@
 defmodule Surface.Formatter.Phases.BlockExceptions do
   @moduledoc """
-  Handle exceptional case for blocks.
-  """
+             Handle exceptional case for blocks.
+             """ && false
 
   @behaviour Surface.Formatter.Phase
   alias Surface.Formatter.Phase

--- a/lib/surface/formatter/phases/final_newline.ex
+++ b/lib/surface/formatter/phases/final_newline.ex
@@ -1,5 +1,7 @@
 defmodule Surface.Formatter.Phases.FinalNewline do
-  @moduledoc "Add a newline after all of the nodes if one was present on the original input"
+  @moduledoc """
+             Add a newline after all of the nodes if one was present on the original input
+             """ && false
 
   @behaviour Surface.Formatter.Phase
 

--- a/lib/surface/formatter/phases/indent.ex
+++ b/lib/surface/formatter/phases/indent.ex
@@ -1,17 +1,17 @@
 defmodule Surface.Formatter.Phases.Indent do
   @moduledoc """
-  Adds indentation nodes (`:indent` and `:indent_one_less`) where appropriate.
+             Adds indentation nodes (`:indent` and `:indent_one_less`) where appropriate.
 
-  `Surface.Formatter.Render.node/2` is responsible for adding the appropriate
-  level of indentation. It keeps track of the indentation level based on how
-  "nested" a node is. While running Formatter Phases, it's not necessary to
-  keep track of that detail.
+             `Surface.Formatter.Render.node/2` is responsible for adding the appropriate
+             level of indentation. It keeps track of the indentation level based on how
+             "nested" a node is. While running Formatter Phases, it's not necessary to
+             keep track of that detail.
 
-  `:indent_one_less` exists to notate the indentation that should occur before
-  a closing tag, which is one less than its children.
+             `:indent_one_less` exists to notate the indentation that should occur before
+             a closing tag, which is one less than its children.
 
-  Relies on `Newlines` phase, which collapses :newline nodes to at most 2 in a row.
-  """
+             Relies on `Newlines` phase, which collapses :newline nodes to at most 2 in a row.
+             """ && false
 
   @behaviour Surface.Formatter.Phase
   alias Surface.Formatter.Phase

--- a/lib/surface/formatter/phases/newlines.ex
+++ b/lib/surface/formatter/phases/newlines.ex
@@ -1,10 +1,10 @@
 defmodule Surface.Formatter.Phases.Newlines do
   @moduledoc """
-  Standardizes usage of newlines.
+             Standardizes usage of newlines.
 
-  - Prevents more than 1 empty line in a row.
-  - Prevents an empty line separating an opening/closing tag from the contents inside.
-  """
+             - Prevents more than 1 empty line in a row.
+             - Prevents an empty line separating an opening/closing tag from the contents inside.
+             """ && false
 
   @behaviour Surface.Formatter.Phase
   alias Surface.Formatter.Phase

--- a/lib/surface/formatter/phases/render.ex
+++ b/lib/surface/formatter/phases/render.ex
@@ -1,8 +1,8 @@
 defmodule Surface.Formatter.Phases.Render do
   @moduledoc """
-  Render the formatted Surface code after it has run through the other
-  transforming phases.
-  """
+             Render the formatted Surface code after it has run through the other
+             transforming phases.
+             """ && false
 
   @behaviour Surface.Formatter.Phase
   alias Surface.Formatter

--- a/lib/surface/formatter/phases/spaces_to_newlines.ex
+++ b/lib/surface/formatter/phases/spaces_to_newlines.ex
@@ -1,13 +1,13 @@
 defmodule Surface.Formatter.Phases.SpacesToNewlines do
   @moduledoc """
-  In a variety of scenarios, converts :space nodes to :newline nodes.
+             In a variety of scenarios, converts :space nodes to :newline nodes.
 
-  (Below, "element" means an HTML element or a Surface component.)
+             (Below, "element" means an HTML element or a Surface component.)
 
-  1. If an element contains other elements as children, surround it with newlines.
-  1. If there is a space after an opening tag or before a closing tag, convert it to a newline.
-  1. If there is a closing tag on its own line, ensure there's a newline before the next sibling node.
-  """
+             1. If an element contains other elements as children, surround it with newlines.
+             1. If there is a space after an opening tag or before a closing tag, convert it to a newline.
+             1. If there is a closing tag on its own line, ensure there's a newline before the next sibling node.
+             """ && false
 
   @behaviour Surface.Formatter.Phase
   alias Surface.{Formatter, Formatter.Phase}

--- a/lib/surface/formatter/phases/tag_whitespace.ex
+++ b/lib/surface/formatter/phases/tag_whitespace.ex
@@ -1,10 +1,10 @@
 defmodule Surface.Formatter.Phases.TagWhitespace do
   @moduledoc """
-  Inspects all text nodes and "tags" leading and trailing whitespace
-  by converting it into a `:space` atom or a list of `:newline` atoms.
+             Inspects all text nodes and "tags" leading and trailing whitespace
+             by converting it into a `:space` atom or a list of `:newline` atoms.
 
-  This is the first phase of formatting, and all other phases depend on it.
-  """
+             This is the first phase of formatting, and all other phases depend on it.
+             """ && false
 
   @behaviour Surface.Formatter.Phase
   alias Surface.Formatter


### PR DESCRIPTION
This PR hides formatter modules that aren't part of the public API, leaving only two:

1. `mix surface.format`
2. `Surface.Formatter.Plugin`