### PR TITLE
Remove compile time dependency on root prop name

### DIFF
--- a/lib/surface/components/context.ex
+++ b/lib/surface/components/context.ex
@@ -96,7 +96,7 @@ defmodule Surface.Components.Context do
       node.props
       |> Enum.filter(fn %{name: name} -> name == :get end)
       |> Enum.map(fn %{value: %{value: value}} -> value end)
-      |> Enum.flat_map(fn {scope, values} ->
+      |> Enum.flat_map(fn {:__context_get__, scope, values} ->
         if scope == nil do
           values
         else

--- a/lib/surface/type_handler.ex
+++ b/lib/surface/type_handler.ex
@@ -35,15 +35,12 @@ defmodule Surface.TypeHandler do
   @callback value_to_opts(name :: atom(), value :: any()) ::
               {:ok, any()} | {:error, String.t()}
 
-  @callback update_prop_expr(expr :: Macro.t(), meta :: Surface.AST.Meta.t()) :: Macro.t()
-
   @optional_callbacks [
     literal_to_ast_node: 4,
     expr_to_quoted: 6,
     expr_to_value: 3,
     value_to_html: 2,
-    value_to_opts: 2,
-    update_prop_expr: 2
+    value_to_opts: 2
   ]
 
   @boolean_tag_attributes [
@@ -96,15 +93,12 @@ defmodule Surface.TypeHandler do
         defdelegate value_to_html(name, value), to: @default_handler
         @impl true
         defdelegate value_to_opts(name, value), to: @default_handler
-        @impl true
-        defdelegate update_prop_expr(expr, meta), to: @default_handler
 
         defoverridable literal_to_ast_node: 4,
                        expr_to_quoted: 6,
                        expr_to_value: 3,
                        value_to_html: 2,
-                       value_to_opts: 2,
-                       update_prop_expr: 2
+                       value_to_opts: 2
       end
     end
   end
@@ -204,10 +198,6 @@ defmodule Surface.TypeHandler do
       {:error, message} ->
         IOHelper.runtime_error(message)
     end
-  end
-
-  def update_prop_expr(type, value, meta) do
-    handler(type).update_prop_expr(value, meta)
   end
 
   def runtime_prop_value!(module, name, clauses, opts, node_alias, original, ctx) do

--- a/lib/surface/type_handler/context_get.ex
+++ b/lib/surface/type_handler/context_get.ex
@@ -13,7 +13,7 @@ defmodule Surface.TypeHandler.ContextGet do
   def expr_to_quoted(_type, _name, clauses, bindings, _meta, _original) do
     with {:ok, scope} <- TypesHelper.extract_scope(clauses),
          true <- TypesHelper.is_bindings?(bindings) do
-      {:ok, {scope, bindings}}
+      {:ok, {:__context_get__, scope, bindings}}
     else
       _ ->
         message = """
@@ -23,10 +23,5 @@ defmodule Surface.TypeHandler.ContextGet do
 
         {:error, message}
     end
-  end
-
-  @impl true
-  def update_prop_expr({scope, values}, _meta) do
-    {scope, Enum.map(values, fn {key, {name, _, _}} -> {key, name} end)}
   end
 end

--- a/lib/surface/type_handler/default.ex
+++ b/lib/surface/type_handler/default.ex
@@ -80,9 +80,4 @@ defmodule Surface.TypeHandler.Default do
   def value_to_opts(_name, value) do
     {:ok, value}
   end
-
-  @impl true
-  def update_prop_expr(value, _meta) do
-    value
-  end
 end

--- a/lib/surface/type_handler/generator.ex
+++ b/lib/surface/type_handler/generator.ex
@@ -13,19 +13,10 @@ defmodule Surface.TypeHandler.Generator do
   end
 
   def expr_to_quoted(_type, _name, [{:<-, _, [binding, value]}], [], _meta, _original) do
-    {:ok, {binding, value}}
+    {:ok, {:__generator__, binding, value}}
   end
 
   def expr_to_quoted(_type, _attribute_name, _clauses, _opts, _meta, _original) do
     {:error, "Expected a :generator Example: `{i <- ...}`"}
-  end
-
-  @impl true
-  def update_prop_expr({_, value}, _meta) do
-    value
-  end
-
-  def update_prop_expr(value, _meta) do
-    value
   end
 end

--- a/lib/surface/type_handler/list.ex
+++ b/lib/surface/type_handler/list.ex
@@ -22,10 +22,6 @@ defmodule Surface.TypeHandler.List do
     :error
   end
 
-  defp handle_list_expr(_name, {:<-, _, [binding, value]}, _module) do
-    {binding, value}
-  end
-
   defp handle_list_expr(_name, expr, _module) when is_list(expr), do: expr
 
   defp handle_list_expr(name, expr, module) do
@@ -40,14 +36,5 @@ defmodule Surface.TypeHandler.List do
           raise "invalid value for property \"#{unquote(name)}\". Expected a :list, got: #{inspect(value)}"
       end
     end
-  end
-
-  @impl true
-  def update_prop_expr({_, value}, _meta) do
-    value
-  end
-
-  def update_prop_expr(value, _meta) do
-    value
   end
 end

--- a/test/surface/integrations/properties_test.exs
+++ b/test/surface/integrations/properties_test.exs
@@ -1154,6 +1154,27 @@ defmodule Surface.PropertiesSyncTest do
              """
     end
 
+    test "warns without root prop" do
+      output =
+        capture_io(:standard_error, fn ->
+          html =
+            render_surface do
+              ~F"""
+              <StringProp {"root label"} />
+              """
+            end
+
+          assert html =~ """
+                 """
+        end)
+
+      assert output =~ """
+             no root property defined for component <StringProp>
+
+             Hint: you can declare a root property using option `root: true`
+             """
+    end
+
     test "literal expression to list prop don't emit warnings" do
       code =
         quote do


### PR DESCRIPTION
Using `:__root__` as a temporary name to find the prop at runtime

Also lowers the compile time dependency to `:context_get` and `:generator` types.