### PR TITLE
Remove compile-time deps from components

### DIFF
--- a/test/support/components_calls_test/component_with_external_template.sface
+++ b/test/support/components_calls_test/component_with_external_template.sface
@@ -1,1 +1,2 @@
 <ComponentCall />
+<#Raw>text</#Raw>

--- a/test/surface/components_calls_test.exs
+++ b/test/surface/components_calls_test.exs
@@ -1,39 +1,164 @@
 defmodule Surface.ComponentsCallsTest do
   use Surface.ConnCase, async: true
 
-  test "Component has __component_calls__/0" do
-    assert Surface.ComponentsCallsTest.Components.ComponentWithExternalTemplate.__components_calls__() == [
-             %{
-               component: Surface.ComponentsCallsTest.Components.ComponentCall,
-               directives: [],
-               line: 1,
-               node_alias: "ComponentCall",
-               props: []
-             }
-           ]
+  describe "__component_calls__/0" do
+    test "on Component" do
+      assert Surface.ComponentsCallsTest.Components.ComponentWithExternalTemplate.__components_calls__() == [
+               %{
+                 component: Surface.Components.Raw,
+                 directives: [],
+                 line: 2,
+                 node_alias: "#Raw",
+                 props: [],
+                 dep_type: :compile
+               },
+               %{
+                 component: Surface.ComponentsCallsTest.Components.ComponentCall,
+                 directives: [],
+                 line: 1,
+                 node_alias: "ComponentCall",
+                 props: [],
+                 dep_type: :export
+               }
+             ]
+    end
+
+    test "on LiveComponent" do
+      assert Surface.ComponentsCallsTest.Components.LiveComponentWithExternalTemplate.__components_calls__() == [
+               %{
+                 component: Surface.ComponentsCallsTest.Components.ComponentCall,
+                 directives: [],
+                 line: 1,
+                 node_alias: "ComponentCall",
+                 props: [],
+                 dep_type: :export
+               }
+             ]
+    end
+
+    test "on LiveView" do
+      assert Surface.ComponentsCallsTest.Components.LiveViewWithExternalTemplate.__components_calls__() == [
+               %{
+                 component: Surface.ComponentsCallsTest.Components.ComponentCall,
+                 directives: [],
+                 line: 1,
+                 node_alias: "ComponentCall",
+                 props: [],
+                 dep_type: :export
+               }
+             ]
+    end
   end
 
-  test "LiveComponent has __component_calls__/0" do
-    assert Surface.ComponentsCallsTest.Components.LiveComponentWithExternalTemplate.__components_calls__() == [
-             %{
-               component: Surface.ComponentsCallsTest.Components.ComponentCall,
-               directives: [],
-               line: 1,
-               node_alias: "ComponentCall",
-               props: []
-             }
-           ]
-  end
+  describe "define __surface_sig_xxxxxx_/0 to trigger dependents recompilation" do
+    defmodule ComponentSignature do
+      use Surface.Component
 
-  test "LiveView has __component_calls__/0" do
-    assert Surface.ComponentsCallsTest.Components.LiveViewWithExternalTemplate.__components_calls__() == [
-             %{
-               component: Surface.ComponentsCallsTest.Components.ComponentCall,
-               directives: [],
-               line: 1,
-               node_alias: "ComponentCall",
-               props: []
-             }
-           ]
+      def render(assigns), do: ~F[<div></div>]
+    end
+
+    defmodule LiveComponentSignature do
+      use Surface.LiveComponent
+
+      def render(assigns), do: ~F[<div></div>]
+    end
+
+    defmodule ComponentSignatureWithProps do
+      use Surface.Component
+
+      prop prop1, :string
+      prop prop2, :string
+
+      def render(assigns), do: ~F[<div></div>]
+    end
+
+    defmodule ComponentSignatureWithPropsAndOptions do
+      use Surface.Component
+
+      prop prop1, :string, required: true
+      prop prop2, :string
+
+      def render(assigns), do: ~F[<div></div>]
+    end
+
+    defmodule ComponentSignatureWithWithPropsAndSlots do
+      use Surface.Component
+
+      prop prop1, :string
+      prop prop2, :string
+      slot slot1
+      slot slot2
+
+      def render(assigns), do: ~F[<div></div>]
+    end
+
+    defmodule ComponentSignatureWithPropsAndSlotName do
+      use Surface.Component, slot: "col"
+
+      prop prop1, :string
+      prop prop2, :string
+
+      def render(assigns), do: ~F[<div></div>]
+    end
+
+    defmodule ComponentSignatureWithPropsAndDifferentRender do
+      use Surface.Component
+
+      prop prop1, :string
+      prop prop2, :string
+
+      def render(assigns), do: ~F[<div>I'm different</div>]
+    end
+
+    defmodule ComponentSignatureWithWithPropsAndSlotsReversed do
+      use Surface.Component
+
+      slot slot2
+      slot slot1
+      prop prop2, :string
+      prop prop1, :string
+
+      def render(assigns), do: ~F[<div></div>]
+    end
+
+    test "gererate signature function" do
+      sig_func = ComponentSignature.__surface_sig__()
+      assert function_exported?(ComponentSignature, sig_func, 0)
+    end
+
+    test "the type of component changes the signature" do
+      assert ComponentSignature.__surface_sig__() !=
+               LiveComponentSignature.__surface_sig__()
+    end
+
+    test "props change the signature" do
+      assert ComponentSignature.__surface_sig__() !=
+               ComponentSignatureWithProps.__surface_sig__()
+    end
+
+    test "options change the signature" do
+      assert ComponentSignatureWithProps.__surface_sig__() !=
+               ComponentSignatureWithPropsAndOptions.__surface_sig__()
+    end
+
+    test "slots change the signature" do
+      assert ComponentSignatureWithProps.__surface_sig__() !=
+               ComponentSignatureWithWithPropsAndSlots.__surface_sig__()
+    end
+
+    test "the slot name changes the signature (slotable component)" do
+      assert ComponentSignatureWithProps.__surface_sig__() !=
+               ComponentSignatureWithPropsAndSlotName.__surface_sig__()
+    end
+
+    test "the order of props and slots is ignored so it doesn't change the signature" do
+      assert ComponentSignatureWithWithPropsAndSlots.__surface_sig__() ==
+               ComponentSignatureWithWithPropsAndSlotsReversed.__surface_sig__()
+    end
+
+    test "changes inside any function (including render/1) don't change the signature" do
+      assert ComponentSignatureWithProps.__surface_sig__() ==
+               ComponentSignatureWithPropsAndDifferentRender.__surface_sig__()
+    end
   end
 end


### PR DESCRIPTION
Removes `compile` deps from components and turn them into `export`. 

The basic rules you can expect when changing a component from now on are:

* Changes in the public API (props, slots, component type, etc.) trigger recompilation only of direct callers (no more transitive deps)
* Other changes, including changes inside `render/1`, trigger recompilation only of the component itself
* For macro components and components implementing `transform/1`, the behavior is exactly as an elixir macro, so it creates a `compile` dep which keeps track of transitive compile-time deps.
