### PR TITLE
Fix scoped css issues

### DIFF
--- a/lib/surface/compiler/css_parser.ex
+++ b/lib/surface/compiler/css_parser.ex
@@ -25,15 +25,6 @@ defmodule Surface.Compiler.CSSParser do
     handle_token(tokens, [[]], state)
   end
 
-  defp handle_token([{:comma, opening} = token | rest], buffers, %{candidate?: true} = state)
-       when opening != "(" do
-    [buffer | buffers] = buffers
-    node = buffer_to_node(buffer, :selector_list)
-    buffers = push_node_to_current_buffer(node, buffers)
-    buffers = push_node_to_current_buffer(token, buffers)
-    handle_token(rest, buffers, %{state | candidate?: false})
-  end
-
   defp handle_token([{:block_open, "{"} | rest], buffers, %{candidate?: true} = state) do
     [buffer | buffers] = buffers
     node = buffer_to_node(buffer, :selector_list)

--- a/lib/surface/compiler/css_parser.ex
+++ b/lib/surface/compiler/css_parser.ex
@@ -28,7 +28,7 @@ defmodule Surface.Compiler.CSSParser do
   defp handle_token([{:comma, opening} = token | rest], buffers, %{candidate?: true} = state)
        when opening != "(" do
     [buffer | buffers] = buffers
-    node = buffer_to_node(buffer, :selector)
+    node = buffer_to_node(buffer, :selector_list)
     buffers = push_node_to_current_buffer(node, buffers)
     buffers = push_node_to_current_buffer(token, buffers)
     handle_token(rest, buffers, %{state | candidate?: false})
@@ -36,7 +36,7 @@ defmodule Surface.Compiler.CSSParser do
 
   defp handle_token([{:block_open, "{"} | rest], buffers, %{candidate?: true} = state) do
     [buffer | buffers] = buffers
-    node = buffer_to_node(buffer, :selector)
+    node = buffer_to_node(buffer, :selector_list)
     buffers = push_node_to_current_buffer(node, buffers)
     buffers = [[] | buffers]
     handle_token(rest, buffers, %{state | candidate?: false})

--- a/lib/surface/compiler/css_tokenizer.ex
+++ b/lib/surface/compiler/css_tokenizer.ex
@@ -203,7 +203,6 @@ defmodule Surface.Compiler.CSSTokenizer do
   defp text_to_acc([], acc), do: acc
   defp text_to_acc(buffer, acc), do: [{:text, buffer_to_string(buffer)} | acc]
 
-  defp string_to_acc([], _delimiter, acc), do: acc
   defp string_to_acc(buffer, delimiter, acc), do: [{:string, delimiter, buffer_to_string(buffer)} | acc]
 
   defp comment_to_acc([], acc), do: acc

--- a/lib/surface/compiler/css_translator.ex
+++ b/lib/surface/compiler/css_translator.ex
@@ -84,7 +84,7 @@ defmodule Surface.Compiler.CSSTranslator do
     translate(rest, acc, state)
   end
 
-  defp translate([{:selector, tokens} | rest], acc, state) do
+  defp translate([{:selector_list, tokens} | rest], acc, state) do
     {updated_tokens, state} = translate_selector(tokens, [], state)
     acc = [updated_tokens | acc]
     translate(rest, acc, state)

--- a/lib/surface/compiler/css_translator.ex
+++ b/lib/surface/compiler/css_translator.ex
@@ -112,6 +112,7 @@ defmodule Surface.Compiler.CSSTranslator do
     {Enum.reverse(acc), state}
   end
 
+  # :deep as the first selector
   defp translate_selector_list([{:text, ":deep"}, {:block, "(", arg, _meta} | rest], acc, state) do
     {updated_tokens, state} = translate(arg, [], state)
     state = %{state | requires_data_attrs_on_root: true}
@@ -123,7 +124,14 @@ defmodule Surface.Compiler.CSSTranslator do
     translate_selector(tokens, acc, state)
   end
 
+  # TODO: check if it's maybe better to just always add [data-s-self][data-s-xxxxxx]
   defp translate_selector([{:text, ":deep"}, {:block, "(", arg, _meta} | rest], acc, state) do
+    {updated_tokens, state} = translate(arg, [], state)
+    acc = [updated_tokens | acc]
+    translate_selector(rest, acc, state)
+  end
+
+  defp translate_selector([{:text, ":global"}, {:block, "(", arg, _meta} | rest], acc, state) do
     {updated_tokens, state} = translate(arg, [], state)
     acc = [updated_tokens | acc]
     translate_selector(rest, acc, state)

--- a/lib/surface/compiler/css_translator.ex
+++ b/lib/surface/compiler/css_translator.ex
@@ -84,10 +84,14 @@ defmodule Surface.Compiler.CSSTranslator do
     translate(rest, acc, state)
   end
 
-  defp translate([{:selector_list, tokens} | rest], acc, state) do
+  defp translate([{:selector_list, []} | rest], acc, state) do
+    translate(rest, acc, state)
+  end
+
+  defp translate([{:selector_list, [tokens | list]} | rest], acc, state) do
     {updated_tokens, state} = translate_selector(tokens, [], state)
     acc = [updated_tokens | acc]
-    translate(rest, acc, state)
+    translate([{:selector_list, list} | rest], acc, state)
   end
 
   defp translate([{:declaration, tokens} | rest], acc, state) do

--- a/test/surface/compiler/css_parser_test.exs
+++ b/test/surface/compiler/css_parser_test.exs
@@ -13,7 +13,7 @@ defmodule Surface.Compiler.CSSParserTest do
 
     assert CSSParser.parse!(css) ==
              [
-               {:selector_list, [text: ".root", ws: " "]},
+               {:selector_list, [[text: ".root", ws: " "]]},
                {:block, "{",
                 [
                   {:ws, " "},
@@ -28,7 +28,7 @@ defmodule Surface.Compiler.CSSParserTest do
     css = ".root{padding: 1px}"
 
     assert CSSParser.parse!(css) == [
-             {:selector_list, [{:text, ".root"}]},
+             {:selector_list, [[{:text, ".root"}]]},
              {:block, "{", [{:declaration, [{:text, "padding"}, {:text, ":"}, {:ws, " "}, {:text, "1px"}]}],
               %{column: 6, column_end: 19, line: 1, line_end: 1}}
            ]
@@ -43,7 +43,7 @@ defmodule Surface.Compiler.CSSParserTest do
     """
 
     assert CSSParser.parse!(css) == [
-             {:selector_list, [text: ".root", ws: " "]},
+             {:selector_list, [[text: ".root", ws: " "]]},
              {:block, "{",
               [
                 {:ws, "\n  "},
@@ -80,7 +80,7 @@ defmodule Surface.Compiler.CSSParserTest do
              {:block, "{",
               [
                 {:ws, "\n  "},
-                {:selector_list, [{:text, ".a"}, {:ws, " "}]},
+                {:selector_list, [[{:text, ".a"}, {:ws, " "}]]},
                 {:block, "{",
                  [
                    {:declaration, [{:text, "display"}, {:text, ":"}, {:ws, " "}, {:text, "block"}]}
@@ -95,7 +95,7 @@ defmodule Surface.Compiler.CSSParserTest do
     div.blog { display: block }
     """
 
-    assert [{:selector_list, [{:text, "div"}, {:text, ".blog"}, {:ws, " "}]} | _] = CSSParser.parse!(css)
+    assert [{:selector_list, [[{:text, "div"}, {:text, ".blog"}, {:ws, " "}]]} | _] = CSSParser.parse!(css)
   end
 
   test "parse multiple selector blocks" do
@@ -105,35 +105,45 @@ defmodule Surface.Compiler.CSSParserTest do
     """
 
     assert [
-             {:selector_list, [text: ".a"]},
+             {:selector_list, [[text: ".a"]]},
              {:block, "{", [declaration: [text: "padding", text: ":", ws: " ", text: "1px"]], _},
              {:ws, "\n"},
-             {:selector_list, [text: ".b"]},
+             {:selector_list, [[text: ".b"]]},
              {:block, "{", [declaration: [text: "padding", text: ":", ws: " ", text: "1px"]], _},
              {:ws, "\n"}
            ] = CSSParser.parse!(css)
   end
 
   test "parse multiple selector items" do
-    css = ".a > .b, .c {padding: 1px}"
+    css = ".a > .b, .c ,  .d {padding: 1px}"
 
     assert CSSParser.parse!(css) == [
              {:selector_list,
               [
-                {:text, ".a"},
-                {:ws, " "},
-                {:text, ">"},
-                {:ws, " "},
-                {:text, ".b"},
-                {:comma, nil},
-                {:ws, " "},
-                {:text, ".c"},
-                {:ws, " "}
+                [
+                  {:text, ".a"},
+                  {:ws, " "},
+                  {:text, ">"},
+                  {:ws, " "},
+                  {:text, ".b"},
+                  {:comma, nil},
+                  {:ws, " "}
+                ],
+                [
+                  {:text, ".c"},
+                  {:ws, " "},
+                  {:comma, nil},
+                  {:ws, "  "}
+                ],
+                [
+                  {:text, ".d"},
+                  {:ws, " "}
+                ]
               ]},
              {:block, "{",
               [
                 {:declaration, [{:text, "padding"}, {:text, ":"}, {:ws, " "}, {:text, "1px"}]}
-              ], %{column: 13, column_end: 26, line: 1, line_end: 1}}
+              ], %{column: 19, column_end: 32, line: 1, line_end: 1}}
            ]
   end
 end

--- a/test/surface/compiler/css_parser_test.exs
+++ b/test/surface/compiler/css_parser_test.exs
@@ -100,32 +100,40 @@ defmodule Surface.Compiler.CSSParserTest do
 
   test "parse multiple selector blocks" do
     css = """
-      .a{padding: 1px}
-      .b{padding: 1px}
-      """
+    .a{padding: 1px}
+    .b{padding: 1px}
+    """
 
-      assert [
-        {:selector_list, [text: ".a"]},
-        {:block, "{", [declaration: [text: "padding", text: ":", ws: " ", text: "1px"]], _},
-        {:ws, "\n"},
-        {:selector_list, [text: ".b"]},
-        {:block, "{", [declaration: [text: "padding", text: ":", ws: " ", text: "1px"]], _},
-        {:ws, "\n"}
-      ] = CSSParser.parse!(css)
+    assert [
+             {:selector_list, [text: ".a"]},
+             {:block, "{", [declaration: [text: "padding", text: ":", ws: " ", text: "1px"]], _},
+             {:ws, "\n"},
+             {:selector_list, [text: ".b"]},
+             {:block, "{", [declaration: [text: "padding", text: ":", ws: " ", text: "1px"]], _},
+             {:ws, "\n"}
+           ] = CSSParser.parse!(css)
   end
 
   test "parse multiple selector items" do
-    css = """
-    .a > .b, .c {padding: 1px}
-    """
+    css = ".a > .b, .c {padding: 1px}"
 
     assert CSSParser.parse!(css) == [
-      {:selector_list, [text: ".a", ws: " ", text: ">", ws: " ", text: ".b"]},
-      {:comma, nil},
-      {:ws, " "},
-      {:selector_list, [text: ".c", ws: " "]},
-      {:block, "{", [declaration: [text: "padding", text: ":", ws: " ", text: "1px"]], %{column: 13, column_end: 26, line: 1, line_end: 1}},
-      {:ws, "\n"}
-    ]
+             {:selector_list,
+              [
+                {:text, ".a"},
+                {:ws, " "},
+                {:text, ">"},
+                {:ws, " "},
+                {:text, ".b"},
+                {:comma, nil},
+                {:ws, " "},
+                {:text, ".c"},
+                {:ws, " "}
+              ]},
+             {:block, "{",
+              [
+                {:declaration, [{:text, "padding"}, {:text, ":"}, {:ws, " "}, {:text, "1px"}]}
+              ], %{column: 13, column_end: 26, line: 1, line_end: 1}}
+           ]
   end
 end

--- a/test/surface/compiler/css_parser_test.exs
+++ b/test/surface/compiler/css_parser_test.exs
@@ -13,7 +13,7 @@ defmodule Surface.Compiler.CSSParserTest do
 
     assert CSSParser.parse!(css) ==
              [
-               {:selector, [text: ".root", ws: " "]},
+               {:selector_list, [text: ".root", ws: " "]},
                {:block, "{",
                 [
                   {:ws, " "},
@@ -28,7 +28,7 @@ defmodule Surface.Compiler.CSSParserTest do
     css = ".root{padding: 1px}"
 
     assert CSSParser.parse!(css) == [
-             {:selector, [{:text, ".root"}]},
+             {:selector_list, [{:text, ".root"}]},
              {:block, "{", [{:declaration, [{:text, "padding"}, {:text, ":"}, {:ws, " "}, {:text, "1px"}]}],
               %{column: 6, column_end: 19, line: 1, line_end: 1}}
            ]
@@ -43,7 +43,7 @@ defmodule Surface.Compiler.CSSParserTest do
     """
 
     assert CSSParser.parse!(css) == [
-             {:selector, [text: ".root", ws: " "]},
+             {:selector_list, [text: ".root", ws: " "]},
              {:block, "{",
               [
                 {:ws, "\n  "},
@@ -80,7 +80,7 @@ defmodule Surface.Compiler.CSSParserTest do
              {:block, "{",
               [
                 {:ws, "\n  "},
-                {:selector, [{:text, ".a"}, {:ws, " "}]},
+                {:selector_list, [{:text, ".a"}, {:ws, " "}]},
                 {:block, "{",
                  [
                    {:declaration, [{:text, "display"}, {:text, ":"}, {:ws, " "}, {:text, "block"}]}
@@ -95,108 +95,37 @@ defmodule Surface.Compiler.CSSParserTest do
     div.blog { display: block }
     """
 
-    assert [{:selector, [{:text, "div"}, {:text, ".blog"}, {:ws, " "}]} | _] = CSSParser.parse!(css)
+    assert [{:selector_list, [{:text, "div"}, {:text, ".blog"}, {:ws, " "}]} | _] = CSSParser.parse!(css)
   end
 
-  test "parse multiple css rules" do
+  test "parse multiple selector blocks" do
     css = """
-    /* padding: s-bind(padding); */
+      .a{padding: 1px}
+      .b{padding: 1px}
+      """
 
-    .root {
-      --custom-color: s-bind('@css.background');
-    }
+      assert [
+        {:selector_list, [text: ".a"]},
+        {:block, "{", [declaration: [text: "padding", text: ":", ws: " ", text: "1px"]], _},
+        {:ws, "\n"},
+        {:selector_list, [text: ".b"]},
+        {:block, "{", [declaration: [text: "padding", text: ":", ws: " ", text: "1px"]], _},
+        {:ws, "\n"}
+      ] = CSSParser.parse!(css)
+  end
 
-    .a:has(> img) > b[class="btn"], c {
-      padding: s-bind('@padding');
-    }
-
-    @media screen and (min-width: 1216px) {
-      .blog { display: block; }
-    }
-
-    @tailwind utilities;
+  test "parse multiple selector items" do
+    css = """
+    .a > .b, .c {padding: 1px}
     """
 
     assert CSSParser.parse!(css) == [
-             {:comment, " padding: s-bind(padding); "},
-             {:ws, "\n\n"},
-             {:selector, [text: ".root", ws: " "]},
-             {:block, "{",
-              [
-                {:ws, "\n  "},
-                {:declaration,
-                 [
-                   {:text, "--custom-color"},
-                   {:text, ":"},
-                   {:ws, " "},
-                   {:text, "s-bind"},
-                   {:block, "(", [{:string, "\'", "@css.background"}],
-                    %{column: 25, column_end: 43, line: 4, line_end: 4}}
-                 ]},
-                :semicolon,
-                {:ws, "\n"}
-              ], %{column: 7, column_end: 1, line: 3, line_end: 5}},
-             {:ws, "\n\n"},
-             {:selector,
-              [
-                {:text, ".a"},
-                {:text, ":has"},
-                {:block, "(", [text: ">", ws: " ", text: "img"],
-                 %{column: 7, column_end: 13, line: 7, line_end: 7}},
-                {:ws, " "},
-                {:text, ">"},
-                {:ws, " "},
-                {:text, "b"},
-                {:block, "[", [{:text, "class="}, {:string, "\"", "btn"}],
-                 %{column: 18, column_end: 30, line: 7, line_end: 7}}
-              ]},
-             {:comma, nil},
-             {:ws, " "},
-             {:selector, [text: "c", ws: " "]},
-             {:block, "{",
-              [
-                {:ws, "\n  "},
-                {:declaration,
-                 [
-                   {:text, "padding"},
-                   {:text, ":"},
-                   {:ws, " "},
-                   {:text, "s-bind"},
-                   {:block, "(", [{:string, "'", "@padding"}], %{column: 18, column_end: 29, line: 8, line_end: 8}}
-                 ]},
-                :semicolon,
-                {:ws, "\n"}
-              ], %{column: 35, column_end: 1, line: 7, line_end: 9}},
-             {:ws, "\n\n"},
-             {:at_rule,
-              [
-                {:text, "@media"},
-                {:ws, " "},
-                {:text, "screen"},
-                {:ws, " "},
-                {:text, "and"},
-                {:ws, " "},
-                {:block, "(", [text: "min-width", text: ":", ws: " ", text: "1216px"],
-                 %{column: 19, column_end: 37, line: 11, line_end: 11}},
-                {:ws, " "}
-              ]},
-             {:block, "{",
-              [
-                {:ws, "\n  "},
-                {:selector, [text: ".blog", ws: " "]},
-                {:block, "{",
-                 [
-                   {:ws, " "},
-                   {:declaration, [text: "display", text: ":", ws: " ", text: "block"]},
-                   :semicolon,
-                   {:ws, " "}
-                 ], %{column: 9, column_end: 27, line: 12, line_end: 12}},
-                {:ws, "\n"}
-              ], %{column: 39, column_end: 1, line: 11, line_end: 13}},
-             {:ws, "\n\n"},
-             {:at_rule, [text: "@tailwind", ws: " ", text: "utilities"]},
-             :semicolon,
-             {:ws, "\n"}
-           ]
+      {:selector_list, [text: ".a", ws: " ", text: ">", ws: " ", text: ".b"]},
+      {:comma, nil},
+      {:ws, " "},
+      {:selector_list, [text: ".c", ws: " "]},
+      {:block, "{", [declaration: [text: "padding", text: ":", ws: " ", text: "1px"]], %{column: 13, column_end: 26, line: 1, line_end: 1}},
+      {:ws, "\n"}
+    ]
   end
 end

--- a/test/surface/compiler/css_tokenizer_test.exs
+++ b/test/surface/compiler/css_tokenizer_test.exs
@@ -132,6 +132,53 @@ defmodule Surface.Compiler.CSSTokenizerTest do
     assert [_, _, {:text, "title="}, {:string, "\'", "quote:\""}, _ | _] = CSSTokenizer.tokenize!(css)
   end
 
+  test "handle empty strings" do
+    css = "div{content:''}"
+
+    assert [
+             {:text, "div"},
+             {:block_open, "{"},
+             {:text, "content"},
+             {:text, ":"},
+             {:string, "'", ""},
+             {:block_close, "}", _}
+           ] = CSSTokenizer.tokenize!(css)
+
+    css = ~S(div{content:""})
+
+    assert [
+             {:text, "div"},
+             {:block_open, "{"},
+             {:text, "content"},
+             {:text, ":"},
+             {:string, "\"", ""},
+             {:block_close, "}", _}
+           ] = CSSTokenizer.tokenize!(css)
+  end
+
+  test "handle empty {} blocks" do
+    css = "div{}"
+
+    assert [
+             {:text, "div"},
+             {:block_open, "{"},
+             {:block_close, "}", _}
+           ] = CSSTokenizer.tokenize!(css)
+  end
+
+  test "handle empty () blocks" do
+    css = "div{foo()}"
+
+    assert [
+             {:text, "div"},
+             {:block_open, "{"},
+             {:text, "foo"},
+             {:block_open, "("},
+             {:block_close, ")", _},
+             {:block_close, "}", _}
+           ] = CSSTokenizer.tokenize!(css)
+  end
+
   test "handle pseudo classes" do
     css = """
     .a:has(>img) {padding: 1px}

--- a/test/surface/compiler/css_translator_test.exs
+++ b/test/surface/compiler/css_translator_test.exs
@@ -187,4 +187,34 @@ defmodule Surface.Compiler.CSSTranslatorTest do
     assert selectors.elements == MapSet.new(["a"])
     assert selectors.classes == MapSet.new(["external-link"])
   end
+
+  test "add self and scope data when selector starts with :deep" do
+    css = """
+    :deep(div > .link) {
+      @apply hover:underline;
+    }
+
+    :deep(.a .link), :deep(.b .link) {
+      @apply hover:underline;
+    }
+    """
+
+    %{css: translated, selectors: selectors} = CSSTranslator.translate!(css, scope_id: "myscope")
+
+    assert translated == """
+           [data-s-self][data-s-myscope] div > .link {
+             @apply hover:underline;
+           }
+
+           [data-s-self][data-s-myscope] .a .link, [data-s-self][data-s-myscope] .b .link {
+             @apply hover:underline;
+           }
+           """
+
+    assert selectors.elements == MapSet.new([])
+    assert selectors.classes == MapSet.new([])
+    assert selectors.ids == MapSet.new([])
+    assert selectors.other == MapSet.new([])
+    assert selectors.combined == MapSet.new([])
+  end
 end

--- a/test/surface/compiler/css_translator_test.exs
+++ b/test/surface/compiler/css_translator_test.exs
@@ -122,4 +122,44 @@ defmodule Surface.Compiler.CSSTranslatorTest do
 
     assert selectors.classes == MapSet.new(["test"])
   end
+
+  test "translate declaration with value containing commas" do
+    css = """
+    .Input [data-input] {
+      font-feature-settings: 'case', 'cpsp' 0, 'dlig' 0, 'ccmp', 'kern';
+    }
+    """
+
+    %{css: translated, selectors: selectors} = CSSTranslator.translate!(css, scope_id: "myscope")
+
+    assert translated == """
+           .Input[data-s-myscope] [data-input] {
+             font-feature-settings: 'case', 'cpsp' 0, 'dlig' 0, 'ccmp', 'kern';
+           }
+           """
+
+    assert selectors.classes == MapSet.new(["Input"])
+  end
+
+  test "translate declaration with variants" do
+    css = """
+    a {
+      @apply bg-sky-500 hover:bg-sky-700;
+      @apply lg:[&:nth-child(3)]:hover:underline;
+      @apply [&_p]:mt-4;
+    }
+    """
+
+    %{css: translated, selectors: selectors} = CSSTranslator.translate!(css, scope_id: "myscope")
+
+    assert translated == """
+           a[data-s-myscope] {
+             @apply bg-sky-500 hover:bg-sky-700;
+             @apply lg:[&:nth-child(3)]:hover:underline;
+             @apply [&_p]:mt-4;
+           }
+           """
+
+    assert selectors.elements == MapSet.new(["a"])
+  end
 end

--- a/test/surface/component_style_test.exs
+++ b/test/surface/component_style_test.exs
@@ -206,6 +206,31 @@ defmodule Surface.ComponentStyleTest do
            """
   end
 
+  test "inject s-data-* on the root node if :deep is used at the begining" do
+    html =
+      render_surface do
+        ~F"""
+        <style>
+          :deep(a) .link {
+            @apply hover:underline;
+          }
+        </style>
+
+        <div>
+          <div>ok</div>
+        </div>
+        <div class="a">ok</div>
+        """
+      end
+
+    assert html =~ """
+           <div data-s-self data-s-03cb861>
+             <div>ok</div>
+           </div>
+           <div data-s-self data-s-03cb861 class="a">ok</div>
+           """
+  end
+
   test "inject s-data-* in any element that matches any selector group. No matter if it doesn't match the whole selector" do
     html =
       render_surface do


### PR DESCRIPTION
* Fix CSS tokenizer handling empty strings
* Fix CSS parser for declarations with commas or variants
* Handle `:deep` as first selector
* Add `:global` pseudo-class