### PR TITLE
Deprecate `:for` directive.

### DIFF
--- a/lib/surface/directive/for.ex
+++ b/lib/surface/directive/for.ex
@@ -2,9 +2,8 @@ defmodule Surface.Directive.For do
   use Surface.Directive
 
   def extract({":for", {:attribute_expr, value, expr_meta}, attr_meta}, meta) do
-    # TODO: deprecate :for after releasing v0.7
-    # message = "directive :for has been deprecated. Please use the {#for ...} block instead."
-    # Surface.IOHelper.warn(message, meta.caller, expr_meta.line)
+    message = "directive :for has been deprecated. Please use the {#for ...} block instead."
+    Surface.IOHelper.warn(message, meta.caller, expr_meta.line)
 
     %AST.Directive{
       module: __MODULE__,

--- a/test/mix/tasks/compile/surface/validate_components_test.exs
+++ b/test/mix/tasks/compile/surface/validate_components_test.exs
@@ -342,7 +342,9 @@ defmodule Mix.Tasks.Compile.Surface.ValidateComponentsTest do
 
     def render(assigns) do
       ~F"""
-      <span :for={v <- @prop}>value: {v}</span>
+      {#for v <- @prop}
+        <span>value: {v}</span>
+      {/for}
       """
     end
   end

--- a/test/surface/components/context_test.exs
+++ b/test/surface/components/context_test.exs
@@ -90,9 +90,11 @@ defmodule Surface.Components.ContextTest do
     def render(assigns) do
       ~F"""
       <Context put={field: "field from OuterWithNamedSlots"}>
-        <span :for={slot <- @my_slot}>
-          <#slot {slot} />
-        </span>
+        {#for slot <- @my_slot}
+          <span>
+            <#slot {slot} />
+          </span>
+        {/for}
       </Context>
       """
     end

--- a/test/surface/constructs/for_test.exs
+++ b/test/surface/constructs/for_test.exs
@@ -9,7 +9,9 @@ defmodule Surface.Constructs.ForTest do
     def render(assigns) do
       ~F"""
       List?: {is_list(@prop)}
-      <span :for={v <- @prop}>value: {inspect(v)}</span>
+      {#for v <- @prop}
+        <span>value: {inspect(v)}</span>
+      {/for}
       """
     end
   end

--- a/test/surface/constructs/if_test.exs
+++ b/test/surface/constructs/if_test.exs
@@ -9,7 +9,9 @@ defmodule Surface.Constructs.IfTest do
     def render(assigns) do
       ~F"""
       List?: {is_list(@prop)}
-      <span :for={v <- @prop}>value: {inspect(v)}</span>
+      {#for v <- @prop}
+        <span>value: {inspect(v)}</span>
+      {/for}
       """
     end
   end

--- a/test/surface/integrations/properties_test.exs
+++ b/test/surface/integrations/properties_test.exs
@@ -33,7 +33,7 @@ defmodule Surface.PropertiesTest do
     def render(assigns) do
       ~F"""
       Map?: {is_map(@prop)}
-      <span :for={{k, v} <- @prop}>key: {k}, value: {v}</span>
+      {#for {k,v} <- @prop}<span>key: {k}, value: {v}</span>{/for}
       """
     end
   end
@@ -46,7 +46,7 @@ defmodule Surface.PropertiesTest do
     def render(assigns) do
       ~F"""
       List?: {is_list(@prop)}
-      <span :for={v <- @prop}>value: {inspect(v)}</span>
+      {#for v <- @prop}<span>value: {inspect(v)}</span>{/for}
       """
     end
   end
@@ -59,7 +59,7 @@ defmodule Surface.PropertiesTest do
     def render(assigns) do
       ~F"""
       Keyword?: {Keyword.keyword?(@prop)}
-      <span :for={{k, v} <- @prop}>key: {k}, value: {v}</span>
+      {#for {k,v} <- @prop}<span>key: {k}, value: {v}</span>{/for}
       """
     end
   end
@@ -83,7 +83,7 @@ defmodule Surface.PropertiesTest do
 
     def render(assigns) do
       ~F"""
-      <div :for={c <- @prop}>{c}</div>
+      {#for c <- @prop}<div>{c}</div>{/for}
       """
     end
   end
@@ -96,7 +96,7 @@ defmodule Surface.PropertiesTest do
     def render(assigns) do
       ~F"""
       List?: {is_list(@prop)}
-      <span :for={v <- @prop}>value: {v}</span>
+      {#for v <- @prop}<span>value: {v}</span>{/for}
       """
     end
   end
@@ -124,9 +124,7 @@ defmodule Surface.PropertiesTest do
       {#if is_nil(@labels)}
         No labels
       {#else}
-        {#for label <- @labels}
-          <#slot generator_value={label} />
-        {/for}
+        {#for label <- @labels}<#slot generator_value={label} />{/for}
       {/if}
       """
     end
@@ -1011,7 +1009,7 @@ defmodule Surface.PropertiesSyncTest do
     def render(assigns) do
       ~F"""
       List?: {is_list(@prop)}
-      <span :for={v <- @prop}>value: {inspect(v)}</span>
+      {#for v <- @prop}<span>value: {inspect(v)}</span>{/for}
       """
     end
   end

--- a/test/surface/integrations/slot_test.exs
+++ b/test/surface/integrations/slot_test.exs
@@ -30,9 +30,11 @@ defmodule Surface.SlotTest do
     def render(assigns) do
       ~F"""
       <div>
-        <div :for={data <- @inner}>
+        {#for data <- @inner}
+        <div>
           {data.label}: <#slot {data} />
         </div>
+        {/for}
         <div>
           <#slot />
         </div>
@@ -269,15 +271,21 @@ defmodule Surface.SlotTest do
       ~F"""
       <table>
         <tr>
-          <th :for={col <- @cols}>
+          {#for col <- @cols}
+          <th>
             {col.title}
           </th>
+          {/for}
         </tr>
-        <tr :for={item <- @items}>
-          <td :for={col <- @cols}>
+        {#for item <- @items}
+        <tr>
+          {#for col <- @cols}
+          <td>
             <#slot {col, info: info} generator_value={item} />
           </td>
+          {/for}
         </tr>
+        {/for}
       </table>
       """
     end
@@ -311,7 +319,8 @@ defmodule Surface.SlotTest do
 
                <b>content 1</b>
                <div>Stateful</div>
-             </div><div>
+             </div>
+             <div>
                label 2: \
 
                <b>content 2</b>
@@ -343,7 +352,8 @@ defmodule Surface.SlotTest do
              <div>
                1000: \
 
-             </div><div>
+             </div>
+             <div>
                1001: \
 
              </div>
@@ -381,7 +391,8 @@ defmodule Surface.SlotTest do
 
                <b>content 1</b>
                <div>Stateful</div>
-             </div><div>
+             </div>
+             <div>
                label 2: \
 
                <b>content 2</b>
@@ -604,7 +615,8 @@ defmodule Surface.SlotTest do
                <td>
                <b>Id: 1</b>
                </td>
-             </tr><tr>
+             </tr>
+             <tr>
                <td>
                <b>Id: 2</b>
                </td>
@@ -640,7 +652,8 @@ defmodule Surface.SlotTest do
                <b>Id: 1</b>
            </span>
                </td>
-             </tr><tr>
+             </tr>
+             <tr>
                <td>
                  <span class="fancy-column">
                <b>Id: 2</b>
@@ -676,7 +689,8 @@ defmodule Surface.SlotTest do
                default title
            </span>
                </td>
-             </tr><tr>
+             </tr>
+             <tr>
                <td>
                  <span class="fancy-column">
                default title
@@ -709,20 +723,24 @@ defmodule Surface.SlotTest do
              <tr>
                <th>
                  ID
-               </th><th>
+               </th>
+               <th>
                  NAME
                </th>
              </tr>
              <tr>
                <td>
                <b>Id: 1</b>
-               </td><td>
+               </td>
+               <td>
                Name: First
                </td>
-             </tr><tr>
+             </tr>
+             <tr>
                <td>
                <b>Id: 2</b>
-               </td><td>
+               </td>
+               <td>
                Name: Second
                </td>
              </tr>
@@ -752,20 +770,24 @@ defmodule Surface.SlotTest do
              <tr>
                <th>
                  ID
-               </th><th>
+               </th>
+               <th>
                  NAME
                </th>
              </tr>
              <tr>
                <td>
                <b>Id: 1</b>
-               </td><td>
+               </td>
+               <td>
                Name: First
                </td>
-             </tr><tr>
+             </tr>
+             <tr>
                <td>
                <b>Id: 2</b>
-               </td><td>
+               </td>
+               <td>
                Name: Second
                </td>
              </tr>
@@ -973,14 +995,16 @@ defmodule Surface.SlotTest do
              <tr>
                <th>
                  ID
-               </th><th>
+               </th>
+               <th>
                  NAME
                </th>
              </tr>
              <tr>
                <td>
                <b>Id: 1</b>
-               </td><td>
+               </td>
+               <td>
                Name: First
                Info: Some info from Grid
                </td>


### PR DESCRIPTION
Removing the use of the `:for` directives in tests required updating the tests' expected results.

Running the tests emits `:for` directive deprecation warnings. Tests need to still be included on the `:for` directive so this is a necessary evil.