### PR TITLE
Missing shortdoc on surface.init prevents task discovery from `mix help`

### DIFF
--- a/lib/mix/tasks/surface/surface.init.ex
+++ b/lib/mix/tasks/surface/surface.init.ex
@@ -1,4 +1,6 @@
 defmodule Mix.Tasks.Surface.Init do
+  @shortdoc "Configures Surface on an phoenix project"
+
   @moduledoc """
   Configures Surface on an phoenix project.
 


### PR DESCRIPTION
I've been a long time user of surface but was recently setting it up on a new project for the first time.  

I noticed the `surface.init` mix task from the docs wasn't showing up in the list of tasks from `mix help`. 

A missing @shortdoc seems to be the cause. The other two tasks have it and show up in the help output.