### PR TITLE
Fix Context.get/put in LiveComponent update

### DIFF
--- a/lib/surface/base_component.ex
+++ b/lib/surface/base_component.ex
@@ -97,25 +97,6 @@ defmodule Surface.BaseComponent do
     end)
   end
 
-  @doc false
-  def restore_private_assigns(socket, assigns) do
-    socket =
-      if Map.has_key?(assigns, :__context__) do
-        Phoenix.Component.assign(socket, :__context__, assigns[:__context__])
-      else
-        socket
-      end
-
-    socket =
-      if Map.has_key?(assigns, :__caller_scope_id__) do
-        Phoenix.Component.assign(socket, :__caller_scope_id__, assigns[:__caller_scope_id__])
-      else
-        socket
-      end
-
-    socket
-  end
-
   defmacro __before_compile__(env) do
     components_calls = Module.get_attribute(env.module, :__components_calls__)
     style = Module.get_attribute(env.module, :__style__)

--- a/lib/surface/components/context.ex
+++ b/lib/surface/components/context.ex
@@ -140,8 +140,9 @@ defmodule Surface.Components.Context do
 
   Without scope:
 
-      Context.put=(key1: @value1, key2: "some other value")
+      Context.put(key1: @value1, key2: "some other value")
 
+  > **Note**: When using `put/3` in [`update/2`](`c:Phoenix.LiveComponent.update/2`) call it giving the `socket`.
   """
   def put(socket_or_assigns, scope \\ nil, values)
 
@@ -187,6 +188,8 @@ defmodule Surface.Components.Context do
       ~F"\""
       <MyTextInput form={form} field={field} />
       "\""
+
+  > **Note**: When using `put/3` in [`update/2`](`c:Phoenix.LiveComponent.update/2`) call it giving the `socket`.
   """
   def get(socket_or_assigns, scope \\ nil, key)
 

--- a/test/surface/components/context_test.exs
+++ b/test/surface/components/context_test.exs
@@ -10,7 +10,8 @@ defmodule Surface.Components.ContextTest do
   register_propagate_context_to_slots([
     __MODULE__.Outer,
     __MODULE__.OuterUsingPropContextPut,
-    __MODULE__.OuterWithNamedSlots
+    __MODULE__.OuterWithNamedSlots,
+    __MODULE__.LiveComponentGetFromContextWithUpdate
   ])
 
   defmodule Outer do
@@ -260,7 +261,12 @@ defmodule Surface.Components.ContextTest do
           String.upcase(assigns.data_without_scope || "")
         ]
 
-        {:ok, assign(socket, :computed_value, computed_value)}
+        socket =
+          socket
+          |> assign(assigns)
+          |> assign(:computed_value, computed_value)
+
+        {:ok, socket}
       end
 
       @impl true
@@ -277,7 +283,7 @@ defmodule Surface.Components.ContextTest do
       end
     end
 
-    test "use a value from the context as default value" do
+    test "use a value from the context if the related prop is not given" do
       html =
         render_surface do
           ~F"""
@@ -314,6 +320,63 @@ defmodule Surface.Components.ContextTest do
 
       assert html =~ "Prop with scope: field from prop with scope"
       assert html =~ "Prop without scope: field from prop without scope"
+    end
+  end
+
+  describe "get in live component update/2" do
+    defmodule LiveComponentGetFromContextWithUpdate do
+      use Surface.LiveComponent
+
+      alias Surface.Components.ContextTest.Outer
+
+      slot default
+      data data_with_scope, :any
+      data data_without_scope, :any
+
+      @impl true
+      def update(assigns, socket) do
+        socket =
+          socket
+          |> assign(assigns)
+          |> assign(:data_with_scope, Context.get(socket, Outer, :field))
+          |> assign(:data_without_scope, Context.get(socket, :field))
+          |> Context.put(field: "updated field")
+
+        {:ok, socket}
+      end
+
+      @impl true
+      def render(assigns) do
+        ~F"""
+        <div>
+          Data with scope: {@data_with_scope}
+          Data without scope: {@data_without_scope}
+          <#slot />
+        </div>
+        """
+      end
+    end
+
+    test "can get and update context in update" do
+      html =
+        render_surface do
+          ~F"""
+          <div>
+            <Outer>
+              <LiveComponentGetFromContextWithUpdate id="1"/>
+            </Outer>
+            <Context put={field: "field without scope"}>
+              <LiveComponentGetFromContextWithUpdate id="2">
+                <RenderContext/>
+              </LiveComponentGetFromContextWithUpdate>
+            </Context>
+          </div>
+          """
+        end
+
+      assert html =~ "Data with scope: field from Outer"
+      assert html =~ "Data without scope: field without scope"
+      assert html =~ "updated field"
     end
   end
 
@@ -377,6 +440,15 @@ defmodule Surface.Components.ContextTest do
 
       assert_raise ArgumentError, msg, fn ->
         Context.put(%{}, SomeScope, value: 1)
+      end
+    end
+
+    test "put/3 throws ArgumentError argument error if the subject is not a socket/assigns, even with `__context__` key" do
+      msg =
+        "put/3 expects a socket or an assigns map from a function component as first argument, got: %{__context__: %{}}"
+
+      assert_raise ArgumentError, msg, fn ->
+        Context.put(%{__context__: %{}}, SomeScope, value: 1)
       end
     end
 


### PR DESCRIPTION
Allow calling `Context.get(socket, :field)` and `Context.put(socket, field: "value")` in [`update/2`](`c:Phoenix.LiveComponent.update/2`)

Calling it giving `assigns` will not work because there's no context information there. It's different from a `render/1` assigns.

If the user is defining `prop`s or `data`s with `from_context` they will have to call `assign(socket, assigns)` for them to be updated (as with any other assigns).

