### PR TITLE
updates `Form.Inputs` to wrap `Phoenix.Component.inputs_for/1`

### DIFF
--- a/lib/surface/components/form/inputs.ex
+++ b/lib/surface/components/form/inputs.ex
@@ -38,7 +38,7 @@ defmodule Surface.Components.Form.Inputs do
   def render(assigns) do
     ~F"""
     <.inputs_for :let={nested_form} field={@form[@for || @field]} {...@opts}>
-      <#slot {@default, form: nested_form, index: nested_form.index } context_put={__MODULE__, form: nested_form} />
+      <#slot {@default, form: nested_form, index: nested_form.index } context_put={Form, form: nested_form} />
     </.inputs_for>
     """
   end

--- a/lib/surface/components/form/inputs.ex
+++ b/lib/surface/components/form/inputs.ex
@@ -11,8 +11,6 @@ defmodule Surface.Components.Form.Inputs do
   alias Surface.Components.Form
   alias Surface.Components.Form.Field
 
-  import Phoenix.HTML.Form
-
   @doc """
   The parent form.
 
@@ -26,9 +24,9 @@ defmodule Surface.Components.Form.Inputs do
   prop for, :any, from_context: {Field, :field}
 
   @doc """
-  Extra options for `inputs_for/3`.
+  Extra options for `inputs_for/1`.
 
-  See `Phoenix.HTML.Form.html.inputs_for/4` for the available options.
+  See `Phoenix.Component.inputs_for/1` for the available options.
   """
   prop opts, :keyword, default: []
 
@@ -39,9 +37,9 @@ defmodule Surface.Components.Form.Inputs do
 
   def render(assigns) do
     ~F"""
-    {#for {f, index}  <- Enum.with_index(inputs_for(@form, @for || @field, @opts))}
-      <#slot {@default, form: f, index: index} context_put={Form, form: f}/>
-    {/for}
+    <.inputs_for :let={nested_form} field={@form[@for || @field]} {...@opts}>
+      <#slot {@default, form: nested_form, index: nested_form.index } context_put={__MODULE__, form: nested_form} />
+    </.inputs_for>
     """
   end
 end

--- a/test/surface/components/context_test.exs
+++ b/test/surface/components/context_test.exs
@@ -897,8 +897,9 @@ defmodule Surface.Components.ContextTest do
       assert html =~ """
              <form action="#" method="post">
                  <input name="_csrf_token" type="hidden" hidden value="test">
+                   <input type="hidden" name="parent[children][_persistent_id]" value="0">
                <div>
-                 <input id="parent_children_name" name="parent[children][name]" type="text">
+                 <input id="parent_children_0_name" name="parent[children][name]" type="text">
              </div>
              </form>
              """

--- a/test/surface/components/form/hidden_inputs_test.exs
+++ b/test/surface/components/form/hidden_inputs_test.exs
@@ -17,11 +17,14 @@ defmodule Surface.Components.Form.HiddenInputsTest do
         """
       end
 
-    assert html =~ """
-           <form action="#" method="post">
-               <input name="_csrf_token" type="hidden" hidden value="test">
-           </form>
-           """
+    assert html =~
+             """
+             <form action="#" method="post">
+                 <input name="_csrf_token" type="hidden" hidden value="test">
+                   <input type="hidden" name="parent[children][_persistent_id]" value="0">
+                 <input id="parent_children_0__persistent_id" name="parent[children][_persistent_id]" type="hidden" value="0">
+             </form>
+             """
   end
 
   test "using generated form stored in the Form context" do
@@ -36,10 +39,12 @@ defmodule Surface.Components.Form.HiddenInputsTest do
         """
       end
 
-    assert html =~ """
-           <form action="#" method="post">
-               <input name="_csrf_token" type="hidden" hidden value="test">
-           </form>
-           """
+    assert html =~
+             """
+             <form action="#" method="post">
+                 <input name="_csrf_token" type="hidden" hidden value="test">
+                   <input type="hidden" name="parent[children][_persistent_id]" value="0">
+             </form>
+             """
   end
 end

--- a/test/surface/components/form/hidden_inputs_test.exs
+++ b/test/surface/components/form/hidden_inputs_test.exs
@@ -44,6 +44,7 @@ defmodule Surface.Components.Form.HiddenInputsTest do
              <form action="#" method="post">
                  <input name="_csrf_token" type="hidden" hidden value="test">
                    <input type="hidden" name="parent[children][_persistent_id]" value="0">
+                 <input id="parent_children_0__persistent_id" name="parent[children][_persistent_id]" type="hidden" value="0">
              </form>
              """
   end

--- a/test/surface/components/form/inputs_test.exs
+++ b/test/surface/components/form/inputs_test.exs
@@ -45,8 +45,9 @@ defmodule Surface.Components.Form.InputsTest do
     assert html =~ """
            <form action="#" method="post">
                <input name="_csrf_token" type="hidden" hidden value="test">
-               <input id="parent_children_name" name="parent[children][name]" type="text">
-               <input id="parent_children_email" name="parent[children][email]" type="text">
+                 <input type="hidden" name="parent[children][_persistent_id]" value="0">
+               <input id="parent_children_0_name" name="parent[children][name]" type="text">
+               <input id="parent_children_0_email" name="parent[children][email]" type="text">
            </form>
            """
   end
@@ -68,7 +69,9 @@ defmodule Surface.Components.Form.InputsTest do
     assert html =~ """
            <form action="#" method="post">
                <input name="_csrf_token" type="hidden" hidden value="test">
+                 <input type="hidden" name="cs[children][0][_persistent_id]" value="0">
                <div>index: <span>0</span></div>
+                 <input type="hidden" name="cs[children][1][_persistent_id]" value="1">
                <div>index: <span>1</span></div>
            </form>
            """
@@ -90,8 +93,9 @@ defmodule Surface.Components.Form.InputsTest do
     assert html =~ """
            <form action="#" method="post">
                <input name="_csrf_token" type="hidden" hidden value="test">
-               <input id="parent_children_name" name="parent[children][name]" type="text">
-               <input id="parent_children_email" name="parent[children][email]" type="text">
+                 <input type="hidden" name="parent[children][_persistent_id]" value="0">
+               <input id="parent_children_0_name" name="parent[children][name]" type="text">
+               <input id="parent_children_0_email" name="parent[children][email]" type="text">
            </form>
            """
   end
@@ -112,8 +116,9 @@ defmodule Surface.Components.Form.InputsTest do
     assert html =~ """
            <form action="#" method="post">
                <input name="_csrf_token" type="hidden" hidden value="test">
-               <input id="parent_children_name" name="custom_name[name]" type="text">
-               <input id="parent_children_email" name="custom_name[email]" type="text">
+                 <input type="hidden" name="custom_name[_persistent_id]" value="0">
+               <input id="parent_children_0_name" name="custom_name[name]" type="text">
+               <input id="parent_children_0_email" name="custom_name[email]" type="text">
            </form>
            """
   end
@@ -137,8 +142,9 @@ defmodule Surface.Components.Form.InputsTest do
            <form action="#" method="post">
                <input name="_csrf_token" type="hidden" hidden value="test">
              <div>
-                 <input id="parent_children_name" name="parent[children][name]" type="text">
-                 <input id="parent_children_email" name="parent[children][email]" type="text">
+                 <input type="hidden" name="parent[children][_persistent_id]" value="0">
+                 <input id="parent_children_0_name" name="parent[children][name]" type="text">
+                 <input id="parent_children_0_email" name="parent[children][email]" type="text">
            </div>
            </form>
            """
@@ -160,8 +166,9 @@ defmodule Surface.Components.Form.InputsTest do
     assert html =~ """
            <form action="#" method="post">
                <input name="_csrf_token" type="hidden" hidden value="test">
-               <input id="parent_children_name" name="parent[children][name]" type="text">
-               <input id="parent_children_email" name="parent[children][email]" type="text">
+                 <input type="hidden" name="parent[children][_persistent_id]" value="0">
+               <input id="parent_children_0_name" name="parent[children][name]" type="text">
+               <input id="parent_children_0_email" name="parent[children][email]" type="text">
            </form>
            """
   end


### PR DESCRIPTION
fixes #703
- updates doc refs
- removes now unused import.
- fixes/updates tests touching `Inputs` to align assertions to newly generated HTML  