### PR TITLE
Fix hidden inputs

### DIFF
--- a/lib/surface/components/form/hidden_inputs.ex
+++ b/lib/surface/components/form/hidden_inputs.ex
@@ -17,6 +17,20 @@ defmodule Surface.Components.Form.HiddenInputs do
   prop for, :form, from_context: {Surface.Components.Form, :form}
 
   def render(assigns) do
-    ~F[{hidden_inputs_for(@for)}]
+    ~F"""
+    {#for {name, value_or_values} <- @for.hidden,
+        name = name_for_value_or_values(@for, name, value_or_values),
+        value <- List.wrap(value_or_values)}
+      <input type="hidden" name={name} value={value}>
+    {/for}
+    """
+  end
+
+  defp name_for_value_or_values(form, field, values) when is_list(values) do
+    input_name(form, field) <> "[]"
+  end
+
+  defp name_for_value_or_values(form, field, _value) do
+    input_name(form, field)
   end
 end

--- a/test/support/schemas.ex
+++ b/test/support/schemas.ex
@@ -1,0 +1,24 @@
+defmodule Surface.Schemas do
+  defmodule Parent do
+    defmodule Child do
+      use Ecto.Schema
+
+      embedded_schema do
+        field(:name, :string)
+      end
+
+      def changeset(cs_or_map, data), do: Ecto.Changeset.cast(cs_or_map, data, [:name])
+    end
+
+    use Ecto.Schema
+
+    embedded_schema do
+      embeds_many(:children, Child)
+    end
+
+    def changeset(cs_or_map \\ %__MODULE__{}, data),
+      do:
+        Ecto.Changeset.cast(cs_or_map, data, [])
+        |> Ecto.Changeset.cast_embed(:children)
+  end
+end

--- a/test/surface/components/form/hidden_inputs_test.exs
+++ b/test/surface/components/form/hidden_inputs_test.exs
@@ -4,6 +4,7 @@ defmodule Surface.Components.Form.HiddenInputsTest do
   alias Surface.Components.Form
   alias Surface.Components.Form.Inputs
   alias Surface.Components.Form.HiddenInputs
+  alias Surface.Schemas.Parent
 
   test "using generated form received as slot arg" do
     html =
@@ -22,7 +23,7 @@ defmodule Surface.Components.Form.HiddenInputsTest do
              <form action="#" method="post">
                  <input name="_csrf_token" type="hidden" hidden value="test">
                    <input type="hidden" name="parent[children][_persistent_id]" value="0">
-                 <input id="parent_children_0__persistent_id" name="parent[children][_persistent_id]" type="hidden" value="0">
+               <input type="hidden" name="parent[children][_persistent_id]" value="0">
              </form>
              """
   end
@@ -44,7 +45,31 @@ defmodule Surface.Components.Form.HiddenInputsTest do
              <form action="#" method="post">
                  <input name="_csrf_token" type="hidden" hidden value="test">
                    <input type="hidden" name="parent[children][_persistent_id]" value="0">
-                 <input id="parent_children_0__persistent_id" name="parent[children][_persistent_id]" type="hidden" value="0">
+               <input type="hidden" name="parent[children][_persistent_id]" value="0">
+             </form>
+             """
+  end
+
+  test "based on a changeset" do
+    cs = Parent.changeset(%{children: [%{name: "first"}]})
+
+    html =
+      render_surface do
+        ~F"""
+        <Form for={cs} as={:parent} opts={csrf_token: "test"}>
+          <Inputs for={:children} :let={form: f}>
+            <HiddenInputs for={f} />
+          </Inputs>
+        </Form>
+        """
+      end
+
+    assert html =~
+             """
+             <form action="#" method="post">
+                 <input name="_csrf_token" type="hidden" hidden value="test">
+                   <input type="hidden" name="parent[children][0][_persistent_id]" value="0">
+               <input type="hidden" name="parent[children][0][_persistent_id]" value="0">
              </form>
              """
   end

--- a/test/surface/components/form/inputs_test.exs
+++ b/test/surface/components/form/inputs_test.exs
@@ -5,29 +5,7 @@ defmodule Surface.Components.Form.InputsTest do
   alias Surface.Components.Form.Field
   alias Surface.Components.Form.Inputs
   alias Surface.Components.Form.TextInput
-
-  defmodule Parent do
-    defmodule Child do
-      use Ecto.Schema
-
-      embedded_schema do
-        field(:name, :string)
-      end
-
-      def changeset(cs_or_map, data), do: Ecto.Changeset.cast(cs_or_map, data, [:name])
-    end
-
-    use Ecto.Schema
-
-    embedded_schema do
-      embeds_many(:children, Child)
-    end
-
-    def changeset(cs_or_map \\ %__MODULE__{}, data),
-      do:
-        Ecto.Changeset.cast(cs_or_map, data, [])
-        |> Ecto.Changeset.cast_embed(:children)
-  end
+  alias Surface.Schemas.Parent
 
   test "using generated form received as slot arg" do
     html =


### PR DESCRIPTION
This PR kills two birds with one stone.
1) Avoid using deprecated `hidden_inputs_for`
2) Avoid crash when base form is a changeset

On that second point, this is a regression caused by 82d7c6e .
I didn't dig into it, but somehow the `hidden` did not use to have  `{"_persistent_id", "0"}` before it. Now that it does (correctly, right?) it crashes:

```
  2) test based on a changeset (Surface.Components.Form.HiddenInputsTest)
     test/surface/components/form/hidden_inputs_test.exs:53
     ** (ArgumentError) expected field to be an atom, got: "_persistent_id"
     code: <HiddenInputs for={f} />
     stacktrace:
       (phoenix_ecto 4.4.0) lib/phoenix_ecto/html.ex:128: Phoenix.HTML.FormData.Ecto.Changeset.input_value/4
       (phoenix_html 3.3.1) lib/phoenix_html/form.ex:941: Phoenix.HTML.Form.generic_input/4
       (phoenix_html 3.3.1) lib/phoenix_html/form.ex:785: Phoenix.HTML.Form.hidden_inputs_for/3
       (elixir 1.15.7) lib/enum.ex:4317: Enum.flat_map_list/2
       (surface 0.11.1) lib/surface/components/form/hidden_inputs.ex:20: anonymous fn/2 in Surface.Components.Form.HiddenInputs."render (overridable 1)"/1
       /Users/mal/surface/test/surface/components/form/hidden_inputs_test.exs:61: (test)
```

`HiddenInputs` simply calls `hidden_inputs_for`, and I find it odd it actually crashes, and I'm not sure if it's a bug or a "feature". Indeed, that loops of the hidden and calls `hidden_input` with `value: "0"`. But the implementation of `hidden_input` calls `Keyword.put_new(:value, input_value(...))` and not `Keyword.put_new_lazy` so `Phoenix.HTML.input_value` is always called, even if there's a `:value` given.
That function officially accepts fields that are strings, but `Ecto.Changeset`'s implementation for `Phoenix.HTML.FormData` somehow only accepts atoms.

In any case, `hidden_inputs_for` [is being removed](https://github.com/phoenixframework/phoenix_html/commit/0be2c6f1fab4fa3655de4bae90ae0a87649c8779) so implementation for `HiddenInputs` needs to change.
