### PR TITLE
fix: ranges for 1.16

### DIFF
--- a/lib/surface/formatter/phases/block_exceptions.ex
+++ b/lib/surface/formatter/phases/block_exceptions.ex
@@ -21,7 +21,7 @@ defmodule Surface.Formatter.Phases.BlockExceptions do
     {:block, "match", match_expr, children, last_meta} = last_sub_block
 
     modified_sub_blocks = [
-      {:block, "match", match_expr, Enum.slice(children, 0..-2), last_meta} | rest
+      {:block, "match", match_expr, Enum.slice(children, 0..-2//1), last_meta} | rest
     ]
 
     modified_sub_blocks = Enum.reverse(modified_sub_blocks)

--- a/lib/surface/formatter/phases/newlines.ex
+++ b/lib/surface/formatter/phases/newlines.ex
@@ -38,9 +38,9 @@ defmodule Surface.Formatter.Phases.Newlines do
 
   defp prevent_empty_line_at_end(nodes) do
     nodes
-    |> Enum.slice(-2..-1)
+    |> Enum.slice(-2..-1//1)
     |> case do
-      [:newline, :newline] -> Enum.slice(nodes, 0..-2)
+      [:newline, :newline] -> Enum.slice(nodes, 0..-2//1)
       _ -> nodes
     end
     |> Phase.transform_element_children(&prevent_empty_line_at_end/1)

--- a/lib/surface/formatter/phases/render.ex
+++ b/lib/surface/formatter/phases/render.ex
@@ -130,7 +130,7 @@ defmodule Surface.Formatter.Phases.Render do
 
             string ->
               string
-              |> String.slice(1..-2)
+              |> String.slice(1..-2//1)
               |> String.trim()
           end
 
@@ -448,7 +448,7 @@ defmodule Surface.Formatter.Phases.Render do
         # handle keyword lists, which will be stripped of the outer brackets per surface syntax sugar
         "[#{expression}]"
         |> Code.format_string!(locals_without_parens: [...: 1])
-        |> Enum.slice(1..-2)
+        |> Enum.slice(1..-2//1)
         |> to_string()
       else
         expression

--- a/lib/surface/formatter/phases/spaces_to_newlines.ex
+++ b/lib/surface/formatter/phases/spaces_to_newlines.ex
@@ -83,7 +83,7 @@ defmodule Surface.Formatter.Phases.SpacesToNewlines do
     nodes =
       case Enum.reverse(nodes) do
         [:space, _element | _rest] ->
-          Enum.slice(nodes, 0..-2) ++ [:newline]
+          Enum.slice(nodes, 0..-2//1) ++ [:newline]
 
         _ ->
           nodes

--- a/test/surface/catalogue/data_test.exs
+++ b/test/surface/catalogue/data_test.exs
@@ -22,7 +22,7 @@ defmodule Surface.Catalogue.DataTest do
 
     test "[first..last] - list's range" do
       list = [:a, :b, :c, :d, :e]
-      assert Data.get(list[1..-2]) == [:b, :c, :d]
+      assert Data.get(list[1..-2//1]) == [:b, :c, :d]
     end
 
     test "[_] - list's all items" do
@@ -134,17 +134,17 @@ defmodule Surface.Catalogue.DataTest do
     end
 
     test "get with negative end index", %{lists: lists} do
-      [cards_1, cards_2] = Data.get(lists[_].cards[1..-2])
+      [cards_1, cards_2] = Data.get(lists[_].cards[1..-2//1])
 
       assert [%{id: "Card_2"}, %{id: "Card_3"}] = cards_1
       assert [%{id: "Card_6"}, %{id: "Card_7"}] = cards_2
 
-      [cards_1, cards_2] = Data.get(lists[_].cards[0..-3])
+      [cards_1, cards_2] = Data.get(lists[_].cards[0..-3//1])
 
       assert [%{id: "Card_1"}, %{id: "Card_2"}] = cards_1
       assert [%{id: "Card_5"}, %{id: "Card_6"}] = cards_2
 
-      [cards_1, cards_2] = Data.get(lists[_].cards[2..-1])
+      [cards_1, cards_2] = Data.get(lists[_].cards[2..-1//1])
 
       assert [%{id: "Card_3"}, %{id: "Card_4"}] = cards_1
       assert [%{id: "Card_7"}, %{id: "Card_8"}] = cards_2


### PR DESCRIPTION
Fixes the remaining ranges that cause runtime warnings in Elixir 1.16
