### PR TITLE
test: fix for 1.16

### DIFF
--- a/test/surface/constructs/case_test.exs
+++ b/test/surface/constructs/case_test.exs
@@ -118,7 +118,7 @@ defmodule Surface.Constructs.CaseTest do
         """
       end
 
-    message = ~S(code:4: syntax error before: ',')
+    message = ~r/syntax error before: ','/
 
     assert_raise(SyntaxError, message, fn ->
       compile_surface(code)


### PR DESCRIPTION
error messages are more elaborate in 1.16, this uses a regex to allow tests to pass on all supported versions
