### PR TITLE
Update Tailwind patcher for phx_new >= 1.7.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,16 +23,19 @@ jobs:
           - elixir: 1.14.0
             otp: 25.0
             run_plugin_tests: true
+            run_integration_tests: true
             warnings_as_errors: true
           - elixir: 1.15.2
             otp: 26.0
             check_formatted: true
             run_plugin_tests: true
+            run_integration_tests: true
             warnings_as_errors: true
           - elixir: 1.16.0
             otp: 26.2.1
             check_formatted: false
             run_plugin_tests: true
+            run_integration_tests: true
             warnings_as_errors: true
     env:
       MIX_ENV: test
@@ -51,7 +54,5 @@ jobs:
         if: matrix.check_formatted
       - run: mix compile --warnings-as-errors
         if: matrix.warnings_as_errors
-      - run: mix test --include integration
-        if: matrix.run_plugin_tests
-      - run: mix test --include integration --exclude plugin
-        if: ${{ !matrix.run_plugin_tests }}
+      - name: mix test
+        run: mix test --include integration:${{ !!matrix.run_integration_tests }} --exclude plugin:${{ !matrix.run_plugin_tests }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         if: matrix.check_formatted
       - run: mix compile --warnings-as-errors
         if: matrix.warnings_as_errors
-      - run: mix test
+      - run: mix test --include integration
         if: matrix.run_plugin_tests
-      - run: mix test --exclude plugin
+      - run: mix test --include integration --exclude plugin
         if: ${{ !matrix.run_plugin_tests }}

--- a/lib/mix/tasks/surface/surface.init/project_patchers/tailwind.ex
+++ b/lib/mix/tasks/surface/surface.init/project_patchers/tailwind.ex
@@ -6,13 +6,13 @@ defmodule Mix.Tasks.Surface.Init.ProjectPatchers.Tailwind do
   @behaviour Mix.Tasks.Surface.Init.ProjectPatcher
 
   @impl true
-  def specs(_assigns) do
+  def specs(assigns) do
     [
-      {:patch, "assets/tailwind.config.js", [add_sface_patterns_to_tailwind_config_js()]}
+      {:patch, "assets/tailwind.config.js", [add_sface_patterns_to_tailwind_config_js(assigns.context_app)]}
     ]
   end
 
-  def add_sface_patterns_to_tailwind_config_js() do
+  def add_sface_patterns_to_tailwind_config_js(context_app) do
     %{
       name: "Add surface files to tailwind.config.js content section",
       instructions: "",
@@ -22,20 +22,20 @@ defmodule Mix.Tasks.Surface.Init.ProjectPatchers.Tailwind do
           """
             content: [
               "./js/**/*.js",
-              "../lib/*_web.ex",
-              "../lib/*_web/**/*.*ex"
+              "../lib/#{context_app}_web.ex",
+              "../lib/#{context_app}_web/**/*.*ex"
             ],
           """,
           """
             content: [
               "./js/**/*.js",
-              "../lib/*_web.ex",
-              "../lib/*_web/**/*.*ex",
-              "../lib/*_web/**/*.sface",
+              "../lib/#{context_app}_web.ex",
+              "../lib/#{context_app}_web/**/*.*ex",
+              "../lib/#{context_app}_web/**/*.sface",
               "../priv/catalogue/**/*.{ex,sface}"
             ],
           """,
-          "../lib/*_web/**/*.sface"
+          "../lib/#{context_app}_web/**/*.sface"
         )
     }
   end

--- a/test/mix/tasks/surface/surface.init/integration_test.exs
+++ b/test/mix/tasks/surface/surface.init/integration_test.exs
@@ -145,11 +145,6 @@ defmodule Mix.Tasks.Surface.Init.IntegrationTest do
       mix_file = Path.join(project_folder, "mix.exs")
       Mix.Tasks.Surface.Init.Patcher.patch_file(mix_file, [add_surface_to_mix_deps()], %{dry_run: false})
 
-      mix_file
-      |> File.read!()
-      |> String.replace(~S({:phoenix_live_view, "~> 0.18.16"}), ~S({:phoenix_live_view, "~> 0.18.18"}))
-      |> then(&File.write!(mix_file, &1))
-
       cmd("mix deps.get", cd: project_folder)
     end
 

--- a/test/mix/tasks/surface/surface.init/project_patchers/tailwind_test.exs
+++ b/test/mix/tasks/surface/surface.init/project_patchers/tailwind_test.exs
@@ -12,8 +12,8 @@ defmodule Mix.Tasks.Surface.Init.ProjectPatchers.TailwindTest do
       module.exports = {
         content: [
           "./js/**/*.js",
-          "../lib/*_web.ex",
-          "../lib/*_web/**/*.*ex"
+          "../lib/my_app_web.ex",
+          "../lib/my_app_web/**/*.*ex"
         ],
         theme: {
           extend: {},
@@ -24,7 +24,7 @@ defmodule Mix.Tasks.Surface.Init.ProjectPatchers.TailwindTest do
       }
       """
 
-      {:patched, updated_code} = Patcher.patch_code(code, add_sface_patterns_to_tailwind_config_js())
+      {:patched, updated_code} = Patcher.patch_code(code, add_sface_patterns_to_tailwind_config_js(:my_app))
 
       assert updated_code == """
              const plugin = require("tailwindcss/plugin")
@@ -32,9 +32,9 @@ defmodule Mix.Tasks.Surface.Init.ProjectPatchers.TailwindTest do
              module.exports = {
                content: [
                  "./js/**/*.js",
-                 "../lib/*_web.ex",
-                 "../lib/*_web/**/*.*ex",
-                 "../lib/*_web/**/*.sface",
+                 "../lib/my_app_web.ex",
+                 "../lib/my_app_web/**/*.*ex",
+                 "../lib/my_app_web/**/*.sface",
                  "../priv/catalogue/**/*.{ex,sface}"
                ],
                theme: {
@@ -52,9 +52,9 @@ defmodule Mix.Tasks.Surface.Init.ProjectPatchers.TailwindTest do
       module.exports = {
         content: [
           "./js/**/*.js",
-          "../lib/*_web.ex",
-          "../lib/*_web/**/*.*ex",
-          "../lib/*_web/**/*.sface",
+          "../lib/my_app_web.ex",
+          "../lib/my_app_web/**/*.*ex",
+          "../lib/my_app_web/**/*.sface",
           "../priv/catalogue/**/*.{ex,sface}"
         ],
         theme: {
@@ -64,7 +64,8 @@ defmodule Mix.Tasks.Surface.Init.ProjectPatchers.TailwindTest do
       }
       """
 
-      assert {:already_patched, ^code} = Patcher.patch_code(code, add_sface_patterns_to_tailwind_config_js())
+      assert {:already_patched, ^code} =
+               Patcher.patch_code(code, add_sface_patterns_to_tailwind_config_js(:my_app))
     end
   end
 end


### PR DESCRIPTION
Currently it fails to patch `assets/tailwind.config.js` because [`1.7.8`](https://www.phoenixdiff.org/compare/1.7.7...1.7.8) changed the content of the file.
![image](https://github.com/surface-ui/surface/assets/1627293/a1c55781-b823-404a-b885-10618136b015)

![image](https://github.com/surface-ui/surface/assets/1627293/04ed9880-4100-4db8-a055-8c627896e505)
