### PR TITLE
Update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,11 @@ jobs:
             check_formatted: true
             run_plugin_tests: true
             warnings_as_errors: true
+          - elixir: 1.16.0
+            otp: 26.2.1
+            check_formatted: false
+            run_plugin_tests: true
+            warnings_as_errors: true
     env:
       MIX_ENV: test
     steps:

--- a/lib/surface/api.ex
+++ b/lib/surface/api.ex
@@ -605,7 +605,7 @@ defmodule Surface.API do
   defp format_opts(opts_ast) do
     opts_ast
     |> Macro.to_string()
-    |> String.slice(1..-2)
+    |> String.slice(1..-2//1)
   end
 
   defp generate_docs(env) do

--- a/lib/surface/compiler/eex_engine.ex
+++ b/lib/surface/compiler/eex_engine.ex
@@ -1093,16 +1093,6 @@ defmodule Surface.Compiler.EExEngine do
     end
   end
 
-  defp require_expr(module, line) do
-    %AST.Expr{
-      value:
-        quote line: line do
-          require(unquote(module)).__info__(:module)
-        end,
-      meta: %AST.Meta{}
-    }
-  end
-
   defp escape_message(message) do
     {:safe, message_iodata} = Phoenix.HTML.html_escape(message)
     IO.iodata_to_binary(message_iodata)

--- a/lib/surface/components/form/hidden_inputs.ex
+++ b/lib/surface/components/form/hidden_inputs.ex
@@ -17,6 +17,20 @@ defmodule Surface.Components.Form.HiddenInputs do
   prop for, :form, from_context: {Surface.Components.Form, :form}
 
   def render(assigns) do
-    ~F[{hidden_inputs_for(@for)}]
+    ~F"""
+    {#for {name, value_or_values} <- @for.hidden,
+        name = name_for_value_or_values(@for, name, value_or_values),
+        value <- List.wrap(value_or_values)}
+      <input type="hidden" name={name} value={value}>
+    {/for}
+    """
+  end
+
+  defp name_for_value_or_values(form, field, values) when is_list(values) do
+    input_name(form, field) <> "[]"
+  end
+
+  defp name_for_value_or_values(form, field, _value) do
+    input_name(form, field)
   end
 end

--- a/lib/surface/formatter/phases/block_exceptions.ex
+++ b/lib/surface/formatter/phases/block_exceptions.ex
@@ -21,7 +21,7 @@ defmodule Surface.Formatter.Phases.BlockExceptions do
     {:block, "match", match_expr, children, last_meta} = last_sub_block
 
     modified_sub_blocks = [
-      {:block, "match", match_expr, Enum.slice(children, 0..-2), last_meta} | rest
+      {:block, "match", match_expr, Enum.slice(children, 0..-2//1), last_meta} | rest
     ]
 
     modified_sub_blocks = Enum.reverse(modified_sub_blocks)

--- a/lib/surface/formatter/phases/newlines.ex
+++ b/lib/surface/formatter/phases/newlines.ex
@@ -38,9 +38,9 @@ defmodule Surface.Formatter.Phases.Newlines do
 
   defp prevent_empty_line_at_end(nodes) do
     nodes
-    |> Enum.slice(-2..-1)
+    |> Enum.slice(-2..-1//1)
     |> case do
-      [:newline, :newline] -> Enum.slice(nodes, 0..-2)
+      [:newline, :newline] -> Enum.slice(nodes, 0..-2//1)
       _ -> nodes
     end
     |> Phase.transform_element_children(&prevent_empty_line_at_end/1)

--- a/lib/surface/formatter/phases/render.ex
+++ b/lib/surface/formatter/phases/render.ex
@@ -130,7 +130,7 @@ defmodule Surface.Formatter.Phases.Render do
 
             string ->
               string
-              |> String.slice(1..-2)
+              |> String.slice(1..-2//1)
               |> String.trim()
           end
 
@@ -448,7 +448,7 @@ defmodule Surface.Formatter.Phases.Render do
         # handle keyword lists, which will be stripped of the outer brackets per surface syntax sugar
         "[#{expression}]"
         |> Code.format_string!(locals_without_parens: [...: 1])
-        |> Enum.slice(1..-2)
+        |> Enum.slice(1..-2//1)
         |> to_string()
       else
         expression

--- a/lib/surface/formatter/phases/spaces_to_newlines.ex
+++ b/lib/surface/formatter/phases/spaces_to_newlines.ex
@@ -83,7 +83,7 @@ defmodule Surface.Formatter.Phases.SpacesToNewlines do
     nodes =
       case Enum.reverse(nodes) do
         [:space, _element | _rest] ->
-          Enum.slice(nodes, 0..-2) ++ [:newline]
+          Enum.slice(nodes, 0..-2//1) ++ [:newline]
 
         _ ->
           nodes

--- a/lib/surface/live_view_test.ex
+++ b/lib/surface/live_view_test.ex
@@ -381,7 +381,8 @@ defmodule Surface.LiveViewTest do
 
   @doc false
   defmacro assert_raise_with_line(exception, message, relative_line, function) do
-    {:fn, _, [{:->, [line: function_start_line], _}]} = function
+    {:fn, _, [{:->, meta, _}]} = function
+    function_start_line = meta[:line]
     expected_line = function_start_line + relative_line
     expected_file = __CALLER__.file |> Path.relative_to_cwd()
 

--- a/test/mix/tasks/compile/surface_test.exs
+++ b/test/mix/tasks/compile/surface_test.exs
@@ -79,9 +79,8 @@ defmodule Mix.Tasks.Compile.SurfaceTest do
         assert {:ok, [^diagnostic]} = handle_diagnostics([diagnostic], [])
       end)
 
-    assert output ==
-             (IO.ANSI.format([:yellow, "warning: "]) |> IO.iodata_to_binary()) <>
-               "test warning\n  file.ex:1: (file)\n\n"
+    assert output =~ IO.ANSI.format([:yellow, "warning:"]) |> IO.iodata_to_binary()
+    assert output =~ "test warning\n  file.ex:1: (file)\n\n"
   end
 
   test "don't print and return `{:error, diagnostics}` on warning with `return_errors` and `warnings_as_errors`" do

--- a/test/support/schemas.ex
+++ b/test/support/schemas.ex
@@ -1,0 +1,24 @@
+defmodule Surface.Schemas do
+  defmodule Parent do
+    defmodule Child do
+      use Ecto.Schema
+
+      embedded_schema do
+        field(:name, :string)
+      end
+
+      def changeset(cs_or_map, data), do: Ecto.Changeset.cast(cs_or_map, data, [:name])
+    end
+
+    use Ecto.Schema
+
+    embedded_schema do
+      embeds_many(:children, Child)
+    end
+
+    def changeset(cs_or_map \\ %__MODULE__{}, data),
+      do:
+        Ecto.Changeset.cast(cs_or_map, data, [])
+        |> Ecto.Changeset.cast_embed(:children)
+  end
+end

--- a/test/surface/catalogue/data_test.exs
+++ b/test/surface/catalogue/data_test.exs
@@ -22,7 +22,7 @@ defmodule Surface.Catalogue.DataTest do
 
     test "[first..last] - list's range" do
       list = [:a, :b, :c, :d, :e]
-      assert Data.get(list[1..-2]) == [:b, :c, :d]
+      assert Data.get(list[1..-2//1]) == [:b, :c, :d]
     end
 
     test "[_] - list's all items" do
@@ -134,17 +134,17 @@ defmodule Surface.Catalogue.DataTest do
     end
 
     test "get with negative end index", %{lists: lists} do
-      [cards_1, cards_2] = Data.get(lists[_].cards[1..-2])
+      [cards_1, cards_2] = Data.get(lists[_].cards[1..-2//1])
 
       assert [%{id: "Card_2"}, %{id: "Card_3"}] = cards_1
       assert [%{id: "Card_6"}, %{id: "Card_7"}] = cards_2
 
-      [cards_1, cards_2] = Data.get(lists[_].cards[0..-3])
+      [cards_1, cards_2] = Data.get(lists[_].cards[0..-3//1])
 
       assert [%{id: "Card_1"}, %{id: "Card_2"}] = cards_1
       assert [%{id: "Card_5"}, %{id: "Card_6"}] = cards_2
 
-      [cards_1, cards_2] = Data.get(lists[_].cards[2..-1])
+      [cards_1, cards_2] = Data.get(lists[_].cards[2..-1//1])
 
       assert [%{id: "Card_3"}, %{id: "Card_4"}] = cards_1
       assert [%{id: "Card_7"}, %{id: "Card_8"}] = cards_2

--- a/test/surface/compiler_test.exs
+++ b/test/surface/compiler_test.exs
@@ -649,7 +649,7 @@ defmodule Surface.CompilerTest do
       </div>
       """
 
-      assert_raise(SyntaxError, "nofile:3: syntax error before: ','", fn ->
+      assert_raise(SyntaxError, ~r/nofile:3:/, fn ->
         Surface.Compiler.compile(code, 1, __ENV__)
       end)
     end
@@ -666,7 +666,7 @@ defmodule Surface.CompilerTest do
       </Grid>
       """
 
-      assert_raise(SyntaxError, "nofile:6: syntax error before: ','", fn ->
+      assert_raise(SyntaxError, ~r/nofile:6:/, fn ->
         Surface.Compiler.compile(code, 1, __ENV__)
       end)
     end
@@ -682,7 +682,7 @@ defmodule Surface.CompilerTest do
       </div>
       """
 
-      assert_raise(SyntaxError, "nofile:6: syntax error before: ','", fn ->
+      assert_raise(SyntaxError, ~r/nofile:6:/, fn ->
         Surface.Compiler.compile(code, 1, __ENV__)
       end)
     end
@@ -696,7 +696,7 @@ defmodule Surface.CompilerTest do
       </Grid>
       """
 
-      assert_raise(SyntaxError, "nofile:1: syntax error before: ','", fn ->
+      assert_raise(SyntaxError, ~r/nofile:1:/, fn ->
         Surface.Compiler.compile(code, 1, __ENV__)
       end)
     end
@@ -713,7 +713,7 @@ defmodule Surface.CompilerTest do
       </Grid>
       """
 
-      assert_raise(SyntaxError, "nofile:5: syntax error before: ','", fn ->
+      assert_raise(SyntaxError, ~r/nofile:5/, fn ->
         Surface.Compiler.compile(code, 1, __ENV__)
       end)
     end
@@ -727,7 +727,7 @@ defmodule Surface.CompilerTest do
       </GridLive>
       """
 
-      assert_raise(SyntaxError, "nofile:1: syntax error before: ','", fn ->
+      assert_raise(SyntaxError, ~r/nofile:1:/, fn ->
         Surface.Compiler.compile(code, 1, __ENV__)
       end)
     end

--- a/test/surface/components/form/hidden_inputs_test.exs
+++ b/test/surface/components/form/hidden_inputs_test.exs
@@ -4,6 +4,7 @@ defmodule Surface.Components.Form.HiddenInputsTest do
   alias Surface.Components.Form
   alias Surface.Components.Form.Inputs
   alias Surface.Components.Form.HiddenInputs
+  alias Surface.Schemas.Parent
 
   test "using generated form received as slot arg" do
     html =
@@ -22,7 +23,7 @@ defmodule Surface.Components.Form.HiddenInputsTest do
              <form action="#" method="post">
                  <input name="_csrf_token" type="hidden" hidden value="test">
                    <input type="hidden" name="parent[children][_persistent_id]" value="0">
-                 <input id="parent_children_0__persistent_id" name="parent[children][_persistent_id]" type="hidden" value="0">
+               <input type="hidden" name="parent[children][_persistent_id]" value="0">
              </form>
              """
   end
@@ -44,7 +45,31 @@ defmodule Surface.Components.Form.HiddenInputsTest do
              <form action="#" method="post">
                  <input name="_csrf_token" type="hidden" hidden value="test">
                    <input type="hidden" name="parent[children][_persistent_id]" value="0">
-                 <input id="parent_children_0__persistent_id" name="parent[children][_persistent_id]" type="hidden" value="0">
+               <input type="hidden" name="parent[children][_persistent_id]" value="0">
+             </form>
+             """
+  end
+
+  test "based on a changeset" do
+    cs = Parent.changeset(%{children: [%{name: "first"}]})
+
+    html =
+      render_surface do
+        ~F"""
+        <Form for={cs} as={:parent} opts={csrf_token: "test"}>
+          <Inputs for={:children} :let={form: f}>
+            <HiddenInputs for={f} />
+          </Inputs>
+        </Form>
+        """
+      end
+
+    assert html =~
+             """
+             <form action="#" method="post">
+                 <input name="_csrf_token" type="hidden" hidden value="test">
+                   <input type="hidden" name="parent[children][0][_persistent_id]" value="0">
+               <input type="hidden" name="parent[children][0][_persistent_id]" value="0">
              </form>
              """
   end

--- a/test/surface/components/form/inputs_test.exs
+++ b/test/surface/components/form/inputs_test.exs
@@ -5,29 +5,7 @@ defmodule Surface.Components.Form.InputsTest do
   alias Surface.Components.Form.Field
   alias Surface.Components.Form.Inputs
   alias Surface.Components.Form.TextInput
-
-  defmodule Parent do
-    defmodule Child do
-      use Ecto.Schema
-
-      embedded_schema do
-        field(:name, :string)
-      end
-
-      def changeset(cs_or_map, data), do: Ecto.Changeset.cast(cs_or_map, data, [:name])
-    end
-
-    use Ecto.Schema
-
-    embedded_schema do
-      embeds_many(:children, Child)
-    end
-
-    def changeset(cs_or_map \\ %__MODULE__{}, data),
-      do:
-        Ecto.Changeset.cast(cs_or_map, data, [])
-        |> Ecto.Changeset.cast_embed(:children)
-  end
+  alias Surface.Schemas.Parent
 
   test "using generated form received as slot arg" do
     html =

--- a/test/surface/constructs/case_test.exs
+++ b/test/surface/constructs/case_test.exs
@@ -118,7 +118,7 @@ defmodule Surface.Constructs.CaseTest do
         """
       end
 
-    message = ~S(code:4: syntax error before: ',')
+    message = ~r/syntax error before: ','/
 
     assert_raise(SyntaxError, message, fn ->
       compile_surface(code)

--- a/test/surface/macro_component_test.exs
+++ b/test/surface/macro_component_test.exs
@@ -185,7 +185,7 @@ defmodule Surface.MacroComponentTest do
         """
       end
 
-    assert_raise(SyntaxError, ~r/code:2: syntax error before: ','/, fn ->
+    assert_raise(SyntaxError, ~r/code:2:/, fn ->
       compile_surface(code)
     end)
   end


### PR DESCRIPTION
Brings in upstream commits for Elixir 1.16, but not the switch to `phoenix_live_view`.

upstream forces an update of `phoenix_live_view`, which might be more difficult