### PR TITLE
Fix CI - Support Phoenix Live View >= 0.20.10

### DIFF
--- a/test/support/debug_annotations_util.ex
+++ b/test/support/debug_annotations_util.ex
@@ -3,7 +3,7 @@ defmodule Surface.CompilerTest.DebugAnnotationsUtil do
     Application.spec(:phoenix_live_view, :vsn)
     |> to_string()
     |> Version.parse!()
-    |> Version.compare("0.20.0") != :lt
+    |> Version.match?(">= 0.20.0 and <= 0.20.9")
   end
 
   defmacro use_component() do


### PR DESCRIPTION
Hello 👋 

I notice that the [CI](https://github.com/surface-ui/surface/actions/runs/8103594810/job/22148674394) was red for Phoenix Live View >= 0.20.10
I investigated and it seems that the debug_hex_annotations [were introduced in 0.20.0](https://github.com/phoenixframework/phoenix_live_view/commit/54764135ec25f0d2b8939da7f28d45b6f1ebcb25) but it [were removed in 0.20.10](https://github.com/phoenixframework/phoenix_live_view/commit/d7c24e8e3bf17fe5ffe1abfceddd206f065440f3)

So I make the helper consistent with that.

Let me know what you think.

