### PR TITLE
Remove live_component/2 and /3 to support LV 0.20.15.

### DIFF
--- a/lib/surface/live_view_test.ex
+++ b/lib/surface/live_view_test.ex
@@ -19,7 +19,6 @@ defmodule Surface.LiveViewTest do
     quote do
       import Phoenix.ConnTest
       import Phoenix.LiveViewTest
-      import Phoenix.LiveView.Helpers, only: [live_component: 2, live_component: 3]
       import Surface, only: [sigil_F: 2]
       import Surface.LiveViewTest
       require Phoenix.LiveView.TagEngine


### PR DESCRIPTION
## Describe the bug
`Surface.LiveViewTest` is broken after Phoenix LiveView `0.20.15`.

They removed `live_component/{2,3}` from the `Phoenix.LiveView.Helpers` ([changelog here](https://hexdocs.pm/phoenix_live_view/changelog.html#removal-of-previously-deprecated-functionality)) which `Surface.LiveViewTest` [depends on](https://github.com/surface-ui/surface/blob/eb32f370f75d332d2b3fdec6a0c16882676f788f/lib/surface/live_view_test.ex#L22).

Whenever we `use Surface.LiveViewTest` we'll get something like:

```
warning: cannot import Phoenix.LiveView.Helpers.live_component/3 because it is undefined or private
use Surface.LiveViewTest
```

## How to reproduce it
1. Bump LV to `0.20.15` or higher and `use Surface.LiveViewTest` on any test.


## About the PR
Someone suggested simply removing the `import` and checking if tests would pass, and that being the case, this would be a reasonable PR.
Tests pass, so here's the PR :)

As I mentioned on the original issue, I'm not sure what would be the best solution, so please let me know if you see any issues here.

Cheers.
