### PR TITLE
Add Elixir 1.17 and OTP 27 to CI, fixing warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,14 @@ jobs:
             run_plugin_tests: true
             run_integration_tests: true
             warnings_as_errors: true
-          - elixir: '1.16.0'
-            otp: '26.2.1'
+          - elixir: '1.17.0'
+            otp: '27.0.1'
+            check_formatted: true
+            run_plugin_tests: true
+            run_integration_tests: true
+            warnings_as_errors: true
+          - elixir: '1.17.0'
+            otp: '27.0.1'
             update_deps: true
             run_plugin_tests: true
     env:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+erlang 27.0.1
+elixir 1.17.2-otp-27

--- a/lib/mix/tasks/surface/surface.init/ex_patcher.ex
+++ b/lib/mix/tasks/surface/surface.init/ex_patcher.ex
@@ -419,9 +419,8 @@ defmodule Mix.Tasks.Surface.Init.ExPatcher do
   end
 
   defp to_string_opts() do
-    "mix.exs"
-    |> Mix.Tasks.Format.formatter_opts_for_file()
-    |> Keyword.take([:line_length])
+    {_formatter, opts} = Mix.Tasks.Format.formatter_for_file("mix.exs")
+    Keyword.take(opts, [:line_length])
   end
 
   defp get_code_by_range(code, range) do

--- a/lib/surface/catalogue/data.ex
+++ b/lib/surface/catalogue/data.ex
@@ -184,7 +184,7 @@ defmodule Surface.Catalogue.Data do
     Access.at(value)
   end
 
-  def access_fun(from..to = range) when is_integer(from) and is_integer(to) do
+  def access_fun(from..to//1 = range) when is_integer(from) and is_integer(to) do
     slice(range)
   end
 
@@ -244,14 +244,14 @@ defmodule Surface.Catalogue.Data do
     {:lists.reverse(gets), :lists.reverse(updates)}
   end
 
-  defp get_and_update_slice(list, from..to, next, updates, gets, -1) do
+  defp get_and_update_slice(list, from..to//1, next, updates, gets, -1) do
     list_length = length(list)
     from = normalize_range_bound(from, list_length)
     to = normalize_range_bound(to, list_length)
     get_and_update_slice(list, from..to, next, updates, gets, 0)
   end
 
-  defp get_and_update_slice([head | rest], from..to = range, next, updates, gets, index) do
+  defp get_and_update_slice([head | rest], from..to//1 = range, next, updates, gets, index) do
     new_index = index + 1
 
     if index >= from and index <= to do

--- a/test/surface/components/link_test.exs
+++ b/test/surface/components/link_test.exs
@@ -184,14 +184,14 @@ defmodule Surface.Components.LinkTest do
       html = render_surface(do: ~F[<Link label="foo" to={{:javascript, "alert(<1>)"}} />])
       assert html =~ ~s[<a href="javascript:alert(&lt;1&gt;)">foo</a>]
 
-      html = render_surface(do: ~F[<Link label="foo" to={{:javascript, 'alert(<1>)'}} />])
+      html = render_surface(do: ~F[<Link label="foo" to={{:javascript, ~c"alert(<1>)"}} />])
       assert html =~ ~s[<a href="javascript:alert(&lt;1&gt;)">foo</a>]
 
       html = render_surface(do: ~F[<Link label="foo" to={{:javascript, {:safe, "alert(<1>)"}}} />])
 
       assert html =~ ~s[<a href="javascript:alert(<1>)">foo</a>]
 
-      html = render_surface(do: ~F[<Link label="foo" to={{:javascript, {:safe, 'alert(<1>)'}}} />])
+      html = render_surface(do: ~F[<Link label="foo" to={{:javascript, {:safe, ~c"alert(<1>)"}}} />])
 
       assert html =~ ~s[<a href="javascript:alert(<1>)">foo</a>]
     end
@@ -212,7 +212,7 @@ defmodule Surface.Components.LinkTest do
       end
 
       assert_raise ArgumentError, ~r"unsupported scheme given to <Link />", fn ->
-        render_surface(do: ~F[<Link label="foo" to={{:safe, 'javascript:alert(<1>)'}} />])
+        render_surface(do: ~F[<Link label="foo" to={{:safe, ~c"javascript:alert(<1>)"}} />])
       end
     end
   end


### PR DESCRIPTION
Fixed the following warnings

```
warning: from..to inside match is deprecated, you must always match on the step: from..to//var or from..to//_ if you want to ignore it
  lib/surface/catalogue/data.ex:187: Surface.Catalogue.Data.access_fun/1

warning: from..to inside match is deprecated, you must always match on the step: from..to//var or from..to//_ if you want to ignore it
  lib/surface/catalogue/data.ex:247: Surface.Catalogue.Data.get_and_update_slice/6

warning: from..to inside match is deprecated, you must always match on the step: from..to//var or from..to//_ if you want to ignore it
  lib/surface/catalogue/data.ex:254: Surface.Catalogue.Data.get_and_update_slice/6

     warning: Mix.Tasks.Format.formatter_opts_for_file/1 is deprecated. Use formatter_for_file/2 instead
     │
 423 │     |> Mix.Tasks.Format.formatter_opts_for_file()
     │                         ~
     │
     └─ lib/mix/tasks/surface/surface.init/ex_patcher.ex:423:25: Mix.Tasks.Surface.Init.ExPatcher.to_string_opts/0
```