### PR TITLE
Make surface.init compatible with phx_new 1.7.14

### DIFF
--- a/lib/mix/tasks/surface/surface.init/file_patchers/phoenix.ex
+++ b/lib/mix/tasks/surface/surface.init/file_patchers/phoenix.ex
@@ -123,7 +123,6 @@ defmodule Mix.Tasks.Surface.Init.FilePatchers.Phoenix do
       esbuild_patcher ->
         esbuild_patcher
         |> halt_if(&find_keyword(&1, [:catalogue]), :already_patched)
-        |> find_keyword_value([:default])
         |> replace_code(
           &"""
           #{&1},

--- a/lib/mix/tasks/surface/surface.init/project_patchers/js_hooks.ex
+++ b/lib/mix/tasks/surface/surface.init/project_patchers/js_hooks.ex
@@ -58,8 +58,8 @@ defmodule Mix.Tasks.Surface.Init.ProjectPatchers.JsHooks do
         &FilePatchers.JS.add_import(&1, ~S[import Hooks from "./_hooks"]),
         &FilePatchers.Text.replace_line_text(
           &1,
-          ~S[let liveSocket = new LiveSocket("/live", Socket, {params: {_csrf_token: csrfToken}})],
-          ~S[let liveSocket = new LiveSocket("/live", Socket, {params: {_csrf_token: csrfToken}, hooks: Hooks})]
+          ~S[  params: {_csrf_token: csrfToken}],
+          ~s[  hooks: Hooks,\n  params: {_csrf_token: csrfToken}]
         )
       ]
     }

--- a/test/mix/tasks/surface/surface.init/integration_test.exs
+++ b/test/mix/tasks/surface/surface.init/integration_test.exs
@@ -4,7 +4,7 @@ defmodule Mix.Tasks.Surface.Init.IntegrationTest do
 
   alias Mix.Tasks.Surface.Init.FilePatchers
 
-  @phx_new_version "1.7.10"
+  @phx_new_version "1.7.11"
 
   setup_all do
     {template_status, template_project_folder} = build_test_project_template("surface_init_test")

--- a/test/mix/tasks/surface/surface.init/integration_test.exs
+++ b/test/mix/tasks/surface/surface.init/integration_test.exs
@@ -4,7 +4,7 @@ defmodule Mix.Tasks.Surface.Init.IntegrationTest do
 
   alias Mix.Tasks.Surface.Init.FilePatchers
 
-  @phx_new_version "1.7.11"
+  @phx_new_version "1.7.14"
 
   setup_all do
     {template_status, template_project_folder} = build_test_project_template("surface_init_test")

--- a/test/mix/tasks/surface/surface.init/project_patchers/catalogue_test.exs
+++ b/test/mix/tasks/surface/surface.init/project_patchers/catalogue_test.exs
@@ -228,7 +228,9 @@ defmodule Mix.Tasks.Surface.Init.ProjectPatchers.CatalogueTest do
     end
 
     test "add catalogue entry if esbuild config has already been set" do
-      code = ~S"""
+      profile = Enum.random(["default", "surface_init_test"])
+
+      code = ~s"""
       import Config
 
       # Use Jason for JSON parsing in Phoenix
@@ -237,7 +239,7 @@ defmodule Mix.Tasks.Surface.Init.ProjectPatchers.CatalogueTest do
       # Configure esbuild (the version is required)
       config :esbuild,
         version: "0.14.10",
-        default: [
+        #{profile}: [
           args: ~w(js/app.js --bundle --target=es2016 --outdir=../priv/static/assets),
           cd: Path.expand("../assets", __DIR__),
           env: %{"NODE_PATH" => Path.expand("../deps", __DIR__)}
@@ -245,12 +247,12 @@ defmodule Mix.Tasks.Surface.Init.ProjectPatchers.CatalogueTest do
 
       # Import environment specific config. This must remain at the bottom
       # of this file so it overrides the configuration defined above.
-      import_config "#{config_env()}.exs"
+      import_config "\#{config_env()}.exs"
       """
 
       {:patched, updated_code} = Patcher.patch_code(code, configure_catalogue_esbuild())
 
-      assert updated_code == ~S"""
+      assert updated_code == ~s"""
              import Config
 
              # Use Jason for JSON parsing in Phoenix
@@ -259,7 +261,7 @@ defmodule Mix.Tasks.Surface.Init.ProjectPatchers.CatalogueTest do
              # Configure esbuild (the version is required)
              config :esbuild,
                version: "0.14.10",
-               default: [
+               #{profile}: [
                  args: ~w(js/app.js --bundle --target=es2016 --outdir=../priv/static/assets),
                  cd: Path.expand("../assets", __DIR__),
                  env: %{"NODE_PATH" => Path.expand("../deps", __DIR__)}
@@ -272,7 +274,7 @@ defmodule Mix.Tasks.Surface.Init.ProjectPatchers.CatalogueTest do
 
              # Import environment specific config. This must remain at the bottom
              # of this file so it overrides the configuration defined above.
-             import_config "#{config_env()}.exs"
+             import_config "\#{config_env()}.exs"
              """
     end
 

--- a/test/mix/tasks/surface/surface.init/project_patchers/js_hooks_test.exs
+++ b/test/mix/tasks/surface/surface.init/project_patchers/js_hooks_test.exs
@@ -14,7 +14,10 @@ defmodule Mix.Tasks.Surface.Init.ProjectPatchers.JSHooksTest do
       import topbar from "../vendor/topbar"
 
       let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
-      let liveSocket = new LiveSocket("/live", Socket, {params: {_csrf_token: csrfToken}})
+      let liveSocket = new LiveSocket("/live", Socket, {
+        longPollFallbackMs: 2500,
+        params: {_csrf_token: csrfToken}
+      })
 
       // connect if there are any LiveViews on the page
       liveSocket.connect()
@@ -22,7 +25,7 @@ defmodule Mix.Tasks.Surface.Init.ProjectPatchers.JSHooksTest do
       window.liveSocket = liveSocket
       """
 
-      {:patched, updated_code} = Patcher.patch_code(code, js_hooks())
+      {_patched, updated_code} = Patcher.patch_code(code, js_hooks())
 
       assert updated_code == """
              // We import the CSS which is extracted to its own file by esbuild.
@@ -33,7 +36,11 @@ defmodule Mix.Tasks.Surface.Init.ProjectPatchers.JSHooksTest do
              import Hooks from "./_hooks"
 
              let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
-             let liveSocket = new LiveSocket("/live", Socket, {params: {_csrf_token: csrfToken}, hooks: Hooks})
+             let liveSocket = new LiveSocket("/live", Socket, {
+               longPollFallbackMs: 2500,
+               hooks: Hooks,
+               params: {_csrf_token: csrfToken}
+             })
 
              // connect if there are any LiveViews on the page
              liveSocket.connect()
@@ -52,7 +59,11 @@ defmodule Mix.Tasks.Surface.Init.ProjectPatchers.JSHooksTest do
       import Hooks from "./_hooks"
 
       let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
-      let liveSocket = new LiveSocket("/live", Socket, {params: {_csrf_token: csrfToken}, hooks: Hooks})
+      let liveSocket = new LiveSocket("/live", Socket, {
+        longPollFallbackMs: 2500,
+        hooks: Hooks,
+        params: {_csrf_token: csrfToken}
+      })
 
       // connect if there are any LiveViews on the page
       liveSocket.connect()


### PR DESCRIPTION
Only changes required were on [`1.7.10 -> 1.7.11`](https://phoenixdiff.org/compare/1.7.10...1.7.11) upgrade.

hooks in `assets/js/app.js`
![image](https://github.com/user-attachments/assets/087f2fa8-13f0-4dd6-8662-b0b50a47a5b8)

esbuild config in `config/config.exs`
![image](https://github.com/user-attachments/assets/8c4726d2-5630-4f36-ab65-fff29cf145f6)
