### PR TITLE
Improve errors and diagnostics

### DIFF
--- a/lib/mix/tasks/compile/surface/validate_components.ex
+++ b/lib/mix/tasks/compile/surface/validate_components.ex
@@ -41,7 +41,7 @@ defmodule Mix.Tasks.Compile.Surface.ValidateComponents do
       missing_props_names = required_props_names -- existing_props_names
 
       for prop_name <- missing_props_names do
-        message = "Missing required property \"#{prop_name}\" for component <#{node_alias}>"
+        message = "missing required property \"#{prop_name}\" for component <#{node_alias}>"
 
         message =
           if prop_name == :id and Helpers.is_stateful_component(module) do

--- a/lib/surface/base_component.ex
+++ b/lib/surface/base_component.ex
@@ -141,7 +141,7 @@ defmodule Surface.BaseComponent do
               # module. This way if the missing/failing module is created/fixed,
               # Elixir will recompile this file.
               # NOTE: there's a bug in Elixir that report the error with the wrong line
-              # in versions <= 1.7. See https://github.com/elixir-lang/elixir/issues/13542
+              # in versions <= 1.17. See https://github.com/elixir-lang/elixir/issues/13542
               # for details.
               {imports,
                [

--- a/lib/surface/catalogue.ex
+++ b/lib/surface/catalogue.ex
@@ -104,15 +104,15 @@ defmodule Surface.Catalogue do
         subject
 
       _ ->
-        message = """
-        no subject defined for #{inspect(type)}
+        message = "no subject defined for #{inspect(type)}"
 
-        Hint: You can define the subject using the :subject option. Example:
+        hint = """
+        you can define the subject using the :subject option. Example:
 
           use #{inspect(type)}, subject: MyApp.MyButton
         """
 
-        Surface.IOHelper.compile_error(message, caller.file, caller.line)
+        Surface.IOHelper.compile_error(message, hint, caller.file, caller.line)
     end
   end
 

--- a/lib/surface/compile_error.ex
+++ b/lib/surface/compile_error.ex
@@ -36,7 +36,8 @@ defmodule Surface.CompileError do
           lineCode = String.trim_trailing(lineCode)
           :elixir_errors.format_snippet(:error, {line, column}, file, description, lineCode, %{})
         else
-          description
+          prefix = IO.ANSI.format([:red, "error:"])
+          "#{prefix} #{description}"
         end
 
       hint =
@@ -47,12 +48,22 @@ defmodule Surface.CompileError do
         end
 
       location = Exception.format_file_line_column(Path.relative_to_cwd(file), line, column)
-      location <> " " <> message <> hint
+      location <> "\n" <> message <> hint
     end
   else
     defp format_message(file, line, column, description, hint) do
       location = Exception.format_file_line_column(Path.relative_to_cwd(file), line, column)
-      location <> " " <> description <> (hint || "")
+
+      hint =
+        if hint do
+          prefix = IO.ANSI.format([:blue, "hint:"])
+          "\n\n#{prefix} " <> hint
+        else
+          ""
+        end
+
+      prefix = IO.ANSI.format([:red, "error:"])
+      location <> "\n#{prefix} " <> description <> hint
     end
   end
 end

--- a/lib/surface/compile_error.ex
+++ b/lib/surface/compile_error.ex
@@ -13,7 +13,7 @@ defmodule Surface.CompileError do
 
   """
 
-  @support_snippet Version.match?(System.version(), ">= 1.16.0")
+  @support_snippet Version.match?(System.version(), ">= 1.17.0")
 
   defexception [:file, :line, :column, :snippet, :hint, description: "compile error"]
 

--- a/lib/surface/compile_error.ex
+++ b/lib/surface/compile_error.ex
@@ -1,0 +1,58 @@
+defmodule Surface.CompileError do
+  @moduledoc """
+  An exception raised when there's a Surface compile error.
+
+  The following fields of this exceptions are public and can be accessed freely:
+
+    * `:file` (`t:Path.t/0` or `nil`) - the file where the error occurred, or `nil` if
+      the error occurred in code that did not come from a file
+    * `:line` - the line where the error occurred
+    * `:column` - the column where the error occurred
+    * `:description` - a description of the error
+    * `:hint` - a hint to help the user to fix the issue
+
+  """
+
+  @support_snippet Version.match?(System.version(), ">= 1.16.0")
+
+  defexception [:file, :line, :column, :snippet, :hint, description: "compile error"]
+
+  @impl true
+  def message(%{
+        file: file,
+        line: line,
+        column: column,
+        description: description,
+        hint: hint
+      }) do
+    format_message(file, line, column, description, hint)
+  end
+
+  if @support_snippet do
+    defp format_message(file, line, column, description, hint) do
+      message =
+        if File.exists?(file) do
+          {lineCode, _} = File.stream!(file) |> Stream.with_index() |> Enum.at(line - 1)
+          lineCode = String.trim_trailing(lineCode)
+          :elixir_errors.format_snippet(:error, {line, column}, file, description, lineCode, %{})
+        else
+          description
+        end
+
+      hint =
+        if hint do
+          "\n\n" <> :elixir_errors.format_snippet(:hint, nil, nil, hint, nil, %{})
+        else
+          ""
+        end
+
+      location = Exception.format_file_line_column(Path.relative_to_cwd(file), line, column)
+      location <> " " <> message <> hint
+    end
+  else
+    defp format_message(file, line, column, description, hint) do
+      location = Exception.format_file_line_column(Path.relative_to_cwd(file), line, column)
+      location <> " " <> description <> (hint || "")
+    end
+  end
+end

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -283,13 +283,15 @@ defmodule Surface.Compiler do
         {:ok, ast} ->
           process_directives(ast)
 
-        {:error, {message, line}, meta} ->
-          IOHelper.warn(message, compile_meta.caller, meta.file, line)
+        {:error, {message, line, column}, meta} ->
+          IOHelper.warn(message, compile_meta.caller, meta.file, {line, column})
           %AST.Error{message: message, meta: meta}
 
-        {:error, {message, details, line}, meta} ->
+        {:error, {message, details, line, column}, meta} ->
           details = if details, do: "\n\n" <> details, else: ""
-          IOHelper.warn(message <> details, compile_meta.caller, meta.file, line)
+          IOHelper.warn(message <> details, compile_meta.caller, meta.file, {line, column})
+          # TODO: check if it's better to raise a compile error
+          # IOHelper.compile_error(message, details, meta.file, {line, column})
           %AST.Error{message: message, meta: meta}
       end
     end
@@ -854,8 +856,9 @@ defmodule Surface.Compiler do
       end
     else
       false ->
-        {:error, {"cannot render <#{node_alias}> (MacroComponents must export an expand/3 function)", meta.line},
-         meta}
+        {:error,
+         {"cannot render <#{node_alias}> (MacroComponents must export an expand/3 function)", meta.line,
+          meta.column}, meta}
 
       error ->
         handle_convert_node_to_ast_error(node_alias, error, meta)
@@ -1246,7 +1249,7 @@ defmodule Surface.Compiler do
         !Map.has_key?(slot_entries, name) or
           Enum.all?(Map.get(slot_entries, name, []), &Helpers.is_blank_or_empty/1) do
       message = "missing required slot \"#{name}\" for component <#{meta.node_alias}>"
-      IOHelper.warn(message, meta.caller, meta.file, meta.line)
+      IOHelper.warn(message, meta.caller, meta.file, {meta.line, meta.column})
     end
 
     for {slot_name, slot_entry_instances} <- slot_entries,
@@ -1508,13 +1511,13 @@ defmodule Surface.Compiler do
   defp handle_convert_node_to_ast_error(name, error, meta) do
     case error do
       {:error, message, details} ->
-        {:error, {"cannot render <#{name}> (#{message})", details, meta.line}, meta}
+        {:error, {"cannot render <#{name}> (#{message})", details, meta.line, meta.column}, meta}
 
       {:error, message} ->
-        {:error, {"cannot render <#{name}> (#{message})", meta.line}, meta}
+        {:error, {"cannot render <#{name}> (#{message})", meta.line, meta.column}, meta}
 
       _ ->
-        {:error, {"cannot render <#{name}>", meta.line}, meta}
+        {:error, {"cannot render <#{name}>", meta.line, meta.column}, meta}
     end
   end
 

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -289,9 +289,10 @@ defmodule Surface.Compiler do
 
         {:error, {message, details, line, column}, meta} ->
           details = if details, do: "\n\n" <> details, else: ""
-          IOHelper.warn(message <> details, compile_meta.caller, meta.file, {line, column})
-          # TODO: check if it's better to raise a compile error
-          # IOHelper.compile_error(message, details, meta.file, {line, column})
+          # TODO: turn it back as a warning when using @after_verify in Elixir >= 0.14.
+          # Make sure to check if the genarated `require <component>.__info__()` doesn't get called,
+          # raising Elixir's CompileError.
+          IOHelper.compile_error(message, details, meta.file, {line, column})
           %AST.Error{message: message, meta: meta}
       end
     end

--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -288,7 +288,6 @@ defmodule Surface.Compiler do
           %AST.Error{message: message, meta: meta}
 
         {:error, {message, details, line, column}, meta} ->
-          details = if details, do: "\n\n" <> details, else: ""
           # TODO: turn it back as a warning when using @after_verify in Elixir >= 0.14.
           # Make sure to check if the genarated `require <component>.__info__()` doesn't get called,
           # raising Elixir's CompileError.

--- a/lib/surface/compiler/helpers.ex
+++ b/lib/surface/compiler/helpers.ex
@@ -291,7 +291,7 @@ defmodule Surface.Compiler.Helpers do
 
   defp hint_for_unloaded_module(node_alias) do
     """
-    Hint: Make sure module `#{node_alias}` can be successfully compiled.
+    Hint: make sure module `#{node_alias}` can be successfully compiled.
 
     If the module is namespaced, you can use its full name. For instance:
 

--- a/lib/surface/compiler/helpers.ex
+++ b/lib/surface/compiler/helpers.ex
@@ -291,7 +291,7 @@ defmodule Surface.Compiler.Helpers do
 
   defp hint_for_unloaded_module(node_alias) do
     """
-    Hint: make sure module `#{node_alias}` can be successfully compiled.
+    make sure module `#{node_alias}` can be successfully compiled.
 
     If the module is namespaced, you can use its full name. For instance:
 

--- a/lib/surface/io_helper.ex
+++ b/lib/surface/io_helper.ex
@@ -13,15 +13,36 @@ defmodule Surface.IOHelper do
     IO.warn(message, stacktrace)
   end
 
+  if Version.match?(System.version(), ">= 1.14.0") do
+    def warn(message, _caller, file, {line, column}) do
+      IO.warn(message, file: file, line: line, column: column)
+    end
+  else
+    # TODO: Remove this clause in Surface v0.13 and set required elixir to >= v1.14
+    def warn(message, caller, file, {line, _column}) do
+      warn(message, caller, file, line)
+    end
+  end
+
   def warn(message, caller, file, line) do
     stacktrace = Macro.Env.stacktrace(%{caller | file: file, line: line})
 
     IO.warn(message, stacktrace)
   end
 
-  @spec compile_error(String.t(), String.t(), integer()) :: no_return()
+  if Version.match?(System.version(), ">= 1.14.0") do
+    def compile_error(message, hint, file, {line, column}) do
+      reraise(%Surface.CompileError{file: file, line: line, column: column, description: message, hint: hint}, [])
+    end
+  else
+    # TODO: Remove this clause in Surface v0.13 and set required elixir to >= v1.14
+    def compile_error(message, file, {line, _column}) do
+      compile_error(message, file, line)
+    end
+  end
+
   def compile_error(message, file, line) do
-    reraise(%CompileError{line: line, file: file, description: message}, [])
+    reraise(%Surface.CompileError{line: line, file: file, description: message}, [])
   end
 
   @spec syntax_error(String.t(), String.t(), integer()) :: no_return()

--- a/lib/surface/io_helper.ex
+++ b/lib/surface/io_helper.ex
@@ -31,18 +31,33 @@ defmodule Surface.IOHelper do
   end
 
   if Version.match?(System.version(), ">= 1.14.0") do
-    def compile_error(message, hint, file, {line, column}) do
-      reraise(%Surface.CompileError{file: file, line: line, column: column, description: message, hint: hint}, [])
+    def compile_error(message, file, {line, column}) do
+      reraise(%Surface.CompileError{file: file, line: line, column: column, description: message}, [])
     end
   else
     # TODO: Remove this clause in Surface v0.13 and set required elixir to >= v1.14
     def compile_error(message, file, {line, _column}) do
-      compile_error(message, file, line)
+      reraise(%Surface.CompileError{line: line, file: file, description: message}, [])
     end
   end
 
   def compile_error(message, file, line) do
     reraise(%Surface.CompileError{line: line, file: file, description: message}, [])
+  end
+
+  if Version.match?(System.version(), ">= 1.14.0") do
+    def compile_error(message, hint, file, {line, column}) do
+      reraise(%Surface.CompileError{file: file, line: line, column: column, description: message, hint: hint}, [])
+    end
+  else
+    # TODO: Remove this clause in Surface v0.13 and set required elixir to >= v1.14
+    def compile_error(message, hint, file, {line, _column}) do
+      reraise(%Surface.CompileError{file: file, line: line, description: message, hint: hint}, [])
+    end
+  end
+
+  def compile_error(message, hint, file, line) do
+    reraise(%Surface.CompileError{line: line, file: file, description: message, hint: hint}, [])
   end
 
   @spec syntax_error(String.t(), String.t(), integer()) :: no_return()

--- a/test/mix/tasks/compile/surface/validate_components_test.exs
+++ b/test/mix/tasks/compile/surface/validate_components_test.exs
@@ -73,7 +73,7 @@ defmodule Mix.Tasks.Compile.Surface.ValidateComponentsTest do
                compiler_name: "Surface",
                details: nil,
                file: Path.expand("code"),
-               message: "Missing required property \"title\" for component <RequiredPropTitle>",
+               message: "missing required property \"title\" for component <RequiredPropTitle>",
                position: {0, 2},
                severity: :warning
              }
@@ -118,7 +118,7 @@ defmodule Mix.Tasks.Compile.Surface.ValidateComponentsTest do
                details: nil,
                file: Path.expand("code"),
                message: ~S"""
-               Missing required property "id" for component <LiveComponentHasRequiredIdProp>
+               missing required property "id" for component <LiveComponentHasRequiredIdProp>
 
                Hint: Components using `Surface.LiveComponent` automatically define a required `id` prop to make them stateful.
                If you meant to create a stateless component, you can switch to `use Surface.Component`.
@@ -190,7 +190,7 @@ defmodule Mix.Tasks.Compile.Surface.ValidateComponentsTest do
                compiler_name: "Surface",
                details: nil,
                file: Path.expand("code"),
-               message: "Missing required property \"title\" for component <#Macro>",
+               message: "missing required property \"title\" for component <#Macro>",
                position: {1, 4},
                severity: :warning
              }
@@ -220,7 +220,7 @@ defmodule Mix.Tasks.Compile.Surface.ValidateComponentsTest do
                  Path.expand(
                    "test/support/mix/tasks/compile/surface/validate_components_test/live_view_with_external_template.sface"
                  ),
-               message: "Missing required property \"value\" for component <ComponentCall>",
+               message: "missing required property \"value\" for component <ComponentCall>",
                position: {1, 2},
                severity: :warning
              }
@@ -263,7 +263,7 @@ defmodule Mix.Tasks.Compile.Surface.ValidateComponentsTest do
                compiler_name: "Surface",
                details: nil,
                file: Path.expand("code"),
-               message: "Missing required property \"list\" for component <Recursive>",
+               message: "missing required property \"list\" for component <Recursive>",
                position: {0, 2},
                severity: :warning
              }

--- a/test/support/case.ex
+++ b/test/support/case.ex
@@ -1,0 +1,13 @@
+defmodule Surface.Case do
+  @moduledoc """
+  This module defines a generic test case importing common funcions for tests.
+  """
+
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      import ANSIHelpers
+    end
+  end
+end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -15,6 +15,7 @@ defmodule Surface.ConnCase do
       use Surface.LiveViewTest
       import Floki
       import FlokiHelpers
+      import ANSIHelpers
 
       # The default endpoint for testing
       @endpoint Endpoint

--- a/test/surface/api_test.exs
+++ b/test/surface/api_test.exs
@@ -146,17 +146,17 @@ defmodule Surface.APITest do
     # invalid value
     code = "prop field, :string, css_variant: 123"
 
-    message = """
-    code:4: invalid value for :css_variant. Expected either a boolean or a keyword list of options, got: 123.
+    message = ~r"""
+    code:4:\n.+?error:.+? invalid value for :css_variant\. Expected either a boolean or a keyword list of options, got: 123\.
 
     Valid options for type :string are:
 
-      * :not_nil - the name of the variant when the value is not `nil`. Default is the assign name.
-      * :nil - the name of the variant when the value is `nil`. Default is `no-[assign-name]`.
+      \* :not_nil - the name of the variant when the value is not `nil`\. Default is the assign name\.
+      \* :nil - the name of the variant when the value is `nil`\. Default is `no-\[assign-name\]`\.
 
     or, if you use the `values` or `values!` options:
 
-      * :prefix - the prefix of the variant name for each value listed in `values` or `values!`. Default is `[assign-name]-`.
+      \* :prefix - the prefix of the variant name for each value listed in `values` or `values!`. Default is `\[assign-name\]-`\.
     """
 
     assert_raise(Surface.CompileError, message, fn -> eval(code) end)
@@ -445,11 +445,11 @@ defmodule Surface.APITest do
       end
       """
 
-      message = """
-      code.exs:7: cannot use property `unknown` as generator for slot. \
+      message = ~r"""
+      code.exs:7:\n.+?error:.+? cannot use property `unknown` as generator for slot\. \
       Expected an existing property of type `:generator`, got: an undefined property `unknown`.
 
-      Hint: Available generators are [:items]\
+      Hint: Available generators are \[:items\]\
       """
 
       assert_raise(Surface.CompileError, message, fn ->
@@ -473,11 +473,11 @@ defmodule Surface.APITest do
       end
       """
 
-      message = """
-      code.exs:6: cannot use property `label` as generator for slot. \
+      message = ~r"""
+      code.exs:6:\n.+?error:.+? cannot use property `label` as generator for slot\. \
       Expected a property of type :generator, got: a property of type :string
 
-      Hint: Available generators are []\
+      Hint: Available generators are \[\]\
       """
 
       assert_raise(Surface.CompileError, message, fn ->
@@ -804,9 +804,7 @@ defmodule Surface.APISyncTest do
         assert {%Surface.CompileError{
                   description: "cannot render <NonExisting> (module NonExisting could not be loaded)",
                   hint: """
-
-
-                  Hint: make sure module `NonExisting` can be successfully compiled.
+                  make sure module `NonExisting` can be successfully compiled.
 
                   If the module is namespaced, you can use its full name. For instance:
 
@@ -843,7 +841,8 @@ defmodule Surface.APISyncTest do
         end
         """
 
-        error_message = ~r"code.exs:7(:8)?: cannot render <NonExisting> \(module NonExisting could not be loaded\)"
+        error_message =
+          ~r"code.exs:7(:8)?:\n.+?error:.+? cannot render <NonExisting> \(module NonExisting could not be loaded\)"
 
         assert_raise(Surface.CompileError, error_message, fn ->
           {{:module, _, _, _}, _} =

--- a/test/surface/api_test.exs
+++ b/test/surface/api_test.exs
@@ -843,7 +843,7 @@ defmodule Surface.APISyncTest do
         end
         """
 
-        error_message = ~r"code.exs:7: cannot render <NonExisting> \(module NonExisting could not be loaded\)"
+        error_message = ~r"code.exs:7(:8)?: cannot render <NonExisting> \(module NonExisting could not be loaded\)"
 
         assert_raise(Surface.CompileError, error_message, fn ->
           {{:module, _, _, _}, _} =

--- a/test/surface/api_test.exs
+++ b/test/surface/api_test.exs
@@ -5,7 +5,7 @@ defmodule Surface.APITest do
     code = "prop label, :unknown_type"
     message = ~r/code:4/
 
-    assert_raise(CompileError, message, fn -> eval(code) end)
+    assert_raise(Surface.CompileError, message, fn -> eval(code) end)
   end
 
   test "validate ast type" do
@@ -16,14 +16,14 @@ defmodule Surface.APITest do
     Expected an atom, got: {:a, :b}
     """
 
-    assert_raise(CompileError, message, fn -> eval(code) end)
+    assert_raise(Surface.CompileError, message, fn -> eval(code) end)
   end
 
   test "validate type in list of available types" do
     code = "prop label, :foo"
     message = ~r/invalid type :foo for prop label.\nExpected one of \[:any/
 
-    assert_raise(CompileError, message, fn -> eval(code) end)
+    assert_raise(Surface.CompileError, message, fn -> eval(code) end)
   end
 
   test "validate options" do
@@ -31,33 +31,33 @@ defmodule Surface.APITest do
 
     message = ~r/invalid options for prop label. Expected a keyword list of options, got: {:a, :b}/
 
-    assert_raise(CompileError, message, fn -> eval(code) end)
+    assert_raise(Surface.CompileError, message, fn -> eval(code) end)
   end
 
   test "validate type options" do
     code = "data label, :string, a: 1"
     message = ~r/unknown option :a/
 
-    assert_raise(CompileError, message, fn -> eval(code) end)
+    assert_raise(Surface.CompileError, message, fn -> eval(code) end)
 
     code = "data label, :string, a: 1, b: 2"
     message = ~r/unknown options \[:a, :b\]/
 
-    assert_raise(CompileError, message, fn -> eval(code) end)
+    assert_raise(Surface.CompileError, message, fn -> eval(code) end)
   end
 
   test "validate :required" do
     code = "prop label, :string, required: 1"
     message = ~r/invalid value for option :required. Expected a boolean, got: 1/
 
-    assert_raise(CompileError, message, fn -> eval(code) end)
+    assert_raise(Surface.CompileError, message, fn -> eval(code) end)
   end
 
   test "validate :values" do
     code = "prop label, :string, values: 1"
     message = ~r/invalid value for option :values. Expected a list of values or a Range, got: 1/
 
-    assert_raise(CompileError, message, fn -> eval(code) end)
+    assert_raise(Surface.CompileError, message, fn -> eval(code) end)
   end
 
   test "validate :values when using a range" do
@@ -73,21 +73,21 @@ defmodule Surface.APITest do
     code = "slot label, as: \"default_label\""
     message = ~r/invalid value for option :as in slot. Expected an atom, got: \"default_label\"/
 
-    assert_raise(CompileError, message, fn -> eval(code) end)
+    assert_raise(Surface.CompileError, message, fn -> eval(code) end)
   end
 
   test "validate :root in prop" do
     code = "prop label, :string, root: 1"
     message = ~r/invalid value for option :root. Expected a boolean, got: 1/
 
-    assert_raise(CompileError, message, fn -> eval(code) end)
+    assert_raise(Surface.CompileError, message, fn -> eval(code) end)
   end
 
   test "validate :static in prop" do
     code = "prop label, :string, static: 1"
     message = ~r/invalid value for option :static. Expected a boolean, got: 1/
 
-    assert_raise(CompileError, message, fn -> eval(code) end)
+    assert_raise(Surface.CompileError, message, fn -> eval(code) end)
   end
 
   test "validate :from_context type" do
@@ -100,30 +100,30 @@ defmodule Surface.APITest do
     """
 
     code = "prop field, :any, from_context: 123"
-    assert_raise(CompileError, message, fn -> eval(code) end)
+    assert_raise(Surface.CompileError, message, fn -> eval(code) end)
 
     code = "data field, :any, from_context: 123"
-    assert_raise(CompileError, message, fn -> eval(code) end)
+    assert_raise(Surface.CompileError, message, fn -> eval(code) end)
   end
 
   test "validate :from_context with :default" do
     message = ~r/using option :from_context along with :default is currently not allowed/
 
     code = "prop field, :any, from_context: :field, default: :my_field"
-    assert_raise(CompileError, message, fn -> eval(code) end)
+    assert_raise(Surface.CompileError, message, fn -> eval(code) end)
 
     code = "data field, :any, from_context: :field, default: :my_field"
-    assert_raise(CompileError, message, fn -> eval(code) end)
+    assert_raise(Surface.CompileError, message, fn -> eval(code) end)
   end
 
   test "validate :from_context in LiveView" do
     message = ~r/option :from_context is not supported for Surface.Liveview/
 
     code = "prop field, :any, from_context: :field"
-    assert_raise(CompileError, message, fn -> eval(code, "LiveView") end)
+    assert_raise(Surface.CompileError, message, fn -> eval(code, "LiveView") end)
 
     code = "data field, :any, from_context: :field"
-    assert_raise(CompileError, message, fn -> eval(code, "LiveView") end)
+    assert_raise(Surface.CompileError, message, fn -> eval(code, "LiveView") end)
   end
 
   test "validate :css_variant type + options" do
@@ -159,7 +159,7 @@ defmodule Surface.APITest do
       * :prefix - the prefix of the variant name for each value listed in `values` or `values!`. Default is `[assign-name]-`.
     """
 
-    assert_raise(CompileError, message, fn -> eval(code) end)
+    assert_raise(Surface.CompileError, message, fn -> eval(code) end)
   end
 
   test "validate duplicate assigns" do
@@ -173,7 +173,7 @@ defmodule Surface.APITest do
     There's already a prop assign with the same name at line 4\
     """
 
-    assert_raise(CompileError, message, fn -> eval(code) end)
+    assert_raise(Surface.CompileError, message, fn -> eval(code) end)
 
     code = """
     prop label, :string
@@ -181,7 +181,7 @@ defmodule Surface.APITest do
     """
 
     message = ~r/cannot use name "label". There's already a prop/
-    assert_raise(CompileError, message, fn -> eval(code) end)
+    assert_raise(Surface.CompileError, message, fn -> eval(code) end)
 
     code = """
     prop label, :string
@@ -189,7 +189,7 @@ defmodule Surface.APITest do
     """
 
     message = ~r/cannot use name "label". There's already a prop/
-    assert_raise(CompileError, message, fn -> eval(code) end)
+    assert_raise(Surface.CompileError, message, fn -> eval(code) end)
 
     code = """
     data label, :string
@@ -197,7 +197,7 @@ defmodule Surface.APITest do
     """
 
     message = ~r/cannot use name "label". There's already a data assign/
-    assert_raise(CompileError, message, fn -> eval(code) end)
+    assert_raise(Surface.CompileError, message, fn -> eval(code) end)
 
     code = """
     data label, :string
@@ -205,7 +205,7 @@ defmodule Surface.APITest do
     """
 
     message = ~r/cannot use name "label". There's already a data assign/
-    assert_raise(CompileError, message, fn -> eval(code) end)
+    assert_raise(Surface.CompileError, message, fn -> eval(code) end)
 
     code = """
     data label, :string
@@ -213,7 +213,7 @@ defmodule Surface.APITest do
     """
 
     message = ~r/cannot use name "label". There's already a data assign/
-    assert_raise(CompileError, message, fn -> eval(code) end)
+    assert_raise(Surface.CompileError, message, fn -> eval(code) end)
 
     code = """
     slot label
@@ -225,7 +225,7 @@ defmodule Surface.APITest do
     You could use the optional ':as' option in slot macro to name the related assigns.
     """
 
-    assert_raise(CompileError, message, fn -> eval(code) end)
+    assert_raise(Surface.CompileError, message, fn -> eval(code) end)
 
     code = """
     slot label
@@ -237,7 +237,7 @@ defmodule Surface.APITest do
     You could use the optional ':as' option in slot macro to name the related assigns.
     """
 
-    assert_raise(CompileError, message, fn -> eval(code) end)
+    assert_raise(Surface.CompileError, message, fn -> eval(code) end)
 
     code = """
     slot label
@@ -249,7 +249,7 @@ defmodule Surface.APITest do
     You could use the optional ':as' option in slot macro to name the related assigns.
     """
 
-    assert_raise(CompileError, message, fn -> eval(code) end)
+    assert_raise(Surface.CompileError, message, fn -> eval(code) end)
 
     code = """
     slot label, as: :default_label
@@ -290,7 +290,7 @@ defmodule Surface.APITest do
     There's already a built-in data assign with the same name.\
     """
 
-    assert_raise(CompileError, message, fn -> eval(code, "LiveComponent") end)
+    assert_raise(Surface.CompileError, message, fn -> eval(code, "LiveComponent") end)
 
     # Ignore built-in assigns from other component types
     code = """
@@ -312,7 +312,7 @@ defmodule Surface.APITest do
     There's already a built-in data assign with the same name.\
     """
 
-    assert_raise(CompileError, message, fn -> eval(code, "LiveComponent") end)
+    assert_raise(Surface.CompileError, message, fn -> eval(code, "LiveComponent") end)
 
     # Ignore built-in assigns from other component types
     code = """
@@ -333,7 +333,7 @@ defmodule Surface.APITest do
     There's already a built-in data assign with the same name.\
     """
 
-    assert_raise(CompileError, message, fn -> eval(code, "LiveView") end)
+    assert_raise(Surface.CompileError, message, fn -> eval(code, "LiveView") end)
 
     # Ignore built-in assigns from other component types
     code = """
@@ -357,7 +357,7 @@ defmodule Surface.APITest do
     Hint: choose a single property to be the root prop.
     """
 
-    assert_raise(CompileError, message, fn -> eval(code) end)
+    assert_raise(Surface.CompileError, message, fn -> eval(code) end)
   end
 
   test "accept invalid quoted expressions like literal maps as default value" do
@@ -386,7 +386,7 @@ defmodule Surface.APITest do
       code = "prop {a, b}, :string"
       message = ~r/invalid prop name. Expected a variable name, got: {a, b}/
 
-      assert_raise(CompileError, message, fn ->
+      assert_raise(Surface.CompileError, message, fn ->
         eval(code)
       end)
     end
@@ -403,7 +403,7 @@ defmodule Surface.APITest do
       message =
         ~r/unknown option :a. Available options: \[:required, :default, :values, :values!, :accumulate, :root, :static, :from_context, :css_variant\]/
 
-      assert_raise(CompileError, message, fn ->
+      assert_raise(Surface.CompileError, message, fn ->
         eval(code)
       end)
     end
@@ -414,7 +414,7 @@ defmodule Surface.APITest do
       code = "slot {a, b}"
       message = ~r/invalid slot name. Expected a variable name, got: {a, b}/
 
-      assert_raise(CompileError, message, fn ->
+      assert_raise(Surface.CompileError, message, fn ->
         eval(code)
       end)
     end
@@ -423,7 +423,7 @@ defmodule Surface.APITest do
       code = "slot cols, a: 1"
       message = ~r/unknown option :a. Available options: \[:required, :arg, :as, :generator_prop\]/
 
-      assert_raise(CompileError, message, fn ->
+      assert_raise(Surface.CompileError, message, fn ->
         eval(code)
       end)
     end
@@ -452,7 +452,7 @@ defmodule Surface.APITest do
       Hint: Available generators are [:items]\
       """
 
-      assert_raise(CompileError, message, fn ->
+      assert_raise(Surface.CompileError, message, fn ->
         {{:module, _, _, _}, _} = Code.eval_string(code, [], %{__ENV__ | file: "code.exs", line: 1})
       end)
     end
@@ -480,7 +480,7 @@ defmodule Surface.APITest do
       Hint: Available generators are []\
       """
 
-      assert_raise(CompileError, message, fn ->
+      assert_raise(Surface.CompileError, message, fn ->
         {{:module, _, _, _}, _} = Code.eval_string(code, [], %{__ENV__ | file: "code.exs", line: 1})
       end)
     end
@@ -491,7 +491,7 @@ defmodule Surface.APITest do
       code = "data {a, b}, :string"
       message = ~r/invalid data name. Expected a variable name, got: {a, b}/
 
-      assert_raise(CompileError, message, fn ->
+      assert_raise(Surface.CompileError, message, fn ->
         eval(code)
       end)
     end
@@ -507,7 +507,7 @@ defmodule Surface.APITest do
       message =
         ~r/unknown option :a. Available options: \[:default, :values, :values!, :from_context, :css_variant\]/
 
-      assert_raise(CompileError, message, fn ->
+      assert_raise(Surface.CompileError, message, fn ->
         eval(code)
       end)
     end
@@ -686,10 +686,8 @@ defmodule Surface.APISyncTest do
           {{:module, _, _, _}, _} = Code.eval_string(code, [], %{__ENV__ | file: "code.exs", line: 1})
         end)
 
-      assert output =~ ~r"""
-             missing required slot "default" for component <ComponentWithRequiredDefaultSlot>
-               code.exs:6:\
-             """
+      assert output =~ ~S(missing required slot "default" for component <ComponentWithRequiredDefaultSlot>)
+      assert output =~ "code.exs:6:"
     end
 
     test "warn if required slot is not assigned (blank content)" do
@@ -714,10 +712,8 @@ defmodule Surface.APISyncTest do
           {{:module, _, _, _}, _} = Code.eval_string(code, [], %{__ENV__ | file: "code.exs", line: 1})
         end)
 
-      assert output =~ ~r"""
-             missing required slot "default" for component <ComponentWithRequiredDefaultSlot>
-               code.exs:6:\
-             """
+      assert output =~ ~S(missing required slot "default" for component <ComponentWithRequiredDefaultSlot>)
+      assert output =~ "code.exs:6:"
     end
 
     test "warn if required default slot is not assigned (other slots present)" do
@@ -745,10 +741,8 @@ defmodule Surface.APISyncTest do
           {{:module, _, _, _}, _} = Code.eval_string(code, [], %{__ENV__ | file: "code.exs", line: 1})
         end)
 
-      assert output =~ ~r"""
-             missing required slot "default" for component <ComponentWithRequiredDefaultSlot>
-               code.exs:6:\
-             """
+      assert output =~ ~S(missing required slot "default" for component <ComponentWithRequiredDefaultSlot>)
+      assert output =~ "code.exs:6:"
     end
 
     test "warn if a required named slot is not assigned" do
@@ -773,10 +767,8 @@ defmodule Surface.APISyncTest do
           {{:module, _, _, _}, _} = Code.eval_string(code, [], %{__ENV__ | file: "code.exs", line: 1})
         end)
 
-      assert output =~ ~r"""
-             missing required slot "header" for component <ComponentWithRequiredSlots>
-               code.exs:6:\
-             """
+      assert output =~ ~S(missing required slot "header" for component <ComponentWithRequiredSlots>)
+      assert output =~ "code.exs:6:"
     end
 
     if Version.match?(System.version(), ">= 1.15.0") do
@@ -836,6 +828,11 @@ defmodule Surface.APISyncTest do
           end
         end
         """
+
+        # NOTE: there's a bug in Elixir that report the error with the wrong line
+        # in versions <= 1.7. See https://github.com/elixir-lang/elixir/issues/13542
+        # for details.
+        # TODO: Keep only code.exs:7:
 
         error_message = "code.exs:7: module NonExisting is not loaded and could not be found"
 

--- a/test/surface/api_test.exs
+++ b/test/surface/api_test.exs
@@ -1,5 +1,5 @@
 defmodule Surface.APITest do
-  use ExUnit.Case, async: true
+  use Surface.Case, async: true
 
   test "raise error at the right line" do
     code = "prop label, :unknown_type"
@@ -147,7 +147,8 @@ defmodule Surface.APITest do
     code = "prop field, :string, css_variant: 123"
 
     message = ~r"""
-    code:4:\n.+?error:.+? invalid value for :css_variant\. Expected either a boolean or a keyword list of options, got: 123\.
+    code:4:
+    #{maybe_ansi("error:")} invalid value for :css_variant\. Expected either a boolean or a keyword list of options, got: 123\.
 
     Valid options for type :string are:
 
@@ -446,7 +447,8 @@ defmodule Surface.APITest do
       """
 
       message = ~r"""
-      code.exs:7:\n.+?error:.+? cannot use property `unknown` as generator for slot\. \
+      code.exs:7:
+      #{maybe_ansi("error:")} cannot use property `unknown` as generator for slot\. \
       Expected an existing property of type `:generator`, got: an undefined property `unknown`.
 
       Hint: Available generators are \[:items\]\
@@ -474,7 +476,8 @@ defmodule Surface.APITest do
       """
 
       message = ~r"""
-      code.exs:6:\n.+?error:.+? cannot use property `label` as generator for slot\. \
+      code.exs:6:
+      #{maybe_ansi("error:")} cannot use property `label` as generator for slot\. \
       Expected a property of type :generator, got: a property of type :string
 
       Hint: Available generators are \[\]\
@@ -842,7 +845,7 @@ defmodule Surface.APISyncTest do
         """
 
         error_message =
-          ~r"code.exs:7(:8)?:\n.+?error:.+? cannot render <NonExisting> \(module NonExisting could not be loaded\)"
+          ~r"code.exs:7(:8)?:\n#{maybe_ansi("error:")} cannot render <NonExisting> \(module NonExisting could not be loaded\)"
 
         assert_raise(Surface.CompileError, error_message, fn ->
           {{:module, _, _, _}, _} =

--- a/test/surface/api_test.exs
+++ b/test/surface/api_test.exs
@@ -801,11 +801,25 @@ defmodule Surface.APISyncTest do
             end
           end)
 
-        assert {%CompileError{},
-                [
-                  %{message: "cannot render <NonExisting> (module NonExisting could not be loaded)" <> _},
-                  %{message: "module NonExisting is not loaded and could not be found"}
-                ]} = diagnostics
+        assert {%Surface.CompileError{
+                  description: "cannot render <NonExisting> (module NonExisting could not be loaded)",
+                  hint: """
+
+
+                  Hint: make sure module `NonExisting` can be successfully compiled.
+
+                  If the module is namespaced, you can use its full name. For instance:
+
+                    <MyProject.Components.NonExisting>
+
+                  or add a proper alias so you can use just `<NonExisting>`:
+
+                    alias MyProject.Components.NonExisting
+                  """,
+                  file: "code.exs",
+                  line: 7,
+                  column: 8
+                }, []} = diagnostics
       end
     else
       # Remove this test (and the `if`) whenever we drop support for Elixir < 1.15
@@ -829,23 +843,12 @@ defmodule Surface.APISyncTest do
         end
         """
 
-        # NOTE: there's a bug in Elixir that report the error with the wrong line
-        # in versions <= 1.7. See https://github.com/elixir-lang/elixir/issues/13542
-        # for details.
-        # TODO: Keep only code.exs:7:
+        error_message = ~r"code.exs:7: cannot render <NonExisting> \(module NonExisting could not be loaded\)"
 
-        error_message = "code.exs:7: module NonExisting is not loaded and could not be found"
-
-        output =
-          capture_io(:standard_error, fn ->
-            assert_raise(CompileError, error_message, fn ->
-              {{:module, _, _, _}, _} =
-                Code.eval_string(code, [], %{__ENV__ | file: "code.exs", line: 1}) |> IO.inspect()
-            end)
-          end)
-
-        assert output =~ ~r"cannot render <NonExisting> \(module NonExisting could not be loaded\)"
-        assert output =~ ~r"  code.exs:7:"
+        assert_raise(Surface.CompileError, error_message, fn ->
+          {{:module, _, _, _}, _} =
+            Code.eval_string(code, [], %{__ENV__ | file: "code.exs", line: 1}) |> IO.inspect()
+        end)
       end
     end
   end

--- a/test/surface/api_test.exs
+++ b/test/surface/api_test.exs
@@ -628,7 +628,7 @@ defmodule Surface.APITest do
 end
 
 defmodule Surface.APISyncTest do
-  use ExUnit.Case
+  use Surface.Case
   import ExUnit.CaptureIO
 
   defmodule ComponentWithRequiredDefaultSlot do

--- a/test/surface/catalogue/live_example_test.exs
+++ b/test/surface/catalogue/live_example_test.exs
@@ -1,5 +1,5 @@
 defmodule Surface.Catalogue.LiveExampleTest do
-  use ExUnit.Case
+  use Surface.Case
 
   alias Surface.Catalogue.FakeLiveExample
   alias Surface.Catalogue.FakeLiveExampleModuleDocFalse
@@ -36,9 +36,10 @@ defmodule Surface.Catalogue.LiveExampleTest do
     """
 
     message = ~r"""
-    code\.exs:2:\n.+?error:.+? no subject defined for Surface\.Catalogue\.LiveExample
+    code\.exs:2:
+    #{maybe_ansi("error:")} no subject defined for Surface\.Catalogue\.LiveExample
 
-    .+?hint:.+? you can define the subject using the :subject option\. Example:
+    #{maybe_ansi("hint:")} you can define the subject using the :subject option\. Example:
 
       use Surface\.Catalogue\.LiveExample, subject: MyApp.MyButton
     """

--- a/test/surface/catalogue/live_example_test.exs
+++ b/test/surface/catalogue/live_example_test.exs
@@ -35,12 +35,12 @@ defmodule Surface.Catalogue.LiveExampleTest do
     end
     """
 
-    message = """
-    code.exs:2: no subject defined for Surface.Catalogue.LiveExample
+    message = ~r"""
+    code\.exs:2:\n.+?error:.+? no subject defined for Surface\.Catalogue\.LiveExample
 
-    Hint: You can define the subject using the :subject option. Example:
+    .+?hint:.+? you can define the subject using the :subject option\. Example:
 
-      use Surface.Catalogue.LiveExample, subject: MyApp.MyButton
+      use Surface\.Catalogue\.LiveExample, subject: MyApp.MyButton
     """
 
     assert_raise Surface.CompileError, message, fn ->

--- a/test/surface/catalogue/live_example_test.exs
+++ b/test/surface/catalogue/live_example_test.exs
@@ -43,7 +43,7 @@ defmodule Surface.Catalogue.LiveExampleTest do
       use Surface.Catalogue.LiveExample, subject: MyApp.MyButton
     """
 
-    assert_raise CompileError, message, fn ->
+    assert_raise Surface.CompileError, message, fn ->
       Code.eval_string(code, [], %{__ENV__ | file: "code.exs", line: 1})
     end
   end

--- a/test/surface/catalogue/playground_test.exs
+++ b/test/surface/catalogue/playground_test.exs
@@ -36,7 +36,7 @@ defmodule Surface.Catalogue.PlaygroundTest do
       use Surface.Catalogue.Playground, subject: MyApp.MyButton
     """
 
-    assert_raise CompileError, message, fn ->
+    assert_raise Surface.CompileError, message, fn ->
       Code.eval_string(code, [], %{__ENV__ | file: "code.exs", line: 1})
     end
   end

--- a/test/surface/catalogue/playground_test.exs
+++ b/test/surface/catalogue/playground_test.exs
@@ -28,10 +28,10 @@ defmodule Surface.Catalogue.PlaygroundTest do
     end
     """
 
-    message = """
-    code.exs:2: no subject defined for Surface.Catalogue.Playground
+    message = ~r"""
+    code.exs:2:\n.+?error:.+? no subject defined for Surface.Catalogue.Playground
 
-    Hint: You can define the subject using the :subject option. Example:
+    .+?hint:.+?you can define the subject using the :subject option. Example:
 
       use Surface.Catalogue.Playground, subject: MyApp.MyButton
     """

--- a/test/surface/catalogue/playground_test.exs
+++ b/test/surface/catalogue/playground_test.exs
@@ -29,9 +29,10 @@ defmodule Surface.Catalogue.PlaygroundTest do
     """
 
     message = ~r"""
-    code.exs:2:\n.+?error:.+? no subject defined for Surface.Catalogue.Playground
+    code.exs:2:
+    #{maybe_ansi("error:")} no subject defined for Surface.Catalogue.Playground
 
-    .+?hint:.+?you can define the subject using the :subject option. Example:
+    #{maybe_ansi("hint:")} you can define the subject using the :subject option. Example:
 
       use Surface.Catalogue.Playground, subject: MyApp.MyButton
     """

--- a/test/surface/compiler/parser_test.exs
+++ b/test/surface/compiler/parser_test.exs
@@ -742,8 +742,8 @@ defmodule Surface.Compiler.ParserTest do
       />
       """
 
-      message = """
-      nofile:2: invalid value for tagged expression `{=1}`. The expression must be either an assign or a variable.
+      message = ~r"""
+      nofile:2:\n.+?error:.+? invalid value for tagged expression `{=1}`. The expression must be either an assign or a variable.
 
       Examples: `<div {=@class}>` or `<div {=class}>`
       """
@@ -758,8 +758,8 @@ defmodule Surface.Compiler.ParserTest do
       />
       """
 
-      message = """
-      nofile:2: cannot assign `{=@class}` to attribute `class`. \
+      message = ~r"""
+      nofile:2:\n.+?error:.+? cannot assign `{=@class}` to attribute `class`. \
       The tagged expression `{= }` can only be used on a root attribute/property.
 
       Example: <div {=@class}>
@@ -995,7 +995,7 @@ defmodule Surface.Compiler.ParserTest do
       {/if}
       """
 
-      message = "nofile:2: missing expression for block {#if ...}"
+      message = ~r"nofile:2:\n.+?error:.+? missing expression for block {#if ...}"
 
       assert_raise Surface.CompileError, message, fn -> parse!(code) end
 
@@ -1006,7 +1006,7 @@ defmodule Surface.Compiler.ParserTest do
       {/case}
       """
 
-      message = "nofile:2: missing expression for block {#case ...}"
+      message = ~r"nofile:2:\n.+?error:.+? missing expression for block {#case ...}"
 
       assert_raise Surface.CompileError, message, fn -> parse!(code) end
     end

--- a/test/surface/compiler/parser_test.exs
+++ b/test/surface/compiler/parser_test.exs
@@ -1,5 +1,5 @@
 defmodule Surface.Compiler.ParserTest do
-  use ExUnit.Case, async: true
+  use Surface.Case, async: true
 
   import Surface.Compiler.Parser
   alias Surface.Compiler.ParseError
@@ -743,7 +743,8 @@ defmodule Surface.Compiler.ParserTest do
       """
 
       message = ~r"""
-      nofile:2:\n.+?error:.+? invalid value for tagged expression `{=1}`. The expression must be either an assign or a variable.
+      nofile:2:
+      #{maybe_ansi("error:")} invalid value for tagged expression `{=1}`. The expression must be either an assign or a variable.
 
       Examples: `<div {=@class}>` or `<div {=class}>`
       """
@@ -759,7 +760,8 @@ defmodule Surface.Compiler.ParserTest do
       """
 
       message = ~r"""
-      nofile:2:\n.+?error:.+? cannot assign `{=@class}` to attribute `class`. \
+      nofile:2:
+      #{maybe_ansi("error:")} cannot assign `{=@class}` to attribute `class`. \
       The tagged expression `{= }` can only be used on a root attribute/property.
 
       Example: <div {=@class}>
@@ -995,7 +997,7 @@ defmodule Surface.Compiler.ParserTest do
       {/if}
       """
 
-      message = ~r"nofile:2:\n.+?error:.+? missing expression for block {#if ...}"
+      message = ~r"nofile:2:\n#{maybe_ansi("error:")} missing expression for block {#if ...}"
 
       assert_raise Surface.CompileError, message, fn -> parse!(code) end
 
@@ -1006,7 +1008,7 @@ defmodule Surface.Compiler.ParserTest do
       {/case}
       """
 
-      message = ~r"nofile:2:\n.+?error:.+? missing expression for block {#case ...}"
+      message = ~r"nofile:2:\n#{maybe_ansi("error:")} missing expression for block {#case ...}"
 
       assert_raise Surface.CompileError, message, fn -> parse!(code) end
     end

--- a/test/surface/compiler/parser_test.exs
+++ b/test/surface/compiler/parser_test.exs
@@ -748,7 +748,7 @@ defmodule Surface.Compiler.ParserTest do
       Examples: `<div {=@class}>` or `<div {=class}>`
       """
 
-      assert_raise CompileError, message, fn -> parse!(code) end
+      assert_raise Surface.CompileError, message, fn -> parse!(code) end
     end
 
     test "raise on assigning {= ...} to an attribute" do
@@ -765,7 +765,7 @@ defmodule Surface.Compiler.ParserTest do
       Example: <div {=@class}>
       """
 
-      assert_raise CompileError, message, fn -> parse!(code) end
+      assert_raise Surface.CompileError, message, fn -> parse!(code) end
     end
   end
 
@@ -997,7 +997,7 @@ defmodule Surface.Compiler.ParserTest do
 
       message = "nofile:2: missing expression for block {#if ...}"
 
-      assert_raise CompileError, message, fn -> parse!(code) end
+      assert_raise Surface.CompileError, message, fn -> parse!(code) end
 
       code = """
       1
@@ -1008,7 +1008,7 @@ defmodule Surface.Compiler.ParserTest do
 
       message = "nofile:2: missing expression for block {#case ...}"
 
-      assert_raise CompileError, message, fn -> parse!(code) end
+      assert_raise Surface.CompileError, message, fn -> parse!(code) end
     end
 
     test "raise error on missing closing block" do

--- a/test/surface/compiler_test.exs
+++ b/test/surface/compiler_test.exs
@@ -1021,7 +1021,7 @@ defmodule Surface.CompilerSyncTest do
 
     assert_raise(
       Surface.CompileError,
-      ~r/nofile:2(:4)?: cannot render <But> \(module But could not be loaded\)/,
+      ~r/nofile:2(:4)?:\n.+?error:.+? cannot render <But> \(module But could not be loaded\)/,
       fn ->
         Surface.Compiler.compile(code, 1, __ENV__)
       end

--- a/test/surface/compiler_test.exs
+++ b/test/surface/compiler_test.exs
@@ -942,7 +942,7 @@ defmodule Surface.CompilerTest do
 end
 
 defmodule Surface.CompilerSyncTest do
-  use ExUnit.Case
+  use Surface.Case
 
   import ExUnit.CaptureIO
 
@@ -1021,7 +1021,7 @@ defmodule Surface.CompilerSyncTest do
 
     assert_raise(
       Surface.CompileError,
-      ~r/nofile:2(:4)?:\n.+?error:.+? cannot render <But> \(module But could not be loaded\)/,
+      ~r/nofile:2(:4)?:\n#{maybe_ansi("error:")} cannot render <But> \(module But could not be loaded\)/,
       fn ->
         Surface.Compiler.compile(code, 1, __ENV__)
       end

--- a/test/surface/compiler_test.exs
+++ b/test/surface/compiler_test.exs
@@ -1012,30 +1012,20 @@ defmodule Surface.CompilerSyncTest do
     assert {:ok, _component} = run_compile(code, __ENV__)
   end
 
-  test "warning with hint when a unaliased component cannot be loaded" do
+  test "raise when a unaliased component cannot be loaded" do
     code = """
     <div>
       <But />
     </div>
     """
 
-    {:warn, line, message} = run_compile(code, __ENV__)
-
-    assert message =~ """
-           cannot render <But> (module But could not be loaded)
-
-           Hint: make sure module `But` can be successfully compiled.
-
-           If the module is namespaced, you can use its full name. For instance:
-
-             <MyProject.Components.But>
-
-           or add a proper alias so you can use just `<But>`:
-
-             alias MyProject.Components.But
-           """
-
-    assert line == 2
+    assert_raise(
+      Surface.CompileError,
+      ~r/nofile:2(:\d)?: cannot render <But> \(module But could not be loaded\)/,
+      fn ->
+        Surface.Compiler.compile(code, 1, __ENV__)
+      end
+    )
   end
 
   test "warning when module is not a component" do

--- a/test/surface/compiler_test.exs
+++ b/test/surface/compiler_test.exs
@@ -1021,7 +1021,7 @@ defmodule Surface.CompilerSyncTest do
 
     assert_raise(
       Surface.CompileError,
-      ~r/nofile:2(:\d)?: cannot render <But> \(module But could not be loaded\)/,
+      ~r/nofile:2(:4)?: cannot render <But> \(module But could not be loaded\)/,
       fn ->
         Surface.Compiler.compile(code, 1, __ENV__)
       end

--- a/test/surface/compiler_test.exs
+++ b/test/surface/compiler_test.exs
@@ -1024,7 +1024,7 @@ defmodule Surface.CompilerSyncTest do
     assert message =~ """
            cannot render <But> (module But could not be loaded)
 
-           Hint: Make sure module `But` can be successfully compiled.
+           Hint: make sure module `But` can be successfully compiled.
 
            If the module is namespaced, you can use its full name. For instance:
 

--- a/test/surface/component_test.exs
+++ b/test/surface/component_test.exs
@@ -210,7 +210,7 @@ defmodule Surface.ComponentTest do
 
     message = "code.exs:2: invalid value for option :slot. Expected a string, got: {1, 2}"
 
-    assert_raise(CompileError, message, fn ->
+    assert_raise(Surface.CompileError, message, fn ->
       {{:module, _, _, _}, _} = Code.eval_string(code, [], %{__ENV__ | file: "code.exs", line: 1})
     end)
   end
@@ -335,10 +335,8 @@ defmodule Surface.ComponentTest do
                  """
         end)
 
-      assert output =~ ~r"""
-             cannot render <Enum> \(module Enum is not a component\)
-               code:2:\
-             """
+      assert output =~ "cannot render <Enum> (module Enum is not a component)"
+      assert output =~ "code:2:"
     end
   end
 

--- a/test/surface/component_test.exs
+++ b/test/surface/component_test.exs
@@ -208,7 +208,7 @@ defmodule Surface.ComponentTest do
     end
     """
 
-    message = "code.exs:2: invalid value for option :slot. Expected a string, got: {1, 2}"
+    message = ~r"code.exs:2:\n.+?error:.+? invalid value for option :slot. Expected a string, got: {1, 2}"
 
     assert_raise(Surface.CompileError, message, fn ->
       {{:module, _, _, _}, _} = Code.eval_string(code, [], %{__ENV__ | file: "code.exs", line: 1})

--- a/test/surface/component_test.exs
+++ b/test/surface/component_test.exs
@@ -208,7 +208,8 @@ defmodule Surface.ComponentTest do
     end
     """
 
-    message = ~r"code.exs:2:\n.+?error:.+? invalid value for option :slot. Expected a string, got: {1, 2}"
+    message =
+      ~r"code.exs:2:\n#{maybe_ansi("error:")} invalid value for option :slot. Expected a string, got: {1, 2}"
 
     assert_raise(Surface.CompileError, message, fn ->
       {{:module, _, _, _}, _} = Code.eval_string(code, [], %{__ENV__ | file: "code.exs", line: 1})

--- a/test/surface/components/context_test.exs
+++ b/test/surface/components/context_test.exs
@@ -931,11 +931,11 @@ defmodule Surface.Components.ContextTest do
           """
         end
 
-      message = """
-      code:2: invalid value for property "get". expected a scope \
-      module (optional) along with a keyword list of bindings, \
+      message = ~r"""
+      code:2:\n.+?error:.+? invalid value for property "get". expected a scope \
+      module \(optional\) along with a keyword list of bindings, \
       e.g. {Form, form: form} or {field: my_field}, \
-      got: {ContextTest.Outer, field: [field]}.\
+      got: {ContextTest.Outer, field: \[field\]}.\
       """
 
       assert_raise(Surface.CompileError, message, fn ->
@@ -954,7 +954,7 @@ defmodule Surface.Components.ContextTest do
           """
         end
 
-      assert_raise(Surface.CompileError, ~r/code:2: invalid value for property "get"/, fn ->
+      assert_raise(Surface.CompileError, ~r/code:2:\n.+?error:.+? invalid value for property "get"/, fn ->
         compile_surface(code)
       end)
     end
@@ -970,7 +970,7 @@ defmodule Surface.Components.ContextTest do
           """
         end
 
-      assert_raise(Surface.CompileError, ~r/code:2: invalid value for property "get"/, fn ->
+      assert_raise(Surface.CompileError, ~r/code:2:\n.+?error:.+? invalid value for property "get"/, fn ->
         compile_surface(code)
       end)
     end
@@ -988,9 +988,9 @@ defmodule Surface.Components.ContextTest do
           """
         end
 
-      message = """
-      code:2: invalid value for property "put". expected a scope \
-      module (optional) along with a keyword list of values, \
+      message = ~r"""
+      code:2:\n.+?error:.+? invalid value for property "put". expected a scope \
+      module \(optional\) along with a keyword list of values, \
       e.g. {MyModule, field: @value, other: "other"} or {field: @value}, \
       got: {ContextTest.Outer, 123}.\
       """
@@ -1011,7 +1011,7 @@ defmodule Surface.Components.ContextTest do
           """
         end
 
-      assert_raise(Surface.CompileError, ~r/code:2: invalid value for property "put"/, fn ->
+      assert_raise(Surface.CompileError, ~r/code:2:\n.+?error:.+? invalid value for property "put"/, fn ->
         compile_surface(code)
       end)
     end
@@ -1027,7 +1027,7 @@ defmodule Surface.Components.ContextTest do
           """
         end
 
-      assert_raise(Surface.CompileError, ~r/code:2: invalid value for property "put"/, fn ->
+      assert_raise(Surface.CompileError, ~r/code:2:\n.+?error:.+? invalid value for property "put"/, fn ->
         compile_surface(code)
       end)
     end
@@ -1177,8 +1177,8 @@ defmodule Surface.Components.ContextTest do
     end
     """
 
-    message = """
-    code.exs:7: components propagating context values through slots must be configured \
+    message = ~r"""
+    code.exs:7:\n.+?error:.+? components propagating context values through slots must be configured \
     as `propagate_context_to_slots: true`.
 
     In case you don't want to propagate any value, you need to explicitly \
@@ -1186,10 +1186,10 @@ defmodule Surface.Components.ContextTest do
 
     # Example
 
-    config :surface, :components, [
+    config :surface, :components, \[
       {Surface.Components.ContextTest.WarnOnSlotPropContextPut, propagate_context_to_slots: true},
       ...
-    ]
+    \]
 
     This warning is emitted whenever a <#slot ...> uses the `context_put` prop or \
     it's placed inside a parent component that propagates context values through its slots.
@@ -1217,8 +1217,8 @@ defmodule Surface.Components.ContextTest do
     end
     """
 
-    message = """
-    code.exs:9: components propagating context values through slots must be configured \
+    message = ~r"""
+    code.exs:9:\n.+?error:.+? components propagating context values through slots must be configured \
     as `propagate_context_to_slots: true`.
 
     In case you don't want to propagate any value, you need to explicitly \
@@ -1226,17 +1226,17 @@ defmodule Surface.Components.ContextTest do
 
     # Example
 
-    config :surface, :components, [
+    config :surface, :components, \[
       {Surface.Components.ContextTest.WarnOnContextPut, propagate_context_to_slots: true},
       ...
-    ]
+    \]
 
     This warning is emitted whenever a <#slot ...> uses the `context_put` prop or \
     it's placed inside a parent component that propagates context values through its slots.
 
     Current parent components propagating context values:
 
-        * `Surface.Components.Context` at line 8
+        \* `Surface.Components.Context` at line 8
     """
 
     assert_raise(Surface.CompileError, message, fn ->
@@ -1263,27 +1263,27 @@ defmodule Surface.Components.ContextTest do
     end
     """
 
-    message = """
-    code.exs:10: components propagating context values through slots must be configured \
-    as `propagate_context_to_slots: true`.
+    message = ~r"""
+    code.exs:10:\n.+?error:.+? components propagating context values through slots must be configured \
+    as `propagate_context_to_slots: true`\.
 
     In case you don't want to propagate any value, you need to explicitly \
-    set `propagate_context_to_slots` to `false`.
+    set `propagate_context_to_slots` to `false`\.
 
     # Example
 
-    config :surface, :components, [
+    config :surface, :components, \[
       {Surface.Components.ContextTest.WarnOnSlotInsideComponentPropagating, propagate_context_to_slots: true},
       ...
-    ]
+    \]
 
     This warning is emitted whenever a <#slot ...> uses the `context_put` prop or \
     it's placed inside a parent component that propagates context values through its slots.
 
     Current parent components propagating context values:
 
-        * `Surface.Components.ContextTest.Outer` at line 8
-        * `Surface.Components.ContextTest.OuterUsingPropContextPut` at line 9
+        \* `Surface.Components.ContextTest.Outer` at line 8
+        \* `Surface.Components.ContextTest.OuterUsingPropContextPut` at line 9
     """
 
     assert_raise(Surface.CompileError, message, fn ->

--- a/test/surface/components/context_test.exs
+++ b/test/surface/components/context_test.exs
@@ -932,7 +932,8 @@ defmodule Surface.Components.ContextTest do
         end
 
       message = ~r"""
-      code:2:\n.+?error:.+? invalid value for property "get". expected a scope \
+      code:2:
+      #{maybe_ansi("error:")} invalid value for property "get". expected a scope \
       module \(optional\) along with a keyword list of bindings, \
       e.g. {Form, form: form} or {field: my_field}, \
       got: {ContextTest.Outer, field: \[field\]}.\
@@ -954,9 +955,13 @@ defmodule Surface.Components.ContextTest do
           """
         end
 
-      assert_raise(Surface.CompileError, ~r/code:2:\n.+?error:.+? invalid value for property "get"/, fn ->
-        compile_surface(code)
-      end)
+      assert_raise(
+        Surface.CompileError,
+        ~r/code:2:\n#{maybe_ansi("error:")} invalid value for property "get"/,
+        fn ->
+          compile_surface(code)
+        end
+      )
     end
 
     test "raise compile error when passing invalid scope" do
@@ -970,9 +975,13 @@ defmodule Surface.Components.ContextTest do
           """
         end
 
-      assert_raise(Surface.CompileError, ~r/code:2:\n.+?error:.+? invalid value for property "get"/, fn ->
-        compile_surface(code)
-      end)
+      assert_raise(
+        Surface.CompileError,
+        ~r/code:2:\n#{maybe_ansi("error:")} invalid value for property "get"/,
+        fn ->
+          compile_surface(code)
+        end
+      )
     end
   end
 
@@ -989,7 +998,8 @@ defmodule Surface.Components.ContextTest do
         end
 
       message = ~r"""
-      code:2:\n.+?error:.+? invalid value for property "put". expected a scope \
+      code:2:
+      #{maybe_ansi("error:")} invalid value for property "put". expected a scope \
       module \(optional\) along with a keyword list of values, \
       e.g. {MyModule, field: @value, other: "other"} or {field: @value}, \
       got: {ContextTest.Outer, 123}.\
@@ -1011,9 +1021,13 @@ defmodule Surface.Components.ContextTest do
           """
         end
 
-      assert_raise(Surface.CompileError, ~r/code:2:\n.+?error:.+? invalid value for property "put"/, fn ->
-        compile_surface(code)
-      end)
+      assert_raise(
+        Surface.CompileError,
+        ~r/code:2:\n#{maybe_ansi("error:")} invalid value for property "put"/,
+        fn ->
+          compile_surface(code)
+        end
+      )
     end
 
     test "raise compile error when passing invalid scope" do
@@ -1027,9 +1041,13 @@ defmodule Surface.Components.ContextTest do
           """
         end
 
-      assert_raise(Surface.CompileError, ~r/code:2:\n.+?error:.+? invalid value for property "put"/, fn ->
-        compile_surface(code)
-      end)
+      assert_raise(
+        Surface.CompileError,
+        ~r/code:2:\n#{maybe_ansi("error:")} invalid value for property "put"/,
+        fn ->
+          compile_surface(code)
+        end
+      )
     end
   end
 
@@ -1178,7 +1196,8 @@ defmodule Surface.Components.ContextTest do
     """
 
     message = ~r"""
-    code.exs:7:\n.+?error:.+? components propagating context values through slots must be configured \
+    code.exs:7:
+    #{maybe_ansi("error:")} components propagating context values through slots must be configured \
     as `propagate_context_to_slots: true`.
 
     In case you don't want to propagate any value, you need to explicitly \
@@ -1218,7 +1237,8 @@ defmodule Surface.Components.ContextTest do
     """
 
     message = ~r"""
-    code.exs:9:\n.+?error:.+? components propagating context values through slots must be configured \
+    code.exs:9:
+    #{maybe_ansi("error:")} components propagating context values through slots must be configured \
     as `propagate_context_to_slots: true`.
 
     In case you don't want to propagate any value, you need to explicitly \
@@ -1264,7 +1284,8 @@ defmodule Surface.Components.ContextTest do
     """
 
     message = ~r"""
-    code.exs:10:\n.+?error:.+? components propagating context values through slots must be configured \
+    code.exs:10:
+    #{maybe_ansi("error:")} components propagating context values through slots must be configured \
     as `propagate_context_to_slots: true`\.
 
     In case you don't want to propagate any value, you need to explicitly \

--- a/test/surface/components/context_test.exs
+++ b/test/surface/components/context_test.exs
@@ -938,7 +938,7 @@ defmodule Surface.Components.ContextTest do
       got: {ContextTest.Outer, field: [field]}.\
       """
 
-      assert_raise(CompileError, message, fn ->
+      assert_raise(Surface.CompileError, message, fn ->
         compile_surface(code)
       end)
     end
@@ -954,7 +954,7 @@ defmodule Surface.Components.ContextTest do
           """
         end
 
-      assert_raise(CompileError, ~r/code:2: invalid value for property "get"/, fn ->
+      assert_raise(Surface.CompileError, ~r/code:2: invalid value for property "get"/, fn ->
         compile_surface(code)
       end)
     end
@@ -970,7 +970,7 @@ defmodule Surface.Components.ContextTest do
           """
         end
 
-      assert_raise(CompileError, ~r/code:2: invalid value for property "get"/, fn ->
+      assert_raise(Surface.CompileError, ~r/code:2: invalid value for property "get"/, fn ->
         compile_surface(code)
       end)
     end
@@ -995,7 +995,7 @@ defmodule Surface.Components.ContextTest do
       got: {ContextTest.Outer, 123}.\
       """
 
-      assert_raise(CompileError, message, fn ->
+      assert_raise(Surface.CompileError, message, fn ->
         compile_surface(code)
       end)
     end
@@ -1011,7 +1011,7 @@ defmodule Surface.Components.ContextTest do
           """
         end
 
-      assert_raise(CompileError, ~r/code:2: invalid value for property "put"/, fn ->
+      assert_raise(Surface.CompileError, ~r/code:2: invalid value for property "put"/, fn ->
         compile_surface(code)
       end)
     end
@@ -1027,7 +1027,7 @@ defmodule Surface.Components.ContextTest do
           """
         end
 
-      assert_raise(CompileError, ~r/code:2: invalid value for property "put"/, fn ->
+      assert_raise(Surface.CompileError, ~r/code:2: invalid value for property "put"/, fn ->
         compile_surface(code)
       end)
     end
@@ -1195,7 +1195,7 @@ defmodule Surface.Components.ContextTest do
     it's placed inside a parent component that propagates context values through its slots.
     """
 
-    assert_raise(CompileError, message, fn ->
+    assert_raise(Surface.CompileError, message, fn ->
       {{:module, _, _, _}, _} = Code.eval_string(code, [], %{__ENV__ | file: "code.exs", line: 1})
     end)
   end
@@ -1239,7 +1239,7 @@ defmodule Surface.Components.ContextTest do
         * `Surface.Components.Context` at line 8
     """
 
-    assert_raise(CompileError, message, fn ->
+    assert_raise(Surface.CompileError, message, fn ->
       {{:module, _, _, _}, _} = Code.eval_string(code, [], %{__ENV__ | file: "code.exs", line: 1})
     end)
   end
@@ -1286,7 +1286,7 @@ defmodule Surface.Components.ContextTest do
         * `Surface.Components.ContextTest.OuterUsingPropContextPut` at line 9
     """
 
-    assert_raise(CompileError, message, fn ->
+    assert_raise(Surface.CompileError, message, fn ->
       {{:module, _, _, _}, _} = Code.eval_string(code, [], %{__ENV__ | file: "code.exs", line: 1})
     end)
   end

--- a/test/surface/components_calls_test.exs
+++ b/test/surface/components_calls_test.exs
@@ -3,7 +3,7 @@ defmodule Surface.ComponentsCallsTest do
 
   describe "__component_calls__/0" do
     test "on Component" do
-      assert Surface.ComponentsCallsTest.Components.ComponentWithExternalTemplate.__components_calls__() == [
+      assert [
                %{
                  component: Surface.Components.Raw,
                  directives: [],
@@ -11,7 +11,8 @@ defmodule Surface.ComponentsCallsTest do
                  column: 4,
                  node_alias: "#Raw",
                  props: [],
-                 dep_type: :compile
+                 dep_type: :compile,
+                 file: file
                },
                %{
                  component: Surface.ComponentsCallsTest.Components.ComponentCall,
@@ -20,13 +21,16 @@ defmodule Surface.ComponentsCallsTest do
                  column: 2,
                  node_alias: "ComponentCall",
                  props: [],
-                 dep_type: :export
+                 dep_type: :export,
+                 file: file
                }
-             ]
+             ] = Surface.ComponentsCallsTest.Components.ComponentWithExternalTemplate.__components_calls__()
+
+      assert file =~ "test/support/components_calls_test/component_with_external_template.sface"
     end
 
     test "on LiveComponent" do
-      assert Surface.ComponentsCallsTest.Components.LiveComponentWithExternalTemplate.__components_calls__() == [
+      assert [
                %{
                  component: Surface.ComponentsCallsTest.Components.ComponentCall,
                  directives: [],
@@ -34,13 +38,16 @@ defmodule Surface.ComponentsCallsTest do
                  column: 2,
                  node_alias: "ComponentCall",
                  props: [],
-                 dep_type: :export
+                 dep_type: :export,
+                 file: file
                }
-             ]
+             ] = Surface.ComponentsCallsTest.Components.LiveComponentWithExternalTemplate.__components_calls__()
+
+      assert file =~ "test/support/components_calls_test/live_component_with_external_template.sface"
     end
 
     test "on LiveView" do
-      assert Surface.ComponentsCallsTest.Components.LiveViewWithExternalTemplate.__components_calls__() == [
+      assert [
                %{
                  component: Surface.ComponentsCallsTest.Components.ComponentCall,
                  directives: [],
@@ -48,9 +55,12 @@ defmodule Surface.ComponentsCallsTest do
                  column: 2,
                  node_alias: "ComponentCall",
                  props: [],
-                 dep_type: :export
+                 dep_type: :export,
+                 file: file
                }
-             ]
+             ] = Surface.ComponentsCallsTest.Components.LiveViewWithExternalTemplate.__components_calls__()
+
+      assert file =~ "test/support/components_calls_test/live_view_with_external_template.sface"
     end
   end
 

--- a/test/surface/constructs/case_test.exs
+++ b/test/surface/constructs/case_test.exs
@@ -81,7 +81,7 @@ defmodule Surface.Constructs.CaseTest do
 
     message = ~S(code:2: cannot have content between {#case ...} and {#match ...})
 
-    assert_raise(CompileError, message, fn ->
+    assert_raise(Surface.CompileError, message, fn ->
       compile_surface(code)
     end)
   end
@@ -100,7 +100,7 @@ defmodule Surface.Constructs.CaseTest do
     message =
       ~S(code:2: no {#match} sub-block defined. A {#case} block must include at least one {#match ...} sub-block.)
 
-    assert_raise(CompileError, message, fn ->
+    assert_raise(Surface.CompileError, message, fn ->
       compile_surface(code)
     end)
   end

--- a/test/surface/constructs/case_test.exs
+++ b/test/surface/constructs/case_test.exs
@@ -79,7 +79,7 @@ defmodule Surface.Constructs.CaseTest do
         """
       end
 
-    message = ~S(code:2: cannot have content between {#case ...} and {#match ...})
+    message = ~r/code:2:\n.+?error:.+? cannot have content between {#case ...} and {#match ...}/
 
     assert_raise(Surface.CompileError, message, fn ->
       compile_surface(code)
@@ -98,7 +98,7 @@ defmodule Surface.Constructs.CaseTest do
       end
 
     message =
-      ~S(code:2: no {#match} sub-block defined. A {#case} block must include at least one {#match ...} sub-block.)
+      ~r/code:2:\n.+?error:.+? no {#match} sub-block defined. A {#case} block must include at least one {#match ...} sub-block./
 
     assert_raise(Surface.CompileError, message, fn ->
       compile_surface(code)

--- a/test/surface/constructs/case_test.exs
+++ b/test/surface/constructs/case_test.exs
@@ -79,7 +79,7 @@ defmodule Surface.Constructs.CaseTest do
         """
       end
 
-    message = ~r/code:2:\n.+?error:.+? cannot have content between {#case ...} and {#match ...}/
+    message = ~r/code:2:\n#{maybe_ansi("error:")} cannot have content between {#case ...} and {#match ...}/
 
     assert_raise(Surface.CompileError, message, fn ->
       compile_surface(code)
@@ -98,7 +98,7 @@ defmodule Surface.Constructs.CaseTest do
       end
 
     message =
-      ~r/code:2:\n.+?error:.+? no {#match} sub-block defined. A {#case} block must include at least one {#match ...} sub-block./
+      ~r/code:2:\n#{maybe_ansi("error:")} no {#match} sub-block defined. A {#case} block must include at least one {#match ...} sub-block./
 
     assert_raise(Surface.CompileError, message, fn ->
       compile_surface(code)

--- a/test/surface/constructs/for_test.exs
+++ b/test/surface/constructs/for_test.exs
@@ -113,7 +113,7 @@ defmodule Surface.Constructs.ForTest do
 
       message = ~S(code:3: invalid value for property "prop". Expected a :list, got: "some string".)
 
-      assert_raise(CompileError, message, fn ->
+      assert_raise(Surface.CompileError, message, fn ->
         compile_surface(code)
       end)
     end
@@ -209,7 +209,7 @@ defmodule Surface.Constructs.ForTest do
       message =
         ~r/code:3: using `{#else}` is only supported when the expression in `{#for}` has a single generator and no filters./
 
-      assert_raise(CompileError, message, fn ->
+      assert_raise(Surface.CompileError, message, fn ->
         compile_surface(code, assigns)
       end)
     end

--- a/test/surface/constructs/for_test.exs
+++ b/test/surface/constructs/for_test.exs
@@ -111,7 +111,7 @@ defmodule Surface.Constructs.ForTest do
           """
         end
 
-      message = ~S(code:3: invalid value for property "prop". Expected a :list, got: "some string".)
+      message = ~r/code:3:\n.+?error:.+? invalid value for property "prop". Expected a :list, got: "some string"./
 
       assert_raise(Surface.CompileError, message, fn ->
         compile_surface(code)
@@ -207,7 +207,7 @@ defmodule Surface.Constructs.ForTest do
         end
 
       message =
-        ~r/code:3: using `{#else}` is only supported when the expression in `{#for}` has a single generator and no filters./
+        ~r/code:3:\n.+?error:.+? using `{#else}` is only supported when the expression in `{#for}` has a single generator and no filters./
 
       assert_raise(Surface.CompileError, message, fn ->
         compile_surface(code, assigns)

--- a/test/surface/constructs/for_test.exs
+++ b/test/surface/constructs/for_test.exs
@@ -111,7 +111,8 @@ defmodule Surface.Constructs.ForTest do
           """
         end
 
-      message = ~r/code:3:\n.+?error:.+? invalid value for property "prop". Expected a :list, got: "some string"./
+      message =
+        ~r/code:3:\n#{maybe_ansi("error:")} invalid value for property "prop". Expected a :list, got: "some string"./
 
       assert_raise(Surface.CompileError, message, fn ->
         compile_surface(code)
@@ -207,7 +208,7 @@ defmodule Surface.Constructs.ForTest do
         end
 
       message =
-        ~r/code:3:\n.+?error:.+? using `{#else}` is only supported when the expression in `{#for}` has a single generator and no filters./
+        ~r/code:3:\n#{maybe_ansi("error:")} using `{#else}` is only supported when the expression in `{#for}` has a single generator and no filters./
 
       assert_raise(Surface.CompileError, message, fn ->
         compile_surface(code, assigns)

--- a/test/surface/constructs/if_test.exs
+++ b/test/surface/constructs/if_test.exs
@@ -88,7 +88,7 @@ defmodule Surface.Constructs.IfTest do
 
       message = ~S(code:2: invalid value for property "prop". Expected a :list, got: "some string".)
 
-      assert_raise(CompileError, message, fn ->
+      assert_raise(Surface.CompileError, message, fn ->
         compile_surface(code)
       end)
     end
@@ -313,7 +313,7 @@ defmodule Surface.Constructs.IfTest do
 
       message = ~S(code:12: invalid value for property "prop". Expected a :list, got: "some string".)
 
-      assert_raise(CompileError, message, fn ->
+      assert_raise(Surface.CompileError, message, fn ->
         compile_surface(code)
       end)
     end
@@ -398,7 +398,7 @@ defmodule Surface.Constructs.IfTest do
 
       message = ~S(code:2: invalid value for property "prop". Expected a :list, got: "some string".)
 
-      assert_raise(CompileError, message, fn ->
+      assert_raise(Surface.CompileError, message, fn ->
         compile_surface(code)
       end)
     end

--- a/test/surface/constructs/if_test.exs
+++ b/test/surface/constructs/if_test.exs
@@ -86,7 +86,8 @@ defmodule Surface.Constructs.IfTest do
           """
         end
 
-      message = ~r/code:2:\n.+?error:.+? invalid value for property "prop". Expected a :list, got: "some string"./
+      message =
+        ~r/code:2:\n#{maybe_ansi("error:")} invalid value for property "prop". Expected a :list, got: "some string"./
 
       assert_raise(Surface.CompileError, message, fn ->
         compile_surface(code)
@@ -311,7 +312,8 @@ defmodule Surface.Constructs.IfTest do
           """
         end
 
-      message = ~r/code:12:\n.+?error:.+? invalid value for property "prop". Expected a :list, got: "some string"./
+      message =
+        ~r/code:12:\n#{maybe_ansi("error:")} invalid value for property "prop". Expected a :list, got: "some string"./
 
       assert_raise(Surface.CompileError, message, fn ->
         compile_surface(code)
@@ -396,7 +398,8 @@ defmodule Surface.Constructs.IfTest do
           """
         end
 
-      message = ~r/code:2:\n.+?error:.+? invalid value for property "prop". Expected a :list, got: "some string"./
+      message =
+        ~r/code:2:\n#{maybe_ansi("error:")} invalid value for property "prop". Expected a :list, got: "some string"./
 
       assert_raise(Surface.CompileError, message, fn ->
         compile_surface(code)

--- a/test/surface/constructs/if_test.exs
+++ b/test/surface/constructs/if_test.exs
@@ -86,7 +86,7 @@ defmodule Surface.Constructs.IfTest do
           """
         end
 
-      message = ~S(code:2: invalid value for property "prop". Expected a :list, got: "some string".)
+      message = ~r/code:2:\n.+?error:.+? invalid value for property "prop". Expected a :list, got: "some string"./
 
       assert_raise(Surface.CompileError, message, fn ->
         compile_surface(code)
@@ -311,7 +311,7 @@ defmodule Surface.Constructs.IfTest do
           """
         end
 
-      message = ~S(code:12: invalid value for property "prop". Expected a :list, got: "some string".)
+      message = ~r/code:12:\n.+?error:.+? invalid value for property "prop". Expected a :list, got: "some string"./
 
       assert_raise(Surface.CompileError, message, fn ->
         compile_surface(code)
@@ -396,7 +396,7 @@ defmodule Surface.Constructs.IfTest do
           """
         end
 
-      message = ~S(code:2: invalid value for property "prop". Expected a :list, got: "some string".)
+      message = ~r/code:2:\n.+?error:.+? invalid value for property "prop". Expected a :list, got: "some string"./
 
       assert_raise(Surface.CompileError, message, fn ->
         compile_surface(code)

--- a/test/surface/integrations/directives_test.exs
+++ b/test/surface/integrations/directives_test.exs
@@ -187,7 +187,8 @@ defmodule Surface.DirectivesTest do
         end
 
       message = ~r"""
-      code:3:\n.+?error:.+? cannot assign `{\.\.\.@props}` to attribute `class`\. \
+      code:3:
+      #{maybe_ansi("error:")} cannot assign `{\.\.\.@props}` to attribute `class`\. \
       The tagged expression `{\.\.\. }` can only be used on a root attribute/property\.
 
       Example: <div {\.\.\.@attrs}>
@@ -316,7 +317,8 @@ defmodule Surface.DirectivesTest do
         end
 
       message = ~r"""
-      code:3:\n.+?error:.+? cannot assign `{\.\.\.@attrs}` to attribute `class`\. \
+      code:3:
+      #{maybe_ansi("error:")} cannot assign `{\.\.\.@attrs}` to attribute `class`\. \
       The tagged expression `{\.\.\. }` can only be used on a root attribute/property\.
 
       Example: <div {\.\.\.@attrs}>
@@ -386,7 +388,8 @@ defmodule Surface.DirectivesTest do
         end
 
       message = ~r"""
-      code:2:\n.+?error:.+? unknown modifier "unknown" for directive :for\
+      code:2:
+      #{maybe_ansi("error:")} unknown modifier "unknown" for directive :for\
       """
 
       assert_raise(Surface.CompileError, message, fn ->
@@ -408,7 +411,8 @@ defmodule Surface.DirectivesTest do
         end
 
       message = ~r"""
-      code:2:\n.+?error:.+? cannot apply modifier "with_index" on generators with multiple clauses\
+      code:2:
+      #{maybe_ansi("error:")} cannot apply modifier "with_index" on generators with multiple clauses\
       """
 
       assert_raise(Surface.CompileError, message, fn ->

--- a/test/surface/integrations/directives_test.exs
+++ b/test/surface/integrations/directives_test.exs
@@ -186,11 +186,11 @@ defmodule Surface.DirectivesTest do
           """
         end
 
-      message = """
-      code:3: cannot assign `{...@props}` to attribute `class`. \
-      The tagged expression `{... }` can only be used on a root attribute/property.
+      message = ~r"""
+      code:3:\n.+?error:.+? cannot assign `{\.\.\.@props}` to attribute `class`\. \
+      The tagged expression `{\.\.\. }` can only be used on a root attribute/property\.
 
-      Example: <div {...@attrs}>
+      Example: <div {\.\.\.@attrs}>
       """
 
       assert_raise(Surface.CompileError, message, fn ->
@@ -315,11 +315,11 @@ defmodule Surface.DirectivesTest do
           """
         end
 
-      message = """
-      code:3: cannot assign `{...@attrs}` to attribute `class`. \
-      The tagged expression `{... }` can only be used on a root attribute/property.
+      message = ~r"""
+      code:3:\n.+?error:.+? cannot assign `{\.\.\.@attrs}` to attribute `class`\. \
+      The tagged expression `{\.\.\. }` can only be used on a root attribute/property\.
 
-      Example: <div {...@attrs}>
+      Example: <div {\.\.\.@attrs}>
       """
 
       assert_raise(Surface.CompileError, message, fn ->
@@ -385,8 +385,8 @@ defmodule Surface.DirectivesTest do
           """
         end
 
-      message = """
-      code:2: unknown modifier "unknown" for directive :for\
+      message = ~r"""
+      code:2:\n.+?error:.+? unknown modifier "unknown" for directive :for\
       """
 
       assert_raise(Surface.CompileError, message, fn ->
@@ -407,8 +407,8 @@ defmodule Surface.DirectivesTest do
           """
         end
 
-      message = """
-      code:2: cannot apply modifier "with_index" on generators with multiple clauses\
+      message = ~r"""
+      code:2:\n.+?error:.+? cannot apply modifier "with_index" on generators with multiple clauses\
       """
 
       assert_raise(Surface.CompileError, message, fn ->

--- a/test/surface/integrations/directives_test.exs
+++ b/test/surface/integrations/directives_test.exs
@@ -193,7 +193,7 @@ defmodule Surface.DirectivesTest do
       Example: <div {...@attrs}>
       """
 
-      assert_raise(CompileError, message, fn ->
+      assert_raise(Surface.CompileError, message, fn ->
         compile_surface(code, assigns)
       end)
     end
@@ -322,7 +322,7 @@ defmodule Surface.DirectivesTest do
       Example: <div {...@attrs}>
       """
 
-      assert_raise(CompileError, message, fn ->
+      assert_raise(Surface.CompileError, message, fn ->
         compile_surface(code, assigns)
       end)
     end
@@ -389,7 +389,7 @@ defmodule Surface.DirectivesTest do
       code:2: unknown modifier "unknown" for directive :for\
       """
 
-      assert_raise(CompileError, message, fn ->
+      assert_raise(Surface.CompileError, message, fn ->
         compile_surface(code, assigns)
       end)
     end
@@ -411,7 +411,7 @@ defmodule Surface.DirectivesTest do
       code:2: cannot apply modifier "with_index" on generators with multiple clauses\
       """
 
-      assert_raise(CompileError, message, fn ->
+      assert_raise(Surface.CompileError, message, fn ->
         compile_surface(code, assigns)
       end)
     end
@@ -1126,7 +1126,7 @@ defmodule Surface.DirectivesTest do
     end
 
     test "passing unsupported types" do
-      assert_raise(CompileError, ~r(invalid value for key ":map" in attribute ":values".), fn ->
+      assert_raise(Surface.CompileError, ~r(invalid value for key ":map" in attribute ":values".), fn ->
         """
         <div :values={map: %{}, tuple: {}}>
           Some Text

--- a/test/surface/integrations/html_tag_test.exs
+++ b/test/surface/integrations/html_tag_test.exs
@@ -14,7 +14,7 @@ defmodule HtmlTagTest do
   end
 
   test "raise runtime error for invalid attributes values" do
-    assert_raise(CompileError, ~r/invalid value for attribute "title"/, fn ->
+    assert_raise(Surface.CompileError, ~r/invalid value for attribute "title"/, fn ->
       "<div title={{1, 2}}/>"
       |> Surface.Compiler.compile(1, __ENV__)
       |> Surface.Compiler.to_live_struct()
@@ -464,7 +464,7 @@ defmodule HtmlTagTest do
     end
 
     test "raise compile error for invalid style value that can be evaluated at compile time" do
-      assert_raise(CompileError, ~r/invalid value for attribute "style"/, fn ->
+      assert_raise(Surface.CompileError, ~r/invalid value for attribute "style"/, fn ->
         "<div style={{1, 2}}/>"
         |> Surface.Compiler.compile(1, __ENV__)
         |> Surface.Compiler.to_live_struct()

--- a/test/surface/integrations/properties_test.exs
+++ b/test/surface/integrations/properties_test.exs
@@ -197,7 +197,7 @@ defmodule Surface.PropertiesTest do
 
       message = ~S(code:1: invalid value for property "as". Expected a :atom, got: "some string".)
 
-      assert_raise(CompileError, message, fn ->
+      assert_raise(Surface.CompileError, message, fn ->
         compile_surface(code)
       end)
     end
@@ -302,7 +302,7 @@ defmodule Surface.PropertiesTest do
 
       message = ~S(code:1: invalid value for property "prop". Expected a :keyword, got: "some string".)
 
-      assert_raise(CompileError, message, fn ->
+      assert_raise(Surface.CompileError, message, fn ->
         compile_surface(code)
       end)
     end
@@ -448,7 +448,7 @@ defmodule Surface.PropertiesTest do
 
       message = ~S(code:1: invalid value for property "prop". Expected a :map, got: "some string".)
 
-      assert_raise(CompileError, message, fn ->
+      assert_raise(Surface.CompileError, message, fn ->
         compile_surface(code)
       end)
     end
@@ -531,7 +531,7 @@ defmodule Surface.PropertiesTest do
 
       message = ~S(code:1: invalid value for property "prop". Expected a :list, got: {1, 2}.)
 
-      assert_raise(CompileError, message, fn ->
+      assert_raise(Surface.CompileError, message, fn ->
         compile_surface(code)
       end)
     end
@@ -600,7 +600,7 @@ defmodule Surface.PropertiesTest do
 
       message = ~S(code:1: invalid value for property "prop". Expected a :list, got: "some string".)
 
-      assert_raise(CompileError, message, fn ->
+      assert_raise(Surface.CompileError, message, fn ->
         compile_surface(code)
       end)
     end
@@ -852,7 +852,7 @@ defmodule Surface.PropertiesTest do
       code:2: invalid value for property "labels". Expected a :generator Example: `{i <- ...}`, got: {"label"}.\
       """
 
-      assert_raise(CompileError, message, fn ->
+      assert_raise(Surface.CompileError, message, fn ->
         compile_surface(code)
       end)
     end
@@ -1007,7 +1007,7 @@ defmodule Surface.PropertiesSyncTest do
 
     message = "code.exs:11: `generator_value` is missing for slot `default`"
 
-    assert_raise(CompileError, message, fn ->
+    assert_raise(Surface.CompileError, message, fn ->
       {{:module, _, _, _}, _} = Code.eval_string(code, [], %{__ENV__ | file: "code.exs", line: 1})
     end)
   end

--- a/test/surface/integrations/properties_test.exs
+++ b/test/surface/integrations/properties_test.exs
@@ -195,7 +195,7 @@ defmodule Surface.PropertiesTest do
           """
         end
 
-      message = ~S(code:1: invalid value for property "as". Expected a :atom, got: "some string".)
+      message = ~r/code:1:\n.+?error:.+? invalid value for property "as"\. Expected a :atom, got: "some string"\./
 
       assert_raise(Surface.CompileError, message, fn ->
         compile_surface(code)
@@ -300,7 +300,8 @@ defmodule Surface.PropertiesTest do
           """
         end
 
-      message = ~S(code:1: invalid value for property "prop". Expected a :keyword, got: "some string".)
+      message =
+        ~r/code:1:\n.+?error:.+? invalid value for property "prop"\. Expected a :keyword, got: "some string"\./
 
       assert_raise(Surface.CompileError, message, fn ->
         compile_surface(code)
@@ -446,7 +447,7 @@ defmodule Surface.PropertiesTest do
           """
         end
 
-      message = ~S(code:1: invalid value for property "prop". Expected a :map, got: "some string".)
+      message = ~r/code:1:\n.+?error:.+? invalid value for property "prop"\. Expected a :map, got: "some string"\./
 
       assert_raise(Surface.CompileError, message, fn ->
         compile_surface(code)
@@ -529,7 +530,7 @@ defmodule Surface.PropertiesTest do
           """
         end
 
-      message = ~S(code:1: invalid value for property "prop". Expected a :list, got: {1, 2}.)
+      message = ~r/code:1:\n.+?error:.+? invalid value for property "prop"\. Expected a :list, got: {1, 2}\./
 
       assert_raise(Surface.CompileError, message, fn ->
         compile_surface(code)
@@ -598,7 +599,8 @@ defmodule Surface.PropertiesTest do
           """
         end
 
-      message = ~S(code:1: invalid value for property "prop". Expected a :list, got: "some string".)
+      message =
+        ~r/code:1:\n.+?error:.+? invalid value for property "prop"\. Expected a :list, got: "some string"\./
 
       assert_raise(Surface.CompileError, message, fn ->
         compile_surface(code)
@@ -848,8 +850,8 @@ defmodule Surface.PropertiesTest do
           """
         end
 
-      message = """
-      code:2: invalid value for property "labels". Expected a :generator Example: `{i <- ...}`, got: {"label"}.\
+      message = ~r"""
+      code:2:\n.+?error:.+? invalid value for property "labels"\. Expected a :generator Example: `{i <- \.\.\.}`, got: {"label"}\.\
       """
 
       assert_raise(Surface.CompileError, message, fn ->
@@ -1005,7 +1007,7 @@ defmodule Surface.PropertiesSyncTest do
     end
     """
 
-    message = "code.exs:11: `generator_value` is missing for slot `default`"
+    message = ~r"code.exs:11:\n.+?error:.+? `generator_value` is missing for slot `default`"
 
     assert_raise(Surface.CompileError, message, fn ->
       {{:module, _, _, _}, _} = Code.eval_string(code, [], %{__ENV__ | file: "code.exs", line: 1})

--- a/test/surface/integrations/properties_test.exs
+++ b/test/surface/integrations/properties_test.exs
@@ -195,7 +195,8 @@ defmodule Surface.PropertiesTest do
           """
         end
 
-      message = ~r/code:1:\n.+?error:.+? invalid value for property "as"\. Expected a :atom, got: "some string"\./
+      message =
+        ~r/code:1:\n#{maybe_ansi("error:")} invalid value for property "as"\. Expected a :atom, got: "some string"\./
 
       assert_raise(Surface.CompileError, message, fn ->
         compile_surface(code)
@@ -301,7 +302,7 @@ defmodule Surface.PropertiesTest do
         end
 
       message =
-        ~r/code:1:\n.+?error:.+? invalid value for property "prop"\. Expected a :keyword, got: "some string"\./
+        ~r/code:1:\n#{maybe_ansi("error:")} invalid value for property "prop"\. Expected a :keyword, got: "some string"\./
 
       assert_raise(Surface.CompileError, message, fn ->
         compile_surface(code)
@@ -447,7 +448,8 @@ defmodule Surface.PropertiesTest do
           """
         end
 
-      message = ~r/code:1:\n.+?error:.+? invalid value for property "prop"\. Expected a :map, got: "some string"\./
+      message =
+        ~r/code:1:\n#{maybe_ansi("error:")} invalid value for property "prop"\. Expected a :map, got: "some string"\./
 
       assert_raise(Surface.CompileError, message, fn ->
         compile_surface(code)
@@ -530,7 +532,8 @@ defmodule Surface.PropertiesTest do
           """
         end
 
-      message = ~r/code:1:\n.+?error:.+? invalid value for property "prop"\. Expected a :list, got: {1, 2}\./
+      message =
+        ~r/code:1:\n#{maybe_ansi("error:")} invalid value for property "prop"\. Expected a :list, got: {1, 2}\./
 
       assert_raise(Surface.CompileError, message, fn ->
         compile_surface(code)
@@ -600,7 +603,7 @@ defmodule Surface.PropertiesTest do
         end
 
       message =
-        ~r/code:1:\n.+?error:.+? invalid value for property "prop"\. Expected a :list, got: "some string"\./
+        ~r/code:1:\n#{maybe_ansi("error:")} invalid value for property "prop"\. Expected a :list, got: "some string"\./
 
       assert_raise(Surface.CompileError, message, fn ->
         compile_surface(code)
@@ -851,7 +854,8 @@ defmodule Surface.PropertiesTest do
         end
 
       message = ~r"""
-      code:2:\n.+?error:.+? invalid value for property "labels"\. Expected a :generator Example: `{i <- \.\.\.}`, got: {"label"}\.\
+      code:2:
+      #{maybe_ansi("error:")} invalid value for property "labels"\. Expected a :generator Example: `{i <- \.\.\.}`, got: {"label"}\.\
       """
 
       assert_raise(Surface.CompileError, message, fn ->
@@ -1007,7 +1011,7 @@ defmodule Surface.PropertiesSyncTest do
     end
     """
 
-    message = ~r"code.exs:11:\n.+?error:.+? `generator_value` is missing for slot `default`"
+    message = ~r"code.exs:11:\n#{maybe_ansi("error:")} `generator_value` is missing for slot `default`"
 
     assert_raise(Surface.CompileError, message, fn ->
       {{:module, _, _, _}, _} = Code.eval_string(code, [], %{__ENV__ | file: "code.exs", line: 1})

--- a/test/surface/integrations/slot_test.exs
+++ b/test/surface/integrations/slot_test.exs
@@ -782,7 +782,8 @@ defmodule Surface.SlotTest do
       end
 
     message = ~r"""
-    code:2:\n.+?error:.+? cannot use :let to redefine variable from the component's generator\.
+    code:2:
+    #{maybe_ansi("error:")} cannot use :let to redefine variable from the component's generator\.
 
     variables `i` and `j` already defined in `{i, j} <- @items` at code:1
 
@@ -1002,7 +1003,8 @@ defmodule Surface.SlotTest do
       end
 
     message = ~r"""
-    code:3:\n.+?error:.+? invalid value for directive :let\. \
+    code:3:
+    #{maybe_ansi("error:")} invalid value for directive :let\. \
     Expected a pattern to be matched by the slot argument, \
     got: {"a_string", "other_string"}\.\
     """
@@ -1023,7 +1025,8 @@ defmodule Surface.SlotTest do
       end
 
     message = ~r"""
-    code:1:\n.+?error:.+? no slot "default" defined in parent component <OuterWithoutDefaultSlot>
+    code:1:
+    #{maybe_ansi("error:")} no slot "default" defined in parent component <OuterWithoutDefaultSlot>
     """
 
     assert_raise(Surface.CompileError, message, fn ->
@@ -1044,7 +1047,8 @@ defmodule Surface.SlotTest do
       end
 
     message = ~r"""
-    code:2:\n.+?error:.+? invalid value for directive :let\. \
+    code:2:
+    #{maybe_ansi("error:")} invalid value for directive :let\. \
     Expected a pattern to be matched by the slot argument, \
     got: {a, info: \[my_info\]}\.\
     """
@@ -1064,7 +1068,8 @@ defmodule Surface.SlotTest do
       end
 
     message = ~r"""
-    code:2:\n.+?error:.+? invalid value for attribute "root"\. \
+    code:2:
+    #{maybe_ansi("error:")} invalid value for attribute "root"\. \
     Expected the slot and a single expression to be given as the slot argument, \
     got: {@default, a, b}\.\
     """
@@ -1084,7 +1089,8 @@ defmodule Surface.SlotTest do
       end
 
     message = ~r"""
-    code:2:\n.+?error:.+? invalid value for attribute "root"\. \
+    code:2:
+    #{maybe_ansi("error:")} invalid value for attribute "root"\. \
     Expected the slot and a single expression to be given as the slot argument, \
     got: {@default, a, info: "Info from slot"}\.\
     """
@@ -1249,7 +1255,8 @@ defmodule Surface.SlotSyncTest do
       end
 
     message = ~r"""
-    code:2:\n.+?error:.+? The slotable component <Surface.SlotTest.InnerData> has the `:slot` option set to `inner`\.
+    code:2:
+    #{maybe_ansi("error:")} The slotable component <Surface.SlotTest.InnerData> has the `:slot` option set to `inner`\.
 
     That slot name is not declared in parent component <StatefulComponent>\.
 
@@ -1273,7 +1280,8 @@ defmodule Surface.SlotSyncTest do
       end
 
     message = ~r"""
-    code:2:\n.+?error:.+? The slotable component <Surface.SlotTest.InnerData> has the `:slot` option set to `inner`\.
+    code:2:
+    #{maybe_ansi("error:")} The slotable component <Surface.SlotTest.InnerData> has the `:slot` option set to `inner`\.
 
     That slot name is not declared in parent component <Grid>\.
 
@@ -1302,7 +1310,8 @@ defmodule Surface.SlotSyncTest do
       end
 
     message = ~r"""
-    code:4:\n.+?error:.+? no slot "foot" defined in parent component <OuterWithNamedSlot>
+    code:4:
+    #{maybe_ansi("error:")} no slot "foot" defined in parent component <OuterWithNamedSlot>
 
     Did you mean "footer"\?
 
@@ -1335,7 +1344,8 @@ defmodule Surface.SlotSyncTest do
     """
 
     message = ~r"""
-    code:12:\n.+?error:.+? no slot `footer` defined in the component `Surface.SlotSyncTest.TestComponentWithoutDeclaringSlots`
+    code:12:
+    #{maybe_ansi("error:")} no slot `footer` defined in the component `Surface.SlotSyncTest.TestComponentWithoutDeclaringSlots`
 
     Available slots: "default" and "header"\
 
@@ -1367,7 +1377,8 @@ defmodule Surface.SlotSyncTest do
     """
 
     message = ~r"""
-    code:7:\n.+?error:.+? no slot `default` defined in the component `Surface.SlotSyncTest.TestComponentWithShortSyntaxButWithoutDeclaringDefaultSlot`
+    code:7:
+    #{maybe_ansi("error:")} no slot `default` defined in the component `Surface.SlotSyncTest.TestComponentWithShortSyntaxButWithoutDeclaringDefaultSlot`
 
     Please declare the default slot using `slot default` in order to use the `<#slot />` notation\.
     """
@@ -1470,7 +1481,8 @@ defmodule Surface.SlotSyncTest do
       end
 
     message = ~r"""
-    code:1:\n.+?error:.+? no slot "default" defined in parent component <OuterWithoutDefaultSlot>
+    code:1:
+    #{maybe_ansi("error:")} no slot "default" defined in parent component <OuterWithoutDefaultSlot>
     """
 
     assert_raise(Surface.CompileError, message, fn ->
@@ -1534,7 +1546,8 @@ defmodule Surface.SlotSyncTest do
     """
 
     message = ~r"""
-    code:10:\n.+?error:.+? invalid directive `:attrs` for <#slot>\.
+    code:10:
+    #{maybe_ansi("error:")} invalid directive `:attrs` for <#slot>\.
 
     Slots only accept the root prop, `generator_value`, `:if` and `:for`\.
     """
@@ -1565,7 +1578,8 @@ defmodule Surface.SlotSyncTest do
     """
 
     message = ~r"""
-    code:11:\n.+?error:.+? invalid attribute `let` for <#slot>\.
+    code:11:
+    #{maybe_ansi("error:")} invalid attribute `let` for <#slot>\.
 
     Slots only accept the root prop, `generator_value`, `:if` and `:for`\.
     """
@@ -1595,7 +1609,8 @@ defmodule Surface.SlotSyncTest do
     """
 
     message = ~r"""
-    code:10:\n.+?error:.+? cannot pass dynamic attributes to <#slot>.
+    code:10:
+    #{maybe_ansi("error:")} cannot pass dynamic attributes to <#slot>.
 
     Slots only accept the root prop, `for`, `name`, `index`, `generator_value`, `:if` and `:for`.
     """
@@ -1625,7 +1640,8 @@ defmodule Surface.SlotSyncTest do
     """
 
     message = ~r"""
-    code:10:\n.+?error:.+? cannot pass dynamic attributes to <#slot>.
+    code:10:
+    #{maybe_ansi("error:")} cannot pass dynamic attributes to <#slot>.
 
     Slots only accept the root prop, `for`, `name`, `index`, `generator_value`, `:if` and `:for`.
     """

--- a/test/surface/integrations/slot_test.exs
+++ b/test/surface/integrations/slot_test.exs
@@ -781,8 +781,8 @@ defmodule Surface.SlotTest do
         """
       end
 
-    message = """
-    code:2: cannot use :let to redefine variable from the component's generator.
+    message = ~r"""
+    code:2:\n.+?error:.+? cannot use :let to redefine variable from the component's generator\.
 
     variables `i` and `j` already defined in `{i, j} <- @items` at code:1
 
@@ -1001,10 +1001,10 @@ defmodule Surface.SlotTest do
         """
       end
 
-    message = """
-    code:3: invalid value for directive :let. \
+    message = ~r"""
+    code:3:\n.+?error:.+? invalid value for directive :let\. \
     Expected a pattern to be matched by the slot argument, \
-    got: {"a_string", "other_string"}.\
+    got: {"a_string", "other_string"}\.\
     """
 
     assert_raise(Surface.CompileError, message, fn ->
@@ -1022,8 +1022,8 @@ defmodule Surface.SlotTest do
         """
       end
 
-    message = """
-    code:1: no slot "default" defined in parent component <OuterWithoutDefaultSlot>
+    message = ~r"""
+    code:1:\n.+?error:.+? no slot "default" defined in parent component <OuterWithoutDefaultSlot>
     """
 
     assert_raise(Surface.CompileError, message, fn ->
@@ -1043,10 +1043,10 @@ defmodule Surface.SlotTest do
         """
       end
 
-    message = """
-    code:2: invalid value for directive :let. \
+    message = ~r"""
+    code:2:\n.+?error:.+? invalid value for directive :let\. \
     Expected a pattern to be matched by the slot argument, \
-    got: {a, info: [my_info]}.\
+    got: {a, info: \[my_info\]}\.\
     """
 
     assert_raise(Surface.CompileError, message, fn ->
@@ -1063,10 +1063,10 @@ defmodule Surface.SlotTest do
         """
       end
 
-    message = """
-    code:2: invalid value for attribute "root". \
+    message = ~r"""
+    code:2:\n.+?error:.+? invalid value for attribute "root"\. \
     Expected the slot and a single expression to be given as the slot argument, \
-    got: {@default, a, b}.\
+    got: {@default, a, b}\.\
     """
 
     assert_raise(Surface.CompileError, message, fn ->
@@ -1083,10 +1083,10 @@ defmodule Surface.SlotTest do
         """
       end
 
-    message = """
-    code:2: invalid value for attribute "root". \
+    message = ~r"""
+    code:2:\n.+?error:.+? invalid value for attribute "root"\. \
     Expected the slot and a single expression to be given as the slot argument, \
-    got: {@default, a, info: "Info from slot"}.\
+    got: {@default, a, info: "Info from slot"}\.\
     """
 
     assert_raise(Surface.CompileError, message, fn ->
@@ -1248,12 +1248,12 @@ defmodule Surface.SlotSyncTest do
         """
       end
 
-    message = """
-    code:2: The slotable component <Surface.SlotTest.InnerData> has the `:slot` option set to `inner`.
+    message = ~r"""
+    code:2:\n.+?error:.+? The slotable component <Surface.SlotTest.InnerData> has the `:slot` option set to `inner`\.
 
-    That slot name is not declared in parent component <StatefulComponent>.
+    That slot name is not declared in parent component <StatefulComponent>\.
 
-    Please declare the slot in the parent component or rename the value in the `:slot` option.
+    Please declare the slot in the parent component or rename the value in the `:slot` option\.
     """
 
     assert_raise(Surface.CompileError, message, fn ->
@@ -1272,12 +1272,12 @@ defmodule Surface.SlotSyncTest do
         """
       end
 
-    message = """
-    code:2: The slotable component <Surface.SlotTest.InnerData> has the `:slot` option set to `inner`.
+    message = ~r"""
+    code:2:\n.+?error:.+? The slotable component <Surface.SlotTest.InnerData> has the `:slot` option set to `inner`\.
 
-    That slot name is not declared in parent component <Grid>.
+    That slot name is not declared in parent component <Grid>\.
 
-    Please declare the slot in the parent component or rename the value in the `:slot` option.
+    Please declare the slot in the parent component or rename the value in the `:slot` option\.
 
     Available slot: "col"
     """
@@ -1301,10 +1301,10 @@ defmodule Surface.SlotSyncTest do
         """
       end
 
-    message = """
-    code:4: no slot "foot" defined in parent component <OuterWithNamedSlot>
+    message = ~r"""
+    code:4:\n.+?error:.+? no slot "foot" defined in parent component <OuterWithNamedSlot>
 
-    Did you mean "footer"?
+    Did you mean "footer"\?
 
     Available slots: "default", "header" and "footer"
     """
@@ -1335,11 +1335,11 @@ defmodule Surface.SlotSyncTest do
     """
 
     message = ~r"""
-    code:12: no slot `footer` defined in the component `Surface.SlotSyncTest.TestComponentWithoutDeclaringSlots`
+    code:12:\n.+?error:.+? no slot `footer` defined in the component `Surface.SlotSyncTest.TestComponentWithoutDeclaringSlots`
 
     Available slots: "default" and "header"\
 
-    Hint: You can define slots using the `slot` macro.\
+    Hint: You can define slots using the `slot` macro\.\
 
     For instance: `slot footer`\
     """
@@ -1367,9 +1367,9 @@ defmodule Surface.SlotSyncTest do
     """
 
     message = ~r"""
-    code:7: no slot `default` defined in the component `Surface.SlotSyncTest.TestComponentWithShortSyntaxButWithoutDeclaringDefaultSlot`
+    code:7:\n.+?error:.+? no slot `default` defined in the component `Surface.SlotSyncTest.TestComponentWithShortSyntaxButWithoutDeclaringDefaultSlot`
 
-    Please declare the default slot using `slot default` in order to use the `<#slot />` notation.
+    Please declare the default slot using `slot default` in order to use the `<#slot />` notation\.
     """
 
     assert_raise(Surface.CompileError, message, fn ->
@@ -1469,8 +1469,8 @@ defmodule Surface.SlotSyncTest do
         """
       end
 
-    message = """
-    code:1: no slot "default" defined in parent component <OuterWithoutDefaultSlot>
+    message = ~r"""
+    code:1:\n.+?error:.+? no slot "default" defined in parent component <OuterWithoutDefaultSlot>
     """
 
     assert_raise(Surface.CompileError, message, fn ->
@@ -1534,9 +1534,9 @@ defmodule Surface.SlotSyncTest do
     """
 
     message = ~r"""
-    code:10: invalid directive `:attrs` for <#slot>.
+    code:10:\n.+?error:.+? invalid directive `:attrs` for <#slot>\.
 
-    Slots only accept the root prop, `generator_value`, `:if` and `:for`.
+    Slots only accept the root prop, `generator_value`, `:if` and `:for`\.
     """
 
     assert_raise(Surface.CompileError, message, fn ->
@@ -1565,9 +1565,9 @@ defmodule Surface.SlotSyncTest do
     """
 
     message = ~r"""
-    code:11: invalid attribute `let` for <#slot>.
+    code:11:\n.+?error:.+? invalid attribute `let` for <#slot>\.
 
-    Slots only accept the root prop, `generator_value`, `:if` and `:for`.
+    Slots only accept the root prop, `generator_value`, `:if` and `:for`\.
     """
 
     assert_raise(Surface.CompileError, message, fn ->
@@ -1595,7 +1595,7 @@ defmodule Surface.SlotSyncTest do
     """
 
     message = ~r"""
-    code:10: cannot pass dynamic attributes to <#slot>.
+    code:10:\n.+?error:.+? cannot pass dynamic attributes to <#slot>.
 
     Slots only accept the root prop, `for`, `name`, `index`, `generator_value`, `:if` and `:for`.
     """
@@ -1625,7 +1625,7 @@ defmodule Surface.SlotSyncTest do
     """
 
     message = ~r"""
-    code:10: cannot pass dynamic attributes to <#slot>.
+    code:10:\n.+?error:.+? cannot pass dynamic attributes to <#slot>.
 
     Slots only accept the root prop, `for`, `name`, `index`, `generator_value`, `:if` and `:for`.
     """

--- a/test/surface/integrations/slot_test.exs
+++ b/test/surface/integrations/slot_test.exs
@@ -789,7 +789,7 @@ defmodule Surface.SlotTest do
     Hint: choose a different name.\
     """
 
-    assert_raise(CompileError, message, fn ->
+    assert_raise(Surface.CompileError, message, fn ->
       compile_surface(code)
     end)
   end
@@ -1007,7 +1007,7 @@ defmodule Surface.SlotTest do
     got: {"a_string", "other_string"}.\
     """
 
-    assert_raise(CompileError, message, fn ->
+    assert_raise(Surface.CompileError, message, fn ->
       compile_surface(code, assigns)
     end)
   end
@@ -1026,7 +1026,7 @@ defmodule Surface.SlotTest do
     code:1: no slot "default" defined in parent component <OuterWithoutDefaultSlot>
     """
 
-    assert_raise(CompileError, message, fn ->
+    assert_raise(Surface.CompileError, message, fn ->
       compile_surface(code)
     end)
   end
@@ -1049,7 +1049,7 @@ defmodule Surface.SlotTest do
     got: {a, info: [my_info]}.\
     """
 
-    assert_raise(CompileError, message, fn ->
+    assert_raise(Surface.CompileError, message, fn ->
       compile_surface(code)
     end)
   end
@@ -1069,7 +1069,7 @@ defmodule Surface.SlotTest do
     got: {@default, a, b}.\
     """
 
-    assert_raise(CompileError, message, fn ->
+    assert_raise(Surface.CompileError, message, fn ->
       compile_surface(code)
     end)
   end
@@ -1089,7 +1089,7 @@ defmodule Surface.SlotTest do
     got: {@default, a, info: "Info from slot"}.\
     """
 
-    assert_raise(CompileError, message, fn ->
+    assert_raise(Surface.CompileError, message, fn ->
       compile_surface(code)
     end)
   end
@@ -1256,7 +1256,7 @@ defmodule Surface.SlotSyncTest do
     Please declare the slot in the parent component or rename the value in the `:slot` option.
     """
 
-    assert_raise(CompileError, message, fn ->
+    assert_raise(Surface.CompileError, message, fn ->
       compile_surface(code)
     end)
   end
@@ -1282,7 +1282,7 @@ defmodule Surface.SlotSyncTest do
     Available slot: "col"
     """
 
-    assert_raise(CompileError, message, fn ->
+    assert_raise(Surface.CompileError, message, fn ->
       compile_surface(code)
     end)
   end
@@ -1309,7 +1309,7 @@ defmodule Surface.SlotSyncTest do
     Available slots: "default", "header" and "footer"
     """
 
-    assert_raise(CompileError, message, fn ->
+    assert_raise(Surface.CompileError, message, fn ->
       compile_surface(code)
     end)
   end
@@ -1344,7 +1344,7 @@ defmodule Surface.SlotSyncTest do
     For instance: `slot footer`\
     """
 
-    assert_raise(CompileError, message, fn ->
+    assert_raise(Surface.CompileError, message, fn ->
       capture_io(:standard_error, fn ->
         Code.eval_string(component_code, [], %{__ENV__ | file: "code", line: 1})
       end)
@@ -1372,7 +1372,7 @@ defmodule Surface.SlotSyncTest do
     Please declare the default slot using `slot default` in order to use the `<#slot />` notation.
     """
 
-    assert_raise(CompileError, message, fn ->
+    assert_raise(Surface.CompileError, message, fn ->
       capture_io(:standard_error, fn ->
         Code.eval_string(component_code, [], %{__ENV__ | file: "code", line: 1})
       end)
@@ -1473,7 +1473,7 @@ defmodule Surface.SlotSyncTest do
     code:1: no slot "default" defined in parent component <OuterWithoutDefaultSlot>
     """
 
-    assert_raise(CompileError, message, fn ->
+    assert_raise(Surface.CompileError, message, fn ->
       compile_surface(code)
     end)
   end
@@ -1539,7 +1539,7 @@ defmodule Surface.SlotSyncTest do
     Slots only accept the root prop, `generator_value`, `:if` and `:for`.
     """
 
-    assert_raise(CompileError, message, fn ->
+    assert_raise(Surface.CompileError, message, fn ->
       capture_io(:standard_error, fn ->
         Code.eval_string(code, [], %{__ENV__ | file: "code", line: 1})
       end)
@@ -1570,7 +1570,7 @@ defmodule Surface.SlotSyncTest do
     Slots only accept the root prop, `generator_value`, `:if` and `:for`.
     """
 
-    assert_raise(CompileError, message, fn ->
+    assert_raise(Surface.CompileError, message, fn ->
       capture_io(:standard_error, fn ->
         Code.eval_string(code, [], %{__ENV__ | file: "code", line: 1})
       end)
@@ -1600,7 +1600,7 @@ defmodule Surface.SlotSyncTest do
     Slots only accept the root prop, `for`, `name`, `index`, `generator_value`, `:if` and `:for`.
     """
 
-    assert_raise(CompileError, message, fn ->
+    assert_raise(Surface.CompileError, message, fn ->
       capture_io(:standard_error, fn ->
         Code.eval_string(code, [], %{__ENV__ | file: "code", line: 1})
       end)
@@ -1630,7 +1630,7 @@ defmodule Surface.SlotSyncTest do
     Slots only accept the root prop, `for`, `name`, `index`, `generator_value`, `:if` and `:for`.
     """
 
-    assert_raise(CompileError, message, fn ->
+    assert_raise(Surface.CompileError, message, fn ->
       capture_io(:standard_error, fn ->
         Code.eval_string(code, [], %{__ENV__ | file: "code", line: 1})
       end)
@@ -1715,9 +1715,9 @@ defmodule Surface.SlotSyncTest do
         compile_surface(code, %{})
       end)
 
-    assert output =~ ~r"""
-           cannot render <div> \(slot entries are not allowed as children of HTML elements. Did you mean \<\#slot \/\>\?\)
-             code:2:\
-           """
+    assert output =~
+             "cannot render <div> (slot entries are not allowed as children of HTML elements. Did you mean <#slot />?)"
+
+    assert output =~ "code:2:"
   end
 end

--- a/test/surface/integrations/transform_test.exs
+++ b/test/surface/integrations/transform_test.exs
@@ -186,7 +186,7 @@ defmodule Surface.TransformTest do
 
     assert_raise(
       Surface.CompileError,
-      "nofile:1: invalid value for property \"prop\". Expected a :list, got: \"string\".",
+      ~r"nofile:1:\n.+?error:.+? invalid value for property \"prop\"\. Expected a :list, got: \"string\".",
       fn ->
         Surface.Compiler.compile(code, 1, __ENV__)
       end

--- a/test/surface/integrations/transform_test.exs
+++ b/test/surface/integrations/transform_test.exs
@@ -1,5 +1,5 @@
 defmodule Surface.TransformTest do
-  use ExUnit.Case
+  use Surface.Case
 
   defmodule Span do
     use Surface.Component
@@ -186,7 +186,7 @@ defmodule Surface.TransformTest do
 
     assert_raise(
       Surface.CompileError,
-      ~r"nofile:1:\n.+?error:.+? invalid value for property \"prop\"\. Expected a :list, got: \"string\".",
+      ~r"nofile:1:\n#{maybe_ansi("error:")} invalid value for property \"prop\"\. Expected a :list, got: \"string\".",
       fn ->
         Surface.Compiler.compile(code, 1, __ENV__)
       end

--- a/test/surface/integrations/transform_test.exs
+++ b/test/surface/integrations/transform_test.exs
@@ -185,7 +185,7 @@ defmodule Surface.TransformTest do
     """
 
     assert_raise(
-      CompileError,
+      Surface.CompileError,
       "nofile:1: invalid value for property \"prop\". Expected a :list, got: \"string\".",
       fn ->
         Surface.Compiler.compile(code, 1, __ENV__)

--- a/test/surface/macro_component_test.exs
+++ b/test/surface/macro_component_test.exs
@@ -202,7 +202,8 @@ defmodule Surface.MacroComponentTest do
       end
 
     message = ~r"""
-    code:2:\n.+?error:.+? invalid value for property "align"
+    code:2:
+    #{maybe_ansi("error:")} invalid value for property "align"
 
     Expected a string while evaluating {@align}, got: nil
 
@@ -282,7 +283,7 @@ defmodule Surface.MacroComponentTest do
 
       assert_raise(
         Surface.CompileError,
-        ~r/code:1(:2)?:\n.+?error:.+? cannot render \<#NonExisting\> \(module NonExisting could not be loaded\)/,
+        ~r/code:1(:2)?:\n#{maybe_ansi("error:")} cannot render \<#NonExisting\> \(module NonExisting could not be loaded\)/,
         fn ->
           compile_surface(code)
         end

--- a/test/surface/macro_component_test.exs
+++ b/test/surface/macro_component_test.exs
@@ -284,7 +284,7 @@ defmodule Surface.MacroComponentTest do
 
       assert_raise(
         Surface.CompileError,
-        ~r/code:1: cannot render \<#NonExisting\> \(module NonExisting could not be loaded\)/,
+        ~r/code:1(:2)?: cannot render \<#NonExisting\> \(module NonExisting could not be loaded\)/,
         fn ->
           compile_surface(code)
         end

--- a/test/surface/macro_component_test.exs
+++ b/test/surface/macro_component_test.exs
@@ -211,7 +211,7 @@ defmodule Surface.MacroComponentTest do
     assigns, cannot be evaluated as they are not available during compilation.
     """
 
-    assert_raise(CompileError, message, fn ->
+    assert_raise(Surface.CompileError, message, fn ->
       capture_io(:standard_error, fn ->
         compile_surface(code, %{class: "markdown"})
       end)

--- a/test/surface/macro_component_test.exs
+++ b/test/surface/macro_component_test.exs
@@ -201,14 +201,14 @@ defmodule Surface.MacroComponentTest do
         """
       end
 
-    message = """
-    code:2: invalid value for property "align"
+    message = ~r"""
+    code:2:\n.+?error:.+? invalid value for property "align"
 
     Expected a string while evaluating {@align}, got: nil
 
     Hint: static properties of macro components can only accept static values like module attributes,
     literals or compile-time expressions. Runtime variables and expressions, including component
-    assigns, cannot be evaluated as they are not available during compilation.
+    assigns, cannot be evaluated as they are not available during compilation\.
     """
 
     assert_raise(Surface.CompileError, message, fn ->
@@ -255,9 +255,7 @@ defmodule Surface.MacroComponentTest do
       assert {%Surface.CompileError{
                 description: "cannot render <#NonExisting> (module NonExisting could not be loaded)",
                 hint: """
-
-
-                Hint: make sure module `NonExisting` can be successfully compiled.
+                make sure module `NonExisting` can be successfully compiled.
 
                 If the module is namespaced, you can use its full name. For instance:
 
@@ -284,7 +282,7 @@ defmodule Surface.MacroComponentTest do
 
       assert_raise(
         Surface.CompileError,
-        ~r/code:1(:2)?: cannot render \<#NonExisting\> \(module NonExisting could not be loaded\)/,
+        ~r/code:1(:2)?:\n.+?error:.+? cannot render \<#NonExisting\> \(module NonExisting could not be loaded\)/,
         fn ->
           compile_surface(code)
         end

--- a/test/surface_test.exs
+++ b/test/surface_test.exs
@@ -64,7 +64,8 @@ defmodule SurfaceTest do
 
   test "raise error when trying to unquote an undefined variable" do
     message = ~r"""
-    code.ex:2:\n.+?error:.+? undefined variable "content"\.
+    code.ex:2:
+    #{maybe_ansi("error:")} undefined variable "content"\.
 
     Available variable: "message"
     """
@@ -82,7 +83,8 @@ defmodule SurfaceTest do
 
   test "raise error when trying to unquote expressions that are not variables" do
     message = ~r"""
-    code.ex:2:\n.+?error:.+? cannot unquote `to_string\(:abc\)`\.
+    code.ex:2:
+    #{maybe_ansi("error:")} cannot unquote `to_string\(:abc\)`\.
 
     The expression to be unquoted must be written as `\^var`, where `var` is an existing variable\.
     """
@@ -109,7 +111,7 @@ defmodule SurfaceTest do
     end
     """
 
-    message = ~r"code.exs:1:\n.+?error:.+? the code to be quoted must be wrapped in a `~F` sigil\."
+    message = ~r"code.exs:1:\n#{maybe_ansi("error:")} the code to be quoted must be wrapped in a `~F` sigil\."
 
     assert_raise(Surface.CompileError, message, fn ->
       {{:module, _, _, _}, _} = Code.eval_string(code, [], %{__ENV__ | file: "code.exs", line: 1})
@@ -117,7 +119,7 @@ defmodule SurfaceTest do
   end
 
   test "raise error when using {^...} outside `quote_surface`" do
-    message = ~r"code:2:\n.+?error:.+? cannot use tagged expression \{\^var\} outside `quote_surface`"
+    message = ~r"code:2:\n#{maybe_ansi("error:")} cannot use tagged expression \{\^var\} outside `quote_surface`"
 
     code =
       quote do

--- a/test/surface_test.exs
+++ b/test/surface_test.exs
@@ -63,8 +63,8 @@ defmodule SurfaceTest do
   end
 
   test "raise error when trying to unquote an undefined variable" do
-    message = """
-    code.ex:2: undefined variable "content".
+    message = ~r"""
+    code.ex:2:\n.+?error:.+? undefined variable "content"\.
 
     Available variable: "message"
     """
@@ -81,10 +81,10 @@ defmodule SurfaceTest do
   end
 
   test "raise error when trying to unquote expressions that are not variables" do
-    message = """
-    code.ex:2: cannot unquote `to_string(:abc)`.
+    message = ~r"""
+    code.ex:2:\n.+?error:.+? cannot unquote `to_string\(:abc\)`\.
 
-    The expression to be unquoted must be written as `^var`, where `var` is an existing variable.
+    The expression to be unquoted must be written as `\^var`, where `var` is an existing variable\.
     """
 
     assert_raise(Surface.CompileError, message, fn ->
@@ -109,7 +109,7 @@ defmodule SurfaceTest do
     end
     """
 
-    message = "code.exs:1: the code to be quoted must be wrapped in a `~F` sigil."
+    message = ~r"code.exs:1:\n.+?error:.+? the code to be quoted must be wrapped in a `~F` sigil\."
 
     assert_raise(Surface.CompileError, message, fn ->
       {{:module, _, _, _}, _} = Code.eval_string(code, [], %{__ENV__ | file: "code.exs", line: 1})
@@ -117,7 +117,7 @@ defmodule SurfaceTest do
   end
 
   test "raise error when using {^...} outside `quote_surface`" do
-    message = "code:2: cannot use tagged expression {^var} outside `quote_surface`"
+    message = ~r"code:2:\n.+?error:.+? cannot use tagged expression \{\^var\} outside `quote_surface`"
 
     code =
       quote do

--- a/test/surface_test.exs
+++ b/test/surface_test.exs
@@ -69,7 +69,7 @@ defmodule SurfaceTest do
     Available variable: "message"
     """
 
-    assert_raise(CompileError, message, fn ->
+    assert_raise(Surface.CompileError, message, fn ->
       quote_surface line: 1, file: "code.ex" do
         ~F"""
         <div>
@@ -87,7 +87,7 @@ defmodule SurfaceTest do
     The expression to be unquoted must be written as `^var`, where `var` is an existing variable.
     """
 
-    assert_raise(CompileError, message, fn ->
+    assert_raise(Surface.CompileError, message, fn ->
       quote_surface line: 1, file: "code.ex" do
         ~F"""
         <div>
@@ -111,7 +111,7 @@ defmodule SurfaceTest do
 
     message = "code.exs:1: the code to be quoted must be wrapped in a `~F` sigil."
 
-    assert_raise(CompileError, message, fn ->
+    assert_raise(Surface.CompileError, message, fn ->
       {{:module, _, _, _}, _} = Code.eval_string(code, [], %{__ENV__ | file: "code.exs", line: 1})
     end)
   end
@@ -128,7 +128,7 @@ defmodule SurfaceTest do
         """
       end
 
-    assert_raise(CompileError, message, fn ->
+    assert_raise(Surface.CompileError, message, fn ->
       compile_surface(code)
     end)
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -41,6 +41,22 @@ defmodule FlokiHelpers do
   end
 end
 
+defmodule ANSIHelpers do
+  @doc """
+  Returns a regex fragment that conditionally matches a colored text.
+
+  It should be used in tests to avoid failure when running in enviroments where ANSI
+  is disabled, e.g. CI servers.
+  """
+  def maybe_ansi(text) do
+    if IO.ANSI.enabled?() do
+      "(\\e\\[\\d+m)?#{text}(\\e\\[0m)"
+    else
+      text
+    end
+  end
+end
+
 Application.put_env(:surface, Endpoint,
   secret_key_base: "J4lTFt000ENUVhu3dbIB2P2vRVl2nDBH6FLefnPUImL8mHYNX8Kln/N9J0HH19Mq",
   live_view: [


### PR DESCRIPTION
Add custom `Surface.CompileError`, which can handle column and snippet.